### PR TITLE
Issue 69: Split responsibilities of Mode to ModeActivationManager and ModeActivator (WIP)

### DIFF
--- a/wakepy/core/activationresult.py
+++ b/wakepy/core/activationresult.py
@@ -54,10 +54,13 @@ class StageName(StringConstant):
 @dataclass(frozen=True)
 class MethodUsageResult:
     status: UsageStatus
+
+    method_name: str
+
     # None if the method did not fail. Otherwise, the name of the stage where
     # the method failed.
-    method_name: str
     failure_stage: Optional[StageName] = None
+
     message: str = ""
 
     def __repr__(self):

--- a/wakepy/core/calls.py
+++ b/wakepy/core/calls.py
@@ -5,8 +5,7 @@ from dataclasses import dataclass
 
 if typing.TYPE_CHECKING:
     from typing import Any, List, Tuple
-
-    from wakepy.core.dbus import DbusMethod
+    from .dbus import DbusAdapter, DbusMethod, DbusAdapterSeq
 
 
 class Call:
@@ -31,3 +30,32 @@ class DbusMethodCall(Call):
             raise ValueError(
                 f"{self.__class__.__name__} requires completely defined DBusMethod!"
             )
+
+
+# TODO: Define a Caller class
+
+
+def _to_tuple_of_dbus_adapter(
+    dbus_adapter: DbusAdapter | DbusAdapterSeq | None,
+) -> tuple[DbusAdapter, ...] | None:
+    """Makes sure that dbus_adapter is a tuple of DbusAdapter instances."""
+    if not dbus_adapter:
+        return None
+
+    elif isinstance(dbus_adapter, DbusAdapter):
+        return (dbus_adapter,)
+
+    if isinstance(dbus_adapter, (list, tuple)):
+        if not all(isinstance(a, DbusAdapter) for a in dbus_adapter):
+            raise ValueError("dbus_adapter can only consist of DbusAdapters!")
+        return tuple(dbus_adapter)
+
+    raise ValueError("dbus_adapter type not understood")
+
+
+def get_default_dbus_adapter() -> tuple[DbusAdapter, ...]:
+    try:
+        from wakepy.io.dbus.jeepney import JeepneyDbusAdapter
+    except ImportError:
+        return tuple()
+    return (JeepneyDbusAdapter(),)

--- a/wakepy/core/dbus.py
+++ b/wakepy/core/dbus.py
@@ -2,13 +2,12 @@ from __future__ import annotations
 
 import typing
 from enum import auto
-from typing import NamedTuple
+from typing import NamedTuple, List, Tuple, Type, Union
 
 from wakepy.core import StringConstant
 
 if typing.TYPE_CHECKING:
-    from typing import Optional, Union
-
+    from typing import Optional
     from .calls import DbusMethodCall
 
 
@@ -170,3 +169,9 @@ class DbusAdapter:
 
     def create_connection(self):
         ...
+
+
+DbusAdapterSeq = typing.Union[List[DbusAdapter], Tuple[DbusAdapter, ...]]
+DbusAdapterTypeSeq = typing.Union[
+    List[Type[DbusAdapter]], Tuple[Type[DbusAdapter], ...]
+]

--- a/wakepy/core/mode.py
+++ b/wakepy/core/mode.py
@@ -1,160 +1,21 @@
 from __future__ import annotations
 
 import typing
-from abc import ABC, abstractmethod
-from queue import Empty, Queue
-from threading import Thread
+from abc import ABC
 
-from . import CURRENT_SYSTEM, SystemName
 from .activationresult import ActivationResult
-from .dbus import DbusAdapter
-from .definitions import ControlMsg, WorkerThreadMsgType
-from .method import Suitability
+from .modemanager import ModeActivationManager
 
 if typing.TYPE_CHECKING:
     from types import TracebackType
-    from typing import Iterable, List, Optional, Tuple, Type
+    from typing import Optional, Type
 
     from .method import Method
-
-    DbusAdapterSeq = typing.Union[List[DbusAdapter], Tuple[DbusAdapter]]
-
-
-def _to_tuple_of_dbus_adapter(
-    dbus_adapter: DbusAdapter | DbusAdapterSeq | None,
-) -> tuple[DbusAdapter, ...] | None:
-    """Makes sure that dbus_adapter is a tuple of DbusAdapter instances."""
-    if not dbus_adapter:
-        return None
-
-    elif isinstance(dbus_adapter, DbusAdapter):
-        return (dbus_adapter,)
-
-    if isinstance(dbus_adapter, (list, tuple)):
-        if not all(isinstance(a, DbusAdapter) for a in dbus_adapter):
-            raise ValueError("dbus_adapter can only consist of DbusAdapters!")
-        return tuple(dbus_adapter)
-
-    raise ValueError("dbus_adapter type not understood")
+    from .dbus import DbusAdapter, DbusAdapterTypeSeq
 
 
-def get_default_dbus_adapter() -> tuple[DbusAdapter, ...]:
-    try:
-        from wakepy.io.dbus.jeepney import JeepneyDbusAdapter
-    except ImportError:
-        return tuple()
-    return (JeepneyDbusAdapter(),)
-
-
-def sort_methods_by_priority(
-    methods: List[Type[Method]],
-    prioritize: Optional[List[Type[Method]]] = None,
-) -> List[Type[Method]]:
-    """Sort `methods` based on `prioritize`.
-
-    Parameters
-    ----------
-    prioritize:
-        If given a list of Methods (classes), this list will be used to
-        order the returned Methods in the order given in `prioritize`. Any
-        Method in `prioritize` but not in the `methods` list will be
-        disregarded. Any method in `methods` but not in `prioritize`, will be
-        placed in the output list just after all prioritized methods, in same
-        order as in the original `methods`.
-    """
-
-    if not prioritize:
-        return methods
-
-    sorted_methods = sorted(
-        methods,
-        key=lambda method: prioritize.index(method)
-        if method in prioritize
-        else float("inf"),
-    )
-    return sorted_methods
-
-
-class ModeWorkerThread(Thread):
-    def __init__(
-        self,
-        methods: List[Method],
-        queue_in: Queue,
-        queue_out: Queue,
-        system: SystemName = CURRENT_SYSTEM,
-        *args,
-        **kwargs,
-    ):
-        super().__init__(*args, name="wakepy-mode-manager", **kwargs)
-        self.methods = methods
-        self.system = system
-        self.queue_in = queue_in
-        self.queue_out = queue_out
-
-    def run(self):
-        try:
-            candidate_methods = self.check_suitability(self.methods)
-            succesful_methods = self.try_activate_mode(candidate_methods)
-
-            self.queue_out.put((WorkerThreadMsgType.OK, None))
-        except Exception as exc:
-            self.queue_out.put((WorkerThreadMsgType.EXCEPTION, exc))
-
-    def check_suitability(
-        self,
-        methods: List[Method],
-    ) -> List[Method]:
-        candidate_methods = []
-        for method in methods:
-            self.check_input_queue()
-            method.set_suitability(system=self.system)
-            if method.suitability == Suitability.UNSUITABLE:
-                continue
-            candidate_methods.append(method)
-        return candidate_methods
-
-    def try_activate_mode(
-        self,
-        methods: List[Method],
-    ) -> List[Method]:
-        """
-        Activate a mode by trying the methods in the input list.
-
-        Returns
-        --------
-        successful_methods
-            List of methods which were successful.
-
-        Raises
-        ------
-        ExitModeError in the rare case where (1) enter_mode() and heartbeat()
-        and exit_more() are all implemented and (2) enter_mode() succeeds and
-        (3) heartbeat raises exception and (4) exit_mode() raises exception.
-
-        MethodError in the (erroreously implemented) case where (1)
-        enter_mode() and heartbeat() are both not implemented, and no successful
-        activation is possible.
-        """
-
-        succesful_methods = []
-        for method in methods:
-            self.check_input_queue()
-            success = method.activate_the_mode()
-            if success:
-                succesful_methods.append(method)
-        return succesful_methods
-
-    def check_input_queue(self):
-        try:
-            item = self.queue_in.get(block=False)
-        except Empty:
-            return None
-        self._handle_input_queue_item(item)
-
-    def _handle_input_queue_item(self, item):
-        if item == ControlMsg.TERMINATE:
-            self.exit_modes()
-        raise ValueError(f'Queue input not understood: "{item}"')
+class ModeManagerNotSetError(RuntimeError):
+    ...
 
 
 class Mode(ABC):
@@ -164,62 +25,63 @@ class Mode(ABC):
     a possibility to run a heartbeat.
 
     Purpose of Mode:
+    * Provide the main API of wakepy for the user
     * Provide __enter__ for fulfilling the context manager protocol
     * Provide __exit__ for fulfilling the context manager protocol
     * Provide easy way to define list of Methods to be used for entering a mode
-    (in subclasses)
 
     Attributes
     ----------
-    methods:
-        The list of methods associated for this mode. Usually defined as a
-        class level attribute.
-
+    methods: list[Type[Method]]
+        The list of methods associated for this mode.
+    manager: ModeActivationManager
+        The manager which lives in the main thread and talks to the
+        ModeActivator using queues. This is responsive for activating and
+        deactivating a mode.
     """
 
-    @property
-    @abstractmethod
-    def methods(self) -> Iterable[Type[Method]]:
-        ...
+    _manager_class: Type[ModeActivationManager] = ModeActivationManager
 
     def __init__(
         self,
-        prioritize: Optional[List[Type[Method]]] = None,
-        dbus_adapter: DbusAdapter | DbusAdapterSeq | None = None,
+        methods: list[Type[Method]],
     ):
         """
         Parameters
-        ---------
-        dbus_adapter
-            Determines, which Dbus library / implementation is to be used, if
-            Dbus-based methods are to be used with a mode. You may use this to
-            use a custom DBus implementation. Wakepy is in no means tightly
-            coupled to any specific python dbus package.
+        ----------
+        methods:
+            The list of Methods to be used for activating this Mode.
         """
-        self._dbus_adapters: Tuple[DbusAdapter, ...] = (
-            _to_tuple_of_dbus_adapter(dbus_adapter) or get_default_dbus_adapter()
-        )
-        self._prioritize = prioritize
-        self._thread: ModeWorkerThread | None = None
-        self._queue_in: Queue | None = None
-        self._queue_out: Queue | None = None
-        self.results: ActivationResult | None = None
+        self.methods = methods
+        self.manager: ModeActivationManager | None = None
+
+    def __call__(
+        self,
+        dbus_adapter: Type[DbusAdapter] | DbusAdapterTypeSeq | None = None,
+    ):
+        """
+        Provides an easy way to define ModeActivationManager settings, such as
+        the dbus adapter to be used. The call is optional. In other words, if
+        the mode is called keep.running, one may either use
+
+        with keep.running() as k:
+            ...
+
+        or, identically
+
+        with keep.running as k:
+            ...
+
+        but with the first option it is possible to give additional arguments
+        to the ModeActivationManager, such as a custom dbus adapter.
+        """
+        self.manager = self._manager_class(dbus_adapter=dbus_adapter)
 
     def __enter__(self) -> ActivationResult:
-        methods = self._get_methods()
+        if self.manager is None:
+            self.__call__()
 
-        # The actual mode activation happens in a separate thread
-        self._queue_in = Queue()
-        self._queue_out = Queue()
-        self._thread = ModeWorkerThread(
-            methods, queue_in=self._queue_out, queue_out=self._queue_in
-        )
-        self._thread.start()
-
-        self.results = ActivationResult(
-            queue_thread=self._queue_in, candidate_methods=methods
-        )
-        return self.results
+        return self.manager.activate(methods=self.methods)
 
     def __exit__(
         self,
@@ -227,19 +89,7 @@ class Mode(ABC):
         exc_value: Optional[BaseException],
         traceback: Optional[TracebackType],
     ) -> Optional[bool]:
-        # TODO: do exit in the thread.
-        active_methods = self.results.used_methods
-        for method in active_methods:
-            method.exit_mode()
+        self.manager.deactivate()
 
         if not exc_value:
             return True
-
-    def _get_method_classes(self) -> List[Type[Method]]:
-        return sort_methods_by_priority(self.methods, prioritize=self._prioritize)
-
-    def _get_methods(self) -> List[Method]:
-        return [
-            method_cls(dbus_adapters=self._dbus_adapters)
-            for method_cls in self._get_method_classes()
-        ]

--- a/wakepy/core/modeactivator.py
+++ b/wakepy/core/modeactivator.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import typing
+from queue import Empty, Queue
+from threading import Thread
+
+from . import CURRENT_SYSTEM, SystemName
+from .definitions import ControlMsg, WorkerThreadMsgType
+from .method import Suitability
+
+if typing.TYPE_CHECKING:
+    from typing import List, Optional, Type
+
+    from .method import Method
+
+
+def sort_methods_by_priority(
+    methods: List[Type[Method]],
+    prioritize: Optional[List[Type[Method]]] = None,
+) -> List[Type[Method]]:
+    """Sort `methods` based on `prioritize`.
+
+    Parameters
+    ----------
+    prioritize:
+        If given a list of Methods (classes), this list will be used to
+        order the returned Methods in the order given in `prioritize`. Any
+        Method in `prioritize` but not in the `methods` list will be
+        disregarded. Any method in `methods` but not in `prioritize`, will be
+        placed in the output list just after all prioritized methods, in same
+        order as in the original `methods`.
+    """
+
+    if not prioritize:
+        return methods
+
+    sorted_methods = sorted(
+        methods,
+        key=lambda method: prioritize.index(method)
+        if method in prioritize
+        else float("inf"),
+    )
+    return sorted_methods
+
+
+# TODO: Convert ModeWorkerThread to ModeActivator
+# TODO: Check it this could be regular class, and not subclass of Thread
+class ModeWorkerThread(Thread):
+    def __init__(
+        self,
+        methods: List[Method],
+        queue_in: Queue,
+        queue_out: Queue,
+        system: SystemName = CURRENT_SYSTEM,
+        *args,
+        **kwargs,
+    ):
+        super().__init__(*args, name="wakepy-mode-manager", **kwargs)
+        self.methods = methods
+        self.system = system
+        self.queue_in = queue_in
+        self.queue_out = queue_out
+
+    def run(self):
+        try:
+            candidate_methods = self.check_suitability(self.methods)
+            succesful_methods = self.try_activate_mode(candidate_methods)
+
+            self.queue_out.put((WorkerThreadMsgType.OK, None))
+        except Exception as exc:
+            self.queue_out.put((WorkerThreadMsgType.EXCEPTION, exc))
+
+    def check_suitability(
+        self,
+        methods: List[Method],
+    ) -> List[Method]:
+        candidate_methods = []
+        for method in methods:
+            self.check_input_queue()
+            method.set_suitability(system=self.system)
+            if method.suitability == Suitability.UNSUITABLE:
+                continue
+            candidate_methods.append(method)
+        return candidate_methods
+
+    def try_activate_mode(
+        self,
+        methods: List[Method],
+    ) -> List[Method]:
+        """
+        Activate a mode by trying the methods in the input list.
+
+        Returns
+        --------
+        successful_methods
+            List of methods which were successful.
+
+        Raises
+        ------
+        ExitModeError in the rare case where (1) enter_mode() and heartbeat()
+        and exit_more() are all implemented and (2) enter_mode() succeeds and
+        (3) heartbeat raises exception and (4) exit_mode() raises exception.
+
+        MethodError in the (erroreously implemented) case where (1)
+        enter_mode() and heartbeat() are both not implemented, and no successful
+        activation is possible.
+        """
+
+        succesful_methods = []
+        for method in methods:
+            self.check_input_queue()
+            success = method.activate_the_mode()
+            if success:
+                succesful_methods.append(method)
+        return succesful_methods
+
+    def check_input_queue(self):
+        try:
+            item = self.queue_in.get(block=False)
+        except Empty:
+            return None
+        self._handle_input_queue_item(item)
+
+    def _handle_input_queue_item(self, item):
+        if item == ControlMsg.TERMINATE:
+            self.exit_modes()
+        raise ValueError(f'Queue input not understood: "{item}"')

--- a/wakepy/core/modemanager.py
+++ b/wakepy/core/modemanager.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import typing
+from queue import Queue
+
+from .activationresult import ActivationResult
+from .modeactivator import ModeWorkerThread
+
+if typing.TYPE_CHECKING:
+    from typing import List, Optional, Type
+
+    from .method import Method
+    from .dbus import DbusAdapter, DbusAdapterSeq
+
+
+class ModeActivationManager:
+    def __init__(
+        self,
+        prioritize: Optional[List[Type[Method]]] = None,
+        dbus_adapter: DbusAdapter | DbusAdapterSeq | None = None,
+    ):
+        """
+        Parameters
+        ---------
+        dbus_adapter
+            Determines, which Dbus library / implementation is to be used, if
+            Dbus-based methods are to be used with a mode. You may use this to
+            use a custom DBus implementation. Wakepy is in no means tightly
+            coupled to any specific python dbus package.
+        """
+
+        self._prioritize = prioritize
+        self._thread: ModeWorkerThread | None = None
+        self._queue_in: Queue | None = None
+        self._queue_out: Queue | None = None
+        self.results: ActivationResult | None = None
+
+    def activate(self, methods: List[Type[Method]]) -> ActivationResult:
+        # The actual mode activation happens in a separate thread
+        self._queue_in = Queue()
+        self._queue_out = Queue()
+        self._thread = ModeWorkerThread(
+            methods, queue_in=self._queue_out, queue_out=self._queue_in
+        )
+        self._thread.start()
+
+        self.results = ActivationResult(
+            queue_thread=self._queue_in, candidate_methods=methods
+        )
+        return self.results


### PR DESCRIPTION
First part of many for https://github.com/fohrloop/wakepy/issues/69

This is WIP and main functionality is broken. If you want to use a working version, checkout a tagged version from the latest-release branch.

## Contents

    Split Mode into parts
    
    * Mode class simplified. Now it was only following methods
    
      __init__ for creating Modes (typically not for end users)
      __call__ for setting some settings for the Mode. Not needed in very
               basic usage (for power users)
      __enter__ for context manager protocol
      __exit__ for context manager protocol
    
      and these attributes:
    
      .methods (list of Method classes to be used)
      .manager (the activation manager)
    
    * The Mode has now only these responsibilities:
      1) Offer easy way of defining Modes as ordered collections of methods
      2) Provide the main wakepy API in the form on context managers
    
    * Split dbus adapter resolution from Mode to calls.py. This should be
      responsibility of the future Caller class.
    
    * Create modeactivator.py and move the ModeWorkerThread there. In the
      future, there should be a ModeActivator class here which does the
      heavy lifting and activates/deactivates Modes using Methods.
    
      TODO: Create the ModeActivator class
    
    * Split ModeActivationManager out from the Mode. This is also WIP and
      not functional / tests.
    
      TODO: Finish and make tests for ModeActivationManager class.