### PR TITLE
Issue 75: refactoring check_priority_order

### DIFF
--- a/tests/unit/test_core/test_method.py
+++ b/tests/unit/test_core/test_method.py
@@ -439,3 +439,10 @@ def test_check_priority_order(monkeypatch):
         match=re.escape("Asterisk (*) may not be a part of a set in priority_order!"),
     ):
         check_priority_order(priority_order=[{"*"}], methods=methods)
+
+    # Unsupported type
+    with pytest.raises(
+        TypeError,
+        match=re.escape("priority_order must be a list[str | set[str]]!"),
+    ):
+        check_priority_order(priority_order=[MethodA], methods=methods)

--- a/wakepy/core/method.py
+++ b/wakepy/core/method.py
@@ -600,7 +600,6 @@ def iterate_priority_order(
     def check_isstr(method_name: str):
         if not isinstance(method_name, str):
             raise TypeError("priority_order must be a list[str | set[str]]!")
-        yield method_name
 
     def iterate_over_set(item: set):
         for method_name in item:
@@ -608,13 +607,15 @@ def iterate_priority_order(
                 raise ValueError(
                     "Asterisk (*) may not be a part of a set in priority_order!"
                 )
-            yield from check_isstr(method_name)
+            check_isstr(method_name)
+            yield method_name
 
     for item in priority_order:
         if isinstance(item, set):
             yield from iterate_over_set(item)
         else:
-            yield from check_isstr(item)
+            check_isstr(item)
+            yield item
 
 
 def check_priority_order(

--- a/wakepy/core/method.py
+++ b/wakepy/core/method.py
@@ -607,10 +607,11 @@ def check_priority_order(
     Parameters
     ----------
     priority_order: list[str | set[str]]
-        The priority order, which is a list of method names or asterisk ('*').
-        The asterisk means "all rest methods" and may occur only once in the
-        priority order, and cannot be part of a set. All method names must be
-        unique and must be part of the `methods`.
+        The priority order, which is a list of where items are method names,
+        sets of methods names or the asterisk ('*'). The asterisk means "all
+        rest methods" and may occur only once in the priority order, and cannot
+        be part of a set. All method names must be unique and must be part of
+        the `methods`.
     methods: list[MethodCls]
         The methods which the `priority_order` is validated against.
 

--- a/wakepy/core/method.py
+++ b/wakepy/core/method.py
@@ -585,37 +585,18 @@ class MethodCurationOpts:
 
 def iterate_priority_order(
     priority_order: Optional[PriorityOrder],
-) -> typing.Iterator[str]:
-    """Provides an iterator over the items in priority_order.
-
-    Raises
-    ------
-    ValueError if asterisk (*) is part of a set. For example, if the input
-    priority_list is ['A', {'B', '*'}]
-
-    TypeError if the items in the priority order are not either str or set of
-    str.
-    """
-
-    def check_isstr(method_name: str):
-        if not isinstance(method_name, str):
-            raise TypeError("priority_order must be a list[str | set[str]]!")
-
-    def iterate_over_set(item: set):
-        for method_name in item:
-            if method_name == "*":
-                raise ValueError(
-                    "Asterisk (*) may not be a part of a set in priority_order!"
-                )
-            check_isstr(method_name)
-            yield method_name
+) -> typing.Iterator[Tuple[str, bool]]:
+    """Provides an iterator over the items in priority_order. The items in the
+    iterator are (method_name, in_set) 2-tuples, where the method_name is the
+    method name (str) and the in_set is a boolean which is True if the returned
+    method_name is part of a set and False otherwise."""
 
     for item in priority_order:
         if isinstance(item, set):
-            yield from iterate_over_set(item)
+            for method_name in item:
+                yield method_name, True
         else:
-            check_isstr(item)
-            yield item
+            yield item, False
 
 
 def check_priority_order(
@@ -640,11 +621,19 @@ def check_priority_order(
     if priority_order is None:
         return
 
-    known_methods = {m.name: m for m in methods}
+    known_method_names = {m.name for m in methods}
+    known_method_names.add("*")
     seen_method_names = set()
 
-    for method_name in iterate_priority_order(priority_order):
-        if method_name not in known_methods and method_name != "*":
+    for method_name, in_set in iterate_priority_order(priority_order):
+        if not isinstance(method_name, str):
+            raise TypeError("priority_order must be a list[str | set[str]]!")
+
+        if in_set and method_name == "*":
+            raise ValueError(
+                "Asterisk (*) may not be a part of a set in priority_order!"
+            )
+        if method_name not in known_method_names:
             raise ValueError(
                 f'Method "{method_name}" in priority_order not in selected methods!'
             )


### PR DESCRIPTION
Refactor check_priority_order. Move validation responsibilities from iterate_priority_order to check_priority_order and make iterate_priority_order purely an iterator.