### PR TITLE
Fix tests for ActivationResult + should_fake_success

### DIFF
--- a/tests/unit/test_core/test_activationresult.py
+++ b/tests/unit/test_core/test_activationresult.py
@@ -73,25 +73,25 @@ RESULTS_3_FAIL = [
 
 
 @pytest.mark.parametrize(
-    "results, success, real_success, failure, faking_success",
+    "results, success_expected, real_success_expected, faking_success",
     [
-        (RESULTS_1, True, True, False, "0"),
-        (RESULTS_2, True, True, False, "0"),
-        (RESULTS_3_FAIL, False, False, True, "0"),
-        (RESULTS_3_FAIL, False, False, True, "1"),
+        (RESULTS_1, True, True, "0"),
+        (RESULTS_2, True, True, "0"),
+        (RESULTS_3_FAIL, False, False, "0"),
+        (RESULTS_3_FAIL, True, False, "1"),
     ],
 )
 def test_activation_result_success(
-    results, success, real_success, failure, faking_success
+    results, success_expected, real_success_expected, faking_success
 ):
     with pytest.MonkeyPatch.context() as mp:
         mp.setenv("WAKEPY_FAKE_SUCCESS", str(faking_success))
-    ar = ActivationResult(switcher)
-    ar._results = results
+        ar = ActivationResult(switcher)
+        ar._results = results
 
-    assert ar.success == success
-    assert ar.real_success == real_success
-    assert ar.failure == failure
+        assert ar.success == success_expected
+        assert ar.real_success == real_success_expected
+        assert ar.failure == (not success_expected)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_core/test_activationresult.py
+++ b/tests/unit/test_core/test_activationresult.py
@@ -1,9 +1,15 @@
+import os
 from unittest.mock import Mock
 
 import pytest
 
 from wakepy.core import ActivationResult, StageName
-from wakepy.core.activationresult import MethodUsageResult, ModeSwitcher, UsageStatus
+from wakepy.core.activationresult import (
+    MethodUsageResult,
+    ModeSwitcher,
+    UsageStatus,
+    should_fake_success,
+)
 
 switcher = Mock(spec_set=ModeSwitcher)
 
@@ -258,3 +264,18 @@ def test_activation_result_get_detailed_results():
     ) == [
         REQUIREMENTS_FAIL,
     ]
+
+
+def test_should_fake_success(monkeypatch):
+    for val in ("1", "yes", "True", "anystring"):
+        with monkeypatch.context() as mp:
+            mp.setenv("WAKEPY_FAKE_SUCCESS", val)
+            val_from_env = os.environ.get("WAKEPY_FAKE_SUCCESS")
+            assert val_from_env == str(val)
+            assert should_fake_success() is True
+    for val in ("0", "no", "NO", "False", "false", "FALSE"):
+        with monkeypatch.context() as mp:
+            mp.setenv("WAKEPY_FAKE_SUCCESS", val)
+            val_from_env = os.environ.get("WAKEPY_FAKE_SUCCESS")
+            assert val_from_env == str(val)
+            assert should_fake_success() is False

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ setenv =
     WAKEPY_FAKE_SUCCESS = "yes"
 deps =
     pytest>=6
+    jeepney >= 0.7.1;sys_platform=='linux'
 commands =
     {envpython} -m pytest {tty:--color=yes} {posargs}
 allowlist_externals = 

--- a/wakepy/core/activationresult.py
+++ b/wakepy/core/activationresult.py
@@ -20,7 +20,10 @@ def should_fake_success() -> bool:
     """Function which says if fake success should be enabled
 
     Fake success is controlled via WAKEPY_FAKE_SUCCESS environment variable.
-    If that variable is set to non-empty value, fake success is activated.
+    If that variable is set to a truthy value,fake success is activated.
+
+    Falsy values: '0', 'no', 'false' (case ignored)
+    Truthy values: everything else
 
     Motivation:
     -----------
@@ -30,7 +33,13 @@ def should_fake_success() -> bool:
     should fake the successful inhibition anyway. Faking the success is done
     after every other method is tried (and failed).
     """
-    return bool(os.environ.get("WAKEPY_FAKE_SUCCESS"))
+    if "WAKEPY_FAKE_SUCCESS" not in os.environ:
+        return False
+
+    val_from_env = os.environ["WAKEPY_FAKE_SUCCESS"].lower()
+    if val_from_env in ("0", "no", "false"):
+        return False
+    return True
 
 
 class UsageStatus(StringConstant):


### PR DESCRIPTION
Fix tox tests (other than the formatting/mypy stuff)

Fix tests for ActivationResult

Fix should_fake_success and add tests for it.

Previously, should_fake_success was always returning True if
WAKEPY_FAKE_SUCCESS was set to any value as for example bool('0') is
True.