### PR TITLE
rename StringConstant to StrEnum

### DIFF
--- a/tests/unit/test_core/test_constant.py
+++ b/tests/unit/test_core/test_constant.py
@@ -2,11 +2,11 @@ from enum import auto
 
 import pytest
 
-from wakepy.core.constant import StringConstant
+from wakepy.core.strenum import StrEnum
 
 
 def test_constant_basic_functionality():
-    class MyConst(StringConstant):
+    class MyConst(StrEnum):
         FOO = "fooval"
 
     # Any string valued constant is
@@ -24,7 +24,7 @@ def test_constant_basic_functionality():
 
 
 def test_constant_auto():
-    class MyConst(StringConstant):
+    class MyConst(StrEnum):
         BAR = auto()
 
     # Any auto() value is turned into a string which is same as
@@ -38,7 +38,7 @@ def test_constant_uniqueness():
     # from the enum package
 
     # This should cause no problems
-    class MyConst(StringConstant, unique=True):
+    class MyConst(StrEnum, unique=True):
         FOO = "fooval"
         BAR = "barval"
         BAZ = auto()
@@ -55,13 +55,13 @@ def test_constant_uniqueness():
     # uniqueness is asked
     with pytest.raises(ValueError):
 
-        class MyConst(StringConstant, unique=True):
+        class MyConst(StrEnum, unique=True):
             FOO = "fooval"
             BAR = "fooval"
 
     # It should be possible to define duplicate values if uniqueness is not
     # asked
-    class MyConst(StringConstant):
+    class MyConst(StrEnum):
         FOO = "fooval"
         ANOTHER_FOO = "fooval"
 

--- a/wakepy/core/__init__.py
+++ b/wakepy/core/__init__.py
@@ -9,7 +9,7 @@ from .activationresult import StageName as StageName
 from .calls import Call as Call
 from .calls import DbusMethodCall as DbusMethodCall
 from .configuration import CURRENT_SYSTEM as CURRENT_SYSTEM
-from .constant import StringConstant as StringConstant
+from .strenum import StrEnum as StrEnum
 from .dbus import BusType as BusType
 from .dbus import DbusAddress as DbusAddress
 from .dbus import DbusMethod as DbusMethod

--- a/wakepy/core/activationresult.py
+++ b/wakepy/core/activationresult.py
@@ -5,7 +5,7 @@ import typing
 from dataclasses import dataclass
 from functools import wraps
 
-from .constant import StringConstant, auto
+from .strenum import StrEnum, auto
 from .definitions import WorkerThreadMsgType
 
 if typing.TYPE_CHECKING:
@@ -42,13 +42,13 @@ def should_fake_success() -> bool:
     return True
 
 
-class UsageStatus(StringConstant):
+class UsageStatus(StrEnum):
     FAIL = auto()
     SUCCESS = auto()
     UNUSED = auto()
 
 
-class StageName(StringConstant):
+class StageName(StrEnum):
     # These are stages which occur in order for each of the methods
     # until the mode has been succesfully activated with "max number" of
     # methods

--- a/wakepy/core/dbus.py
+++ b/wakepy/core/dbus.py
@@ -4,7 +4,7 @@ import typing
 from enum import auto
 from typing import List, NamedTuple, Tuple, Type, Union
 
-from wakepy.core import StringConstant
+from wakepy.core import StrEnum
 
 if typing.TYPE_CHECKING:
     from typing import Optional
@@ -12,7 +12,7 @@ if typing.TYPE_CHECKING:
     from .calls import DbusMethodCall
 
 
-class BusType(StringConstant):
+class BusType(StrEnum):
     SESSION = auto()
     SYSTEM = auto()
 

--- a/wakepy/core/definitions.py
+++ b/wakepy/core/definitions.py
@@ -1,8 +1,8 @@
 """Common terms and definitions used in many places"""
-from .constant import StringConstant, auto
+from .strenum import StrEnum, auto
 
 
-class SystemName(StringConstant):
+class SystemName(StrEnum):
     """The names of supported systems"""
 
     WINDOWS = "windows"
@@ -10,13 +10,13 @@ class SystemName(StringConstant):
     DARWIN = "darwin"
 
 
-class ControlMsg(StringConstant):
+class ControlMsg(StrEnum):
     """Send to worker threads"""
 
     TERMINATE = auto()
 
 
-class WorkerThreadMsgType(StringConstant):
+class WorkerThreadMsgType(StrEnum):
     """Send from worker threads"""
 
     OK = auto()

--- a/wakepy/core/method.py
+++ b/wakepy/core/method.py
@@ -9,7 +9,7 @@ from typing import Any, List, Optional, Set, Tuple, Type, TypeVar
 from wakepy.core import DbusMethodCall
 
 from . import SystemName as SystemName
-from .constant import StringConstant, auto
+from .strenum import StrEnum, auto
 
 if typing.TYPE_CHECKING:
     from wakepy.core import Call
@@ -101,12 +101,12 @@ class MethodMeta(ABCMeta):
         return super().__setattr__(name, value)
 
 
-class MethodOutcome(StringConstant):
+class MethodOutcome(StrEnum):
     NOT_IMPLEMENTED = auto()
     SUCCESS = auto()
 
 
-class SuitabilityCheckResult(StringConstant):
+class SuitabilityCheckResult(StrEnum):
     # Uused when it is known for sure that a method is not suitable
     UNSUITABLE = auto()
     # Used when it can't be proben that a method is not suitable, but still it
@@ -121,7 +121,7 @@ class SuitabilityCheckResult(StringConstant):
     SUITABLE = auto()
 
 
-class UnsuitabilityTag(StringConstant):
+class UnsuitabilityTag(StrEnum):
     """These are used to distiguish between different reasons for unsuitability
 
     SYSTEM: Used when system is not supported by the method.

--- a/wakepy/core/strenum.py
+++ b/wakepy/core/strenum.py
@@ -68,7 +68,7 @@ class EnumMemberString(str):
     """
 
 
-class StringConstant(Enum, metaclass=ConstantEnumMeta):
+class StrEnum(Enum, metaclass=ConstantEnumMeta):
     """A string constant / enumeration. For creating reusable, typed constants.
 
     Properties
@@ -82,7 +82,7 @@ class StringConstant(Enum, metaclass=ConstantEnumMeta):
 
     >>> from enum import auto
     >>>
-    >>> class MyConst(StringConstant):
+    >>> class MyConst(StrEnum):
     ...     BAR = auto()
 
     >>> MyConst.BAR == "BAR"
@@ -90,7 +90,7 @@ class StringConstant(Enum, metaclass=ConstantEnumMeta):
 
     3) Possibility to make values unique; for example
 
-    >>> class MyConst(StringConstant, unique=True):
+    >>> class MyConst(StrEnum, unique=True):
     ...     FIRST = 'foo'
     ...     SECOND = 'foo'
 
@@ -99,7 +99,7 @@ class StringConstant(Enum, metaclass=ConstantEnumMeta):
 
     4) Testing for containment looks for *values*; for example
 
-    >>> class MyConst(StringConstant):
+    >>> class MyConst(StrEnum):
     ...     FOO = 'bar'
 
     >>> 'bar' in MyConst
@@ -118,12 +118,12 @@ class StringConstant(Enum, metaclass=ConstantEnumMeta):
     def __new__(cls, val=None, *args):
         """This is used to get rid of need for ".value" access:
 
-        >>> StringConstant.FOO.value
+        >>> StrEnum.FOO.value
         'foo'
 
         It is possible to use
 
-        >>> StringConstant.FOO
+        >>> StrEnum.FOO
         'foo'
 
         instead
@@ -132,6 +132,6 @@ class StringConstant(Enum, metaclass=ConstantEnumMeta):
 
 
 __all__ = [
-    "StringConstant",
+    "StrEnum",
     "auto",
 ]


### PR DESCRIPTION
The StringConstant is really much like the enum.StrEnum or the strenum.StrEnum. It makes the code a bit easier to read for others if the same term (StrEnum) is used also here.