### PR TITLE
Issue 75: Replace get_selected_methods with select_methods

### DIFF
--- a/tests/unit/test_core/test_method.py
+++ b/tests/unit/test_core/test_method.py
@@ -14,7 +14,7 @@ from wakepy.core.method import (
     get_method,
     method_names_to_classes,
     get_methods_for_mode,
-    get_selected_methods,
+    select_methods,
 )
 
 from testmethods import MethodIs, get_test_method_class
@@ -297,64 +297,39 @@ def test_get_methods_for_mode(monkeypatch):
     ]
 
 
-def test_get_methods_for_mode(monkeypatch):
+def test_select_methods(monkeypatch):
     # empty method registry
     monkeypatch.setattr("wakepy.core.method.METHOD_REGISTRY", dict())
 
-    # B, D, E
-    first_mode = "first_mode"
-    # A, F
-    second_mode = "second_mode"
-
-    # The register is empty at start
-    assert get_selected_methods(first_mode) == []
-    assert get_selected_methods(second_mode) == []
-
-    class MethodA(Method):
-        name = "A"
-        mode = second_mode
-
     class MethodB(Method):
         name = "B"
-        mode = first_mode
-
-    class MethodC(Method):
-        name = "C"
 
     class MethodD(Method):
         name = "D"
-        mode = first_mode
 
     class MethodE(Method):
         name = "E"
-        mode = first_mode
 
-    class MethodF(Method):
-        name = "F"
-        mode = second_mode
-
-    # Now, there are methods
-    assert get_selected_methods(first_mode) == [MethodB, MethodD, MethodE]
-    assert get_selected_methods(second_mode) == [MethodA, MethodF]
+    methods = [MethodB, MethodD, MethodE]
 
     # These can also be filtered with a blacklist
-    assert get_selected_methods(first_mode, skip=["B"]) == [MethodD, MethodE]
-    assert get_selected_methods(first_mode, skip=["B", "E"]) == [MethodD]
+    assert select_methods(methods, skip=["B"]) == [MethodD, MethodE]
+    assert select_methods(methods, skip=["B", "E"]) == [MethodD]
     # Extra 'skip' methods do not matter
-    assert get_selected_methods(first_mode, skip=["B", "E", "foo", "bar"]) == [
+    assert select_methods(methods, skip=["B", "E", "foo", "bar"]) == [
         MethodD,
     ]
 
     # These can be filtered with a whitelist
-    assert get_selected_methods(first_mode, use_only=["B", "E"]) == [MethodB, MethodE]
+    assert select_methods(methods, use_only=["B", "E"]) == [MethodB, MethodE]
     # If a whitelist contains extra methods, raise exception
     with pytest.raises(
         ValueError,
         match=re.escape(
-            "Methods ['bar', 'foo'] in `use_only` are not part of Mode 'first_mode'!"
+            "Methods ['bar', 'foo'] in `use_only` are not part of `methods`!"
         ),
     ):
-        get_selected_methods(first_mode, use_only=["foo", "bar"])
+        select_methods(methods, use_only=["foo", "bar"])
 
 
 def test_method_curation_opts_constructor(monkeypatch):

--- a/wakepy/core/method.py
+++ b/wakepy/core/method.py
@@ -83,29 +83,27 @@ def get_methods_for_mode(
     return methods
 
 
-def get_selected_methods(
-    modename: ModeName,
+def select_methods(
+    methods: MethodClsCollection,
     skip: Optional[StrCollection] = None,
     use_only: Optional[StrCollection] = None,
 ) -> List[MethodCls]:
-    """Get the Method classes belonging to a Mode[1] optionally filtering with
-    a blacklist (skip) or whitelist (use_only). If `skip` and `use_only` are
-    both None, will return all the methods for the selected `modename`.
-
-    [1] Methods with Method.mode = `modename`.
+    """Selects Methods from from `methods` using a blacklist (skip) or
+    whitelist (use_only). If `skip` and `use_only` are both None, will return
+    all the original methods.
 
     Parameters
     ----------
-    modename: str | ModeName
-        The name of the Mode from which to select the Methods.
+    methods: collection of Method classes
+        The collection of methods from which to make the selection.
     skip: list, tuple or set of str or None
-        The names of Methods to remove from the results; a "blacklist" filter.
-        Any Method in `skip` but not part of the selected Mode will be silently
+        The names of Methods to remove from the `methods`; a "blacklist"
+        filter. Any Method in `skip` but not in `methods` will be silently
         ignored. Cannot be used same time with `use_only`. Optional.
     use_only: list, tuple or set of str
-        The names of Methods to restrict the returned Methods to; a "whitelist"
-        filter. Means "use these and only these Method". Any Methods in
-        `use_only` but not in the selected Mode will raise an exception. Cannot
+        The names of Methods to select from the `methods`; a "whitelist"
+        filter. Means "use these and only these Methods". Any Methods in
+        `use_only` but not in `methods` will raise a ValueError. Cannot
         be used same time with `skip`. Optional.
 
     Returns
@@ -119,18 +117,16 @@ def get_selected_methods(
             "Can only define skip (blacklist) or use_only (whitelist), not both!"
         )
 
-    all_methods = get_methods_for_mode(modename)
-
     if skip is None and use_only is None:
-        selected_methods = all_methods
+        selected_methods = list(methods)
     elif skip:
-        selected_methods = [m for m in all_methods if m.name not in skip]
+        selected_methods = [m for m in methods if m.name not in skip]
     elif use_only:
-        selected_methods = [m for m in all_methods if m.name in use_only]
+        selected_methods = [m for m in methods if m.name in use_only]
         if not set(use_only).issubset(m.name for m in selected_methods):
             missing = sorted(set(use_only) - set(m.name for m in selected_methods))
             raise ValueError(
-                f"Methods {missing} in `use_only` are not part of Mode '{modename}'!"
+                f"Methods {missing} in `use_only` are not part of `methods`!"
             )
     return selected_methods
 


### PR DESCRIPTION
old: get_selected_methods(methodname, skip, use_only)
- methodname: str

new: select_methods(methods, skip, use_only)
- methods: collection of Method

motivation:
Better separation of concerns and responsibilities.