### PR TITLE
Issue 69: ModeActivationManager.activate update

### DIFF
--- a/wakepy/core/activationmanager.py
+++ b/wakepy/core/activationmanager.py
@@ -16,7 +16,6 @@ if typing.TYPE_CHECKING:
 class ModeActivationManager:
     def __init__(
         self,
-        prioritize: Optional[List[Type[Method]]] = None,
         dbus_adapter: DbusAdapter | DbusAdapterSeq | None = None,
     ):
         """
@@ -28,17 +27,35 @@ class ModeActivationManager:
             use a custom DBus implementation. Wakepy is in no means tightly
             coupled to any specific python dbus package.
         """
-
-        self._prioritize = prioritize
         self._thread: ModeWorkerThread | None = None
         self._queue_in: Queue | None = None
         self._queue_out: Queue | None = None
         self.results: ActivationResult | None = None
 
-    def activate(self, methods: List[Type[Method]]) -> ActivationResult:
+    def activate(
+        self,
+        methods: List[Type[Method]],
+        prioritize: Optional[List[Type[Method]]] = None,
+    ) -> ActivationResult:
+        """Activate a mode defined by the methods.
+
+        Parameters
+        -----------
+        methods:
+            The list of Methods to be used for activating this Mode.
+        prioritize:
+            If given a list of Methods (classes), this list will be used to
+            order the returned Methods in the order given in `prioritize`. Any
+            Method in `prioritize` but not in the `methods` list will be
+            disregarded. Any method in `methods` but not in `prioritize`, will
+            be placed in the output list just after all prioritized methods, in
+            same order as in the original `methods`.
+        """
         # The actual mode activation happens in a separate thread
         self._queue_in = Queue()
         self._queue_out = Queue()
+
+        # TODO: Replace with ModeActivator
         self._thread = ModeWorkerThread(
             methods, queue_in=self._queue_out, queue_out=self._queue_in
         )

--- a/wakepy/core/activationmanager.py
+++ b/wakepy/core/activationmanager.py
@@ -40,6 +40,7 @@ class ModeActivationManager:
             use a custom DBus implementation. Wakepy is in no means tightly
             coupled to any specific python dbus package.
         """
+        self._dbus_adapter = dbus_adapter
         self._thread: ModeWorkerThread | None = None
         self._queue_in: Queue | None = None
         self._queue_out: Queue | None = None

--- a/wakepy/core/activationmanager.py
+++ b/wakepy/core/activationmanager.py
@@ -14,6 +14,19 @@ if typing.TYPE_CHECKING:
 
 
 class ModeActivationManager:
+    """Mode Activation Manager
+
+    Purpose:
+    (1) Manage activation of a mode using a collection of methods. Do this by
+      creating a separate thread for the mode activation, and communicate with
+      that thread using Queues.
+    (2) Form an ActivationResult from the result of the activation process and
+      provide it to the user.
+
+    The manager itself is always running in the "main" thread; The thread where
+    a wakepy mode is entered in.
+    """
+
     def __init__(
         self,
         dbus_adapter: DbusAdapter | DbusAdapterSeq | None = None,

--- a/wakepy/core/activationresult.py
+++ b/wakepy/core/activationresult.py
@@ -13,6 +13,7 @@ if typing.TYPE_CHECKING:
     from typing import Any, List, Optional, Sequence, Tuple
 
     from .method import Method
+    from .activationmanager import ModeActivationManager
 
 
 def should_fake_success() -> bool:
@@ -69,6 +70,7 @@ class MethodUsageResult:
         return f"({self.status}{error_at}, {self.method_name}{message_part})"
 
 
+# TODO:_ Move functionality to ModeActivationManager?
 class ModeSwitcher:
     # The minimum and maximum waiting times for waiting data from Queue
     # (seconds). These are used to calculate the timeout, if timeout is not
@@ -194,14 +196,15 @@ class ActivationResult:
         If you want easier access, use .get_details().
     """
 
-    def __init__(self, switcher: ModeSwitcher):
+    def __init__(self, manager: ModeActivationManager):
         """
         Parameters
         ---------
-        switcher:
-            The mode switcher.
+        manager:
+            The mode activation manager, which has methods for controlling and
+            getting information about the mode activation process.
         """
-        self._switcher = switcher
+        self._manager = manager
         self._results: list[MethodUsageResult] = []
 
     @property

--- a/wakepy/core/mode.py
+++ b/wakepy/core/mode.py
@@ -109,6 +109,12 @@ class Mode(ABC):
         Will swallow any ModeExit exception. Other exceptions will be
         re-raised.
         """
+
+        # These are not used but are part of context manager protocol.
+        #  make linters happy
+        _ = exc_type
+        _ = traceback
+
         self.manager.deactivate()
 
         if exception is None or isinstance(exception, ModeExit):
@@ -118,4 +124,5 @@ class Mode(ABC):
         # returning False will tell python to re-raise the exception. Can't
         # return None as type-checkers will mark code after with block
         # unreachable
+
         return False

--- a/wakepy/core/mode.py
+++ b/wakepy/core/mode.py
@@ -8,7 +8,7 @@ from .activationresult import ActivationResult
 
 if typing.TYPE_CHECKING:
     from types import TracebackType
-    from typing import Optional, Type, List
+    from typing import List, Optional, Type
 
     from .dbus import DbusAdapter, DbusAdapterTypeSeq
     from .method import Method

--- a/wakepy/core/mode.py
+++ b/wakepy/core/mode.py
@@ -64,7 +64,7 @@ class Mode(ABC):
         prioritize: Optional[List[Type[Method]]] = None,
         dbus_adapter: Type[DbusAdapter] | DbusAdapterTypeSeq | None = None,
     ):
-        """Initialize a MOde using Methods.
+        """Initialize a Mode using Methods.
 
         This is also where the ModeActivationManager settings, such as the dbus
         adapter to be used, are defined.

--- a/wakepy/core/modeactivator.py
+++ b/wakepy/core/modeactivator.py
@@ -11,7 +11,19 @@ from .method import Suitability
 if typing.TYPE_CHECKING:
     from typing import List, Optional, Type
 
+    from .dbus import DbusAdapter, DbusAdapterTypeSeq
     from .method import Method
+
+
+def activate(
+    methods: List[Type[Method]],
+    queue_in: Queue,
+    queue_out: Queue,
+    prioritize: Optional[List[Type[Method]]] = None,
+    dbus_adapter: DbusAdapter | DbusAdapterTypeSeq | None = None,
+):
+    """dummy function
+    TODO: Replace with real implementation"""
 
 
 def sort_methods_by_priority(


### PR DESCRIPTION
Add "prioritize" parameter mode Mode.\_\_init\_\_, which is passed forward to manager.activate(). This can be used to prioritize some methods over others (needs still some thinking)

Add docstring for ModeActivationManager

Update ModeActivationManager.activate: This now was very basic implementation for activating a mode. It basically forwards everything to the another thread, where (in the future) a ModeActivator is running. It also creates ActivationResult using new \_\_init\_\_() signature; ActivationResul(manager) -> There is a need to update the ActivationResult, too. Idea is that ActivationResult does not have to know anything about threads or queues; manager will handle that.

Add also some implementation of ModeActivationManager.deactivate

The .activate and .decactivate will likely need some more updates later on, and ModeActivationManager will surely need new methods to be consumed by the ActivationResult. These will be addressed later.