### PR TITLE
Automatic registering of Methods + get_method_class function

### DIFF
--- a/tests/unit/test_core/test_method.py
+++ b/tests/unit/test_core/test_method.py
@@ -10,7 +10,7 @@ from wakepy.core.method import (
     MethodError,
 )
 
-from testmethods import MethodIs, get_method_class
+from testmethods import MethodIs, get_test_method_class
 
 
 def test_overridden_methods_autodiscovery():
@@ -116,7 +116,7 @@ def test_all_combinations_with_switch_to_the_mode():
         (MethodIs.MISSING, MethodIs.SUCCESSFUL, MethodIs.RAISING_EXCEPTION),
         (MethodIs.MISSING, MethodIs.SUCCESSFUL, MethodIs.RAISING_EXCEPTION),
     ):
-        method = get_method_class(
+        method = get_test_method_class(
             enter_mode=enter_mode, heartbeat=heartbeat, exit_mode=exit_mode
         )()
 

--- a/tests/unit/test_core/test_method.py
+++ b/tests/unit/test_core/test_method.py
@@ -119,7 +119,7 @@ def test_get_method_class():
 
     # Now the class can be queried with get_method_class:
     method_cls = get_method_class("foo")
-    assert isinstance(method_cls, Method)
+    assert issubclass(method_cls, Method)
     assert method_cls.name == "foo"
 
 

--- a/tests/unit/test_core/test_method.py
+++ b/tests/unit/test_core/test_method.py
@@ -1,4 +1,5 @@
 import itertools
+import re
 
 import pytest
 
@@ -8,6 +9,7 @@ from wakepy.core.method import (
     HeartbeatCallError,
     Method,
     MethodError,
+    get_method_class,
 )
 
 from testmethods import MethodIs, get_test_method_class
@@ -96,6 +98,29 @@ def test_method_has_x_is_not_writeable():
     # Same holds for classes
     with pytest.raises(AttributeError):
         MethodWithEnter.has_enter = False
+
+
+@pytest.mark.skip("WIP")
+def test_get_method_class():
+    """Test the function get_method_class"""
+
+    # Before defining the class, there is no such class with name 'foo'.
+    with pytest.raises(
+        KeyError,
+        match=re.escape(
+            'No Method with name "foo" found! Check that the name is correctly spelled and that the module containing the class is being imported'
+        ),
+    ):
+        get_method_class("foo")
+
+    # Define a class with name = 'foo'
+    class MyFooMethod(Method):
+        name = "foo"
+
+    # Now the class can be queried with get_method_class:
+    method_cls = get_method_class("foo")
+    assert isinstance(method_cls, Method)
+    assert method_cls.name == "foo"
 
 
 def test_all_combinations_with_switch_to_the_mode():

--- a/tests/unit/test_core/test_modeswitcher.py
+++ b/tests/unit/test_core/test_modeswitcher.py
@@ -1,7 +1,7 @@
 import queue
 
 import pytest
-from testmethods import MethodIs, get_method_class
+from testmethods import MethodIs, get_test_method_class
 
 from wakepy.core.method import EnterModeError, ExitModeError
 
@@ -11,7 +11,7 @@ ModeManager._timeout_maximum = 0.1  # make tests fail faster
 
 
 def test_mode_switch_thread():
-    method_ok = get_method_class(
+    method_ok = get_test_method_class(
         enter_mode=MethodIs.SUCCESSFUL,
         exit_mode=MethodIs.SUCCESSFUL,
     )()
@@ -28,8 +28,8 @@ def test_mode_switch_thread():
 
 def test_mode_switcher_two_methods():
     """Test normal (OK case) mode switching with two methods"""
-    method_ok = get_method_class(heartbeat=MethodIs.SUCCESSFUL)()
-    method_ok2 = get_method_class(
+    method_ok = get_test_method_class(heartbeat=MethodIs.SUCCESSFUL)()
+    method_ok2 = get_test_method_class(
         enter_mode=MethodIs.SUCCESSFUL,
         heartbeat=MethodIs.SUCCESSFUL,
         exit_mode=MethodIs.SUCCESSFUL,
@@ -80,7 +80,7 @@ def test_mode_switcher_with_exception(monkeypatch):
     Make sure that this situation is handled correctly.
     """
 
-    method_ok = get_method_class(
+    method_ok = get_test_method_class(
         enter_mode=MethodIs.SUCCESSFUL,
         exit_mode=MethodIs.SUCCESSFUL,
     )()

--- a/tests/unit/test_core/testmethods.py
+++ b/tests/unit/test_core/testmethods.py
@@ -12,7 +12,7 @@ class MethodIs(enum.IntEnum):
 
 
 def create_test_method_classes():
-    """Helper function for get_method_class. (See docs there)"""
+    """Helper function for get_test_method_class. (See docs there)"""
     test_method_classes = dict()
 
     class TestException(Exception):
@@ -45,7 +45,7 @@ def create_test_method_classes():
 _test_method_classes = create_test_method_classes()
 
 
-def get_method_class(
+def get_test_method_class(
     enter_mode: MethodIs = MethodIs.MISSING,
     heartbeat: MethodIs = MethodIs.MISSING,
     exit_mode: MethodIs = MethodIs.MISSING,

--- a/tests/unit/test_core/testmethods.py
+++ b/tests/unit/test_core/testmethods.py
@@ -26,7 +26,7 @@ def create_test_method_classes():
 
     for enter_mode, heartbeat, exit_mode in itertools.product(MethodIs, repeat=3):
         clsname = f"M{enter_mode.value}{heartbeat.value}{exit_mode.value}"
-        clskwargs = {"supported_systems": CURRENT_SYSTEM}
+        clskwargs = {"supported_systems": CURRENT_SYSTEM, "name": clsname}
         for mode, name in zip(
             (enter_mode, heartbeat, exit_mode), ("enter_mode", "heartbeat", "exit_mode")
         ):

--- a/wakepy/core/activationresult.py
+++ b/wakepy/core/activationresult.py
@@ -12,8 +12,8 @@ if typing.TYPE_CHECKING:
     from queue import Queue
     from typing import Any, List, Optional, Sequence, Tuple
 
-    from .method import Method
     from .activationmanager import ModeActivationManager
+    from .method import Method
 
 
 def should_fake_success() -> bool:

--- a/wakepy/core/method.py
+++ b/wakepy/core/method.py
@@ -16,6 +16,22 @@ if typing.TYPE_CHECKING:
     from wakepy.core import Call
     from wakepy.io.dbus import DbusAdapter
 
+METHOD_REGISTRY: dict[str, Type[Method]] = dict()
+"""A name -> Method class mapping. Updated automatically; when python loads
+a module with a subclass of Method, the Method class is added to this registry.
+"""
+
+
+def get_method_class(method_name: str):
+    """Get a Method class based on its name."""
+    if method_name not in METHOD_REGISTRY:
+        raise KeyError(
+            f'No Method with name "{method_name}" found!'
+            " Check that the name is correctly spelled and that the module containing"
+            " the class is being imported."
+        )
+    return METHOD_REGISTRY[method_name]
+
 
 class MethodError(Exception):
     """Occurred inside wakepy.core.method.Method"""

--- a/wakepy/core/method.py
+++ b/wakepy/core/method.py
@@ -33,7 +33,7 @@ def get_method_class(method_name: str):
     return METHOD_REGISTRY[method_name]
 
 
-class MethodError(Exception):
+class MethodError(RuntimeError):
     """Occurred inside wakepy.core.method.Method"""
 
 

--- a/wakepy/core/method.py
+++ b/wakepy/core/method.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import typing
 import warnings
 from abc import ABC, ABCMeta
-from typing import Any
+from typing import Any, Type
 
 from wakepy.core import DbusMethodCall
 
@@ -367,3 +367,7 @@ class Method(ABC, metaclass=MethodMeta):
             )
         )
         return Suitability(SuitabilityCheckResult.POTENTIALLY_SUITABLE, None, None)
+
+
+# type annotation shorthand
+MethodCls = Type[Method]

--- a/wakepy/core/method.py
+++ b/wakepy/core/method.py
@@ -42,7 +42,8 @@ def _register_method(cls: Type[Method]):
 
     if cls.name in METHOD_REGISTRY:
         raise MethodDefinitionError(
-            f'Duplicate Method name "{cls.name}": {cls.__qualname__} (already registered to {METHOD_REGISTRY[cls.name].__qualname__})'
+            f'Duplicate Method name "{cls.name}": {cls.__qualname__} '
+            f"(already registered to {METHOD_REGISTRY[cls.name].__qualname__})"
         )
 
     METHOD_REGISTRY[cls.name] = cls

--- a/wakepy/methods/gnome.py
+++ b/wakepy/methods/gnome.py
@@ -23,6 +23,8 @@ class _GnomeSessionManager(Method, ABC):
     https://lira.no-ip.org:8443/doc/gnome-session/dbus/gnome-session.html#org.gnome.SessionManager.Inhibit
     """
 
+    name = None  # Not listed. This class is subclassed.
+
     session_manager = DbusAddress(
         bus=BusType.SESSION,
         service="org.gnome.SessionManager",
@@ -88,8 +90,10 @@ class _GnomeSessionManager(Method, ABC):
 
 
 class GnomeSessionManagerNoSuspend(_GnomeSessionManager):
+    name = "org.gnome.SessionManager:Inhibit:Suspend"
     flags = GnomeFlag.INHIBIT_SUSPEND
 
 
 class GnomeSessionManagerNoIdle(_GnomeSessionManager):
+    name = "org.gnome.SessionManager:Inhibit:Idle"
     flags = GnomeFlag.INHIBIT_IDLE


### PR DESCRIPTION
Now:
- All Methods have default name of None. 
- Methods (subclasses of Method) with a non-None names will be automatically registered.
- Function get_method_class to get the Method class based on name (str).
- Give names for Gnome methods: "org.gnome.SessionManager:Inhibit:Suspend" and "org.gnome.SessionManager:Inhibit:Idle". (initial; could be changed later)