### PR TITLE
Issue 75: Add function for prioritizing methods using priority_order

### DIFF
--- a/tests/unit/test_core/test_method.py
+++ b/tests/unit/test_core/test_method.py
@@ -458,12 +458,14 @@ def test_check_priority_order():
 def test_get_prioritized_methods_groups_does_not_edit_args():
     """Test that the prioriry_order argument is not modified by the function"""
     methods = get_methods(["A", "B", "C", "D", "E", "F"])
+
     priority_order = ["A", "F"]
-    get_prioritized_methods_groups(
+
+    _ = get_prioritized_methods_groups(
         methods,
         priority_order=priority_order,
     )
-    # The results should be exactly the same as with asterisk in the end
+
     assert priority_order == [
         "A",
         "F",

--- a/tests/unit/test_core/test_method.py
+++ b/tests/unit/test_core/test_method.py
@@ -455,6 +455,22 @@ def test_check_priority_order():
 
 
 @pytest.mark.usefixtures("provide_methods_a_f")
+def test_get_prioritized_methods_groups_does_not_edit_args():
+    """Test that the prioriry_order argument is not modified by the function"""
+    methods = get_methods(["A", "B", "C", "D", "E", "F"])
+    priority_order = ["A", "F"]
+    get_prioritized_methods_groups(
+        methods,
+        priority_order=priority_order,
+    )
+    # The results should be exactly the same as with asterisk in the end
+    assert priority_order == [
+        "A",
+        "F",
+    ], "The priority_order argument should not be modified by the function"
+
+
+@pytest.mark.usefixtures("provide_methods_a_f")
 def test_get_prioritized_methods_groups():
     methods = get_methods(["A", "B", "C", "D", "E", "F"])
     (MethodA, MethodB, MethodC, MethodD, MethodE, MethodF) = methods

--- a/tests/unit/test_core/test_method.py
+++ b/tests/unit/test_core/test_method.py
@@ -14,11 +14,36 @@ from wakepy.core.method import (
     MethodError,
     check_priority_order,
     get_method,
+    get_methods,
     get_methods_for_mode,
     method_names_to_classes,
     get_prioritized_methods_groups,
     select_methods,
 )
+
+
+@pytest.fixture(scope="function")
+def provide_methods_a_f(monkeypatch):
+    # empty method registry
+    monkeypatch.setattr("wakepy.core.method.METHOD_REGISTRY", dict())
+
+    class MethodA(Method):
+        name = "A"
+
+    class MethodB(Method):
+        name = "B"
+
+    class MethodC(Method):
+        name = "C"
+
+    class MethodD(Method):
+        name = "D"
+
+    class MethodE(Method):
+        name = "E"
+
+    class MethodF(Method):
+        name = "F"
 
 
 def test_overridden_methods_autodiscovery():
@@ -382,29 +407,10 @@ def test_method_curation_opts_constructor(monkeypatch):
         MethodCurationOpts.from_names(lower_priority=["A"], skip=["A"])
 
 
-def test_check_priority_order(monkeypatch):
-    # empty method registry
-    monkeypatch.setattr("wakepy.core.method.METHOD_REGISTRY", dict())
-
-    class MethodA(Method):
-        name = "A"
-
-    class MethodB(Method):
-        name = "B"
-
-    class MethodC(Method):
-        name = "C"
-
-    class MethodD(Method):
-        name = "D"
-
-    class MethodE(Method):
-        name = "E"
-
-    class MethodF(Method):
-        name = "F"
-
-    methods = [MethodA, MethodB, MethodC, MethodD, MethodE, MethodF]
+@pytest.mark.usefixtures("provide_methods_a_f")
+def test_check_priority_order():
+    methods = get_methods(["A", "B", "C", "D", "E", "F"])
+    (MethodA, *_) = methods
 
     # These should be fine
     check_priority_order(priority_order=None, methods=methods)
@@ -448,29 +454,10 @@ def test_check_priority_order(monkeypatch):
         check_priority_order(priority_order=[MethodA], methods=methods)
 
 
-def test_get_prioritized_methods_groups(monkeypatch):
-    # empty method registry
-    monkeypatch.setattr("wakepy.core.method.METHOD_REGISTRY", dict())
-
-    class MethodA(Method):
-        name = "A"
-
-    class MethodB(Method):
-        name = "B"
-
-    class MethodC(Method):
-        name = "C"
-
-    class MethodD(Method):
-        name = "D"
-
-    class MethodE(Method):
-        name = "E"
-
-    class MethodF(Method):
-        name = "F"
-
-    methods = [MethodA, MethodB, MethodC, MethodD, MethodE, MethodF]
+@pytest.mark.usefixtures("provide_methods_a_f")
+def test_get_prioritized_methods_groups():
+    methods = get_methods(["A", "B", "C", "D", "E", "F"])
+    (MethodA, MethodB, MethodC, MethodD, MethodE, MethodF) = methods
 
     # Case: Select some methods as more important, with '*'
     methods_prioritised = get_prioritized_methods_groups(

--- a/tests/unit/test_core/test_method.py
+++ b/tests/unit/test_core/test_method.py
@@ -476,26 +476,22 @@ def test_get_prioritized_methods_groups():
     (MethodA, MethodB, MethodC, MethodD, MethodE, MethodF) = methods
 
     # Case: Select some methods as more important, with '*'
-    methods_prioritised = get_prioritized_methods_groups(
-        methods, priority_order=["A", "F", "*"]
-    )
-    assert methods_prioritised == [
+    assert get_prioritized_methods_groups(methods, priority_order=["A", "F", "*"]) == [
         {MethodA},
         {MethodF},
         {MethodB, MethodC, MethodD, MethodE},
     ]
+
     # Case: Select some methods as more important, without '*'
-    priority_order = ["A", "F"]
-    methods_prioritised_without_asterisk = get_prioritized_methods_groups(
-        methods,
-        priority_order=priority_order,
-    )
     # The results should be exactly the same as with asterisk in the end
-    assert methods_prioritised_without_asterisk == methods_prioritised
-    assert priority_order == [
-        "A",
-        "F",
-    ], "The priority_order argument should not be modified by the function"
+    assert get_prioritized_methods_groups(
+        methods,
+        priority_order=["A", "F"],
+    ) == [
+        {MethodA},
+        {MethodF},
+        {MethodB, MethodC, MethodD, MethodE},
+    ]
 
     # Case: asterisk in the middle
     assert get_prioritized_methods_groups(methods, priority_order=["A", "*", "B"]) == [

--- a/tests/unit/test_core/test_method.py
+++ b/tests/unit/test_core/test_method.py
@@ -499,3 +499,30 @@ def test_get_prioritized_methods_groups():
         {MethodC, MethodD, MethodE, MethodF},
         {MethodB},
     ]
+
+    # Case: asterisk at the start
+    assert get_prioritized_methods_groups(methods, priority_order=["*", "A", "B"]) == [
+        {MethodC, MethodD, MethodE, MethodF},
+        {MethodA},
+        {MethodB},
+    ]
+
+    # Case: Using sets
+    assert get_prioritized_methods_groups(
+        methods, priority_order=[{"A", "B"}, "*", {"E", "F"}]
+    ) == [
+        {MethodA, MethodB},
+        {MethodC, MethodD},
+        {MethodE, MethodF},
+    ]
+
+    # Case: Using sets, no asterisk -> implicit asterisk at the end
+    assert get_prioritized_methods_groups(methods, priority_order=[{"A", "B"}]) == [
+        {MethodA, MethodB},
+        {MethodC, MethodD, MethodE, MethodF},
+    ]
+
+    # Case: priority_order is None -> Should return all methods as one set
+    assert get_prioritized_methods_groups(methods, priority_order=None) == [
+        {MethodA, MethodB, MethodC, MethodD, MethodE, MethodF},
+    ]

--- a/tests/unit/test_core/test_method.py
+++ b/tests/unit/test_core/test_method.py
@@ -476,11 +476,11 @@ def test_get_prioritized_methods_groups(monkeypatch):
     methods_prioritised = get_prioritized_methods_groups(
         methods, priority_order=["A", "F", "*"]
     )
-    assert len(methods_prioritised) == 3
-    assert methods_prioritised[:2] == [{MethodA}, {MethodF}]
-    assert isinstance(methods_prioritised[2], set)
-    assert len(methods_prioritised[2]) == 4
-
+    assert methods_prioritised == [
+        {MethodA},
+        {MethodF},
+        {MethodB, MethodC, MethodD, MethodE},
+    ]
     # Case: Select some methods as more important, without '*'
     priority_order = ["A", "F"]
     methods_prioritised_without_asterisk = get_prioritized_methods_groups(
@@ -493,3 +493,10 @@ def test_get_prioritized_methods_groups(monkeypatch):
         "A",
         "F",
     ], "The priority_order argument should not be modified by the function"
+
+    # Case: asterisk in the middle
+    assert get_prioritized_methods_groups(methods, priority_order=["A", "*", "B"]) == [
+        {MethodA},
+        {MethodC, MethodD, MethodE, MethodF},
+        {MethodB},
+    ]

--- a/wakepy/core/method.py
+++ b/wakepy/core/method.py
@@ -695,7 +695,7 @@ def get_prioritized_methods_groups(
 
     for item in priority_order:
         if item == asterisk:
-            # do something
+            # Save the location where to add the rest of the methods ('*')
             asterisk_index = len(out)
         elif isinstance(item, set):
             out.append({method_dct[name] for name in item})

--- a/wakepy/core/method.py
+++ b/wakepy/core/method.py
@@ -660,7 +660,26 @@ def get_prioritized_methods_groups(
     methods: List[MethodCls], priority_order: Optional[PriorityOrder]
 ) -> List[Set[MethodCls]]:
     """Prioritizes Methods in `methods` based on priority order defined by
-    `priority_order`."""
+    `priority_order`. This function does not validate the priority_order in
+    any way; use `check_priority_order` for validation of needed.
+
+    Parameters
+    ----------
+    methods: list[MethodCls]
+        The source list of methods. These methods are returned as prioritized
+        groups.
+    priority_order: list[str | set[str]]
+        The names of the methods in `methods`. This specifies the priority
+        order; the order of method classes in the returned list. An asterisk
+        ('*') can be used to denote "all other methods".
+
+
+    Returns
+    -------
+    method_groups: list[set[MethodCls]]
+        The prioritized methods. Each set in the output represents a group of
+        equal priority. All Methods from the input `methods` are always
+        included in the output"""
     priority_order = priority_order or []
 
     # Make this a list of sets just to make things simpler

--- a/wakepy/core/method.py
+++ b/wakepy/core/method.py
@@ -687,7 +687,7 @@ def get_prioritized_methods_groups(
     Say there are methods MethodA, MethodB, MethodC, MethodD, MethodE, MethodF
     with names "A", "B", "C", "D", "E", "F":
 
-    >>> methods = MethodA, MethodB, MethodC, MethodD, MethodE, MethodF
+    >>> methods = [MethodA, MethodB, MethodC, MethodD, MethodE, MethodF]
     >>> get_prioritized_methods_groups(methods, priority_order=["A", "F", "*"])
     [
         {MethodA},

--- a/wakepy/core/method.py
+++ b/wakepy/core/method.py
@@ -680,6 +680,19 @@ def get_prioritized_methods_groups(
         The prioritized methods. Each set in the output represents a group of
         equal priority. All Methods from the input `methods` are always
         included in the output
+
+
+    Example
+    -------
+    Say there are methods MethodA, MethodB, MethodC, MethodD, MethodE, MethodF
+    with names "A", "B", "C", "D", "E", "F":
+    >>> get_prioritized_methods_groups(methods, priority_order=["A", "F", "*"])
+    [
+        {MethodA},
+        {MethodF},
+        {MethodB, MethodC, MethodD, MethodE},
+    ]
+
     """
 
     priority_order = priority_order or []

--- a/wakepy/core/method.py
+++ b/wakepy/core/method.py
@@ -679,7 +679,9 @@ def get_prioritized_methods_groups(
     method_groups: list[set[MethodCls]]
         The prioritized methods. Each set in the output represents a group of
         equal priority. All Methods from the input `methods` are always
-        included in the output"""
+        included in the output
+    """
+
     priority_order = priority_order or []
 
     # Make this a list of sets just to make things simpler

--- a/wakepy/core/method.py
+++ b/wakepy/core/method.py
@@ -686,6 +686,8 @@ def get_prioritized_methods_groups(
     -------
     Say there are methods MethodA, MethodB, MethodC, MethodD, MethodE, MethodF
     with names "A", "B", "C", "D", "E", "F":
+
+    >>> methods = MethodA, MethodB, MethodC, MethodD, MethodE, MethodF
     >>> get_prioritized_methods_groups(methods, priority_order=["A", "F", "*"])
     [
         {MethodA},

--- a/wakepy/core/method.py
+++ b/wakepy/core/method.py
@@ -649,3 +649,39 @@ def check_priority_order(
                     "The asterisk (*) can only occur once in priority_order!"
                 )
         seen_method_names.add(method_name)
+
+
+def get_prioritized_methods_groups(
+    methods: List[MethodCls], priority_order: Optional[PriorityOrder]
+) -> List[Set[MethodCls]]:
+    """Prioritizes Methods in `methods` based on priority order defined by
+    `priority_order`."""
+
+    # Make this a list of sets just to make things simpler
+    priority_order: List[Set[str]] = [
+        {item} if isinstance(item, str) else item for item in priority_order
+    ]
+
+    method_dct = {m.name: m for m in methods}
+
+    asterisk = {"*"}
+    asterisk_index = None
+    out = []
+
+    for item in priority_order:
+        if item == asterisk:
+            # do something
+            asterisk_index = len(out)
+        elif isinstance(item, set):
+            out.append({method_dct[name] for name in item})
+
+    out_flattened = {m for group in out for m in group}
+    rest_of_the_methods = {m for m in methods if m not in out_flattened}
+
+    if rest_of_the_methods:
+        if asterisk_index is not None:
+            out.insert(asterisk_index, rest_of_the_methods)
+        else:
+            out.append(rest_of_the_methods)
+
+    return out

--- a/wakepy/core/method.py
+++ b/wakepy/core/method.py
@@ -661,6 +661,7 @@ def get_prioritized_methods_groups(
 ) -> List[Set[MethodCls]]:
     """Prioritizes Methods in `methods` based on priority order defined by
     `priority_order`."""
+    priority_order = priority_order or []
 
     # Make this a list of sets just to make things simpler
     priority_order: List[Set[str]] = [

--- a/wakepy/core/method.py
+++ b/wakepy/core/method.py
@@ -41,6 +41,11 @@ def get_method(method_name: str) -> MethodCls:
     return METHOD_REGISTRY[method_name]
 
 
+def get_methods(method_names: List[str]) -> MethodCls:
+    """Get Method classes based on their names."""
+    return [get_method(name) for name in method_names]
+
+
 def method_names_to_classes(
     names: Collection[str] | None = None,
 ) -> Collection[MethodCls] | None:

--- a/wakepy/core/method.py
+++ b/wakepy/core/method.py
@@ -21,6 +21,7 @@ T = TypeVar("T")
 Collection = Union[List[T], Tuple[T, ...], Set[T]]
 MethodClsCollection = Collection[MethodCls]
 StrCollection = Collection[str]
+# The strings in PriorityOrder are names of Methods or the asterisk ('*')
 PriorityOrder = List[Union[str, Set[str]]]
 
 METHOD_REGISTRY: dict[str, MethodCls] = dict()

--- a/wakepy/core/mode.py
+++ b/wakepy/core/mode.py
@@ -9,7 +9,7 @@ from .method import check_priority_order
 
 if typing.TYPE_CHECKING:
     from types import TracebackType
-    from typing import Optional, Type
+    from typing import List, Optional, Type
 
     from .dbus import DbusAdapter, DbusAdapterTypeSeq
     from .method import Method, PriorityOrder

--- a/wakepy/core/mode.py
+++ b/wakepy/core/mode.py
@@ -9,7 +9,7 @@ from .method import check_priority_order
 
 if typing.TYPE_CHECKING:
     from types import TracebackType
-    from typing import List, Optional, Type
+    from typing import Optional, Type
 
     from .dbus import DbusAdapter, DbusAdapterTypeSeq
     from .method import Method, PriorityOrder


### PR DESCRIPTION
Adds a function called get_prioritized_methods_groups to prioritize a list of method classes using a list of method names or sets of method names.

Example

```
>>> methods = [MethodA, MethodB, MethodC, MethodD, MethodE, MethodF]
>>> get_prioritized_methods_groups(methods, priority_order=["A", "F", "*"])
[
    {MethodA},
    {MethodF},
    {MethodB, MethodC, MethodD, MethodE},
]
```