### PR TITLE
Issue 75: Replace MethodCurationOpts with method_priority + update keep.running & keep.presenting args

### DIFF
--- a/tests/unit/test_core/test_method.py
+++ b/tests/unit/test_core/test_method.py
@@ -335,10 +335,10 @@ def test_select_methods():
     methods = [MethodB, MethodD, MethodE]
 
     # These can also be filtered with a blacklist
-    assert select_methods(methods, skip=["B"]) == [MethodD, MethodE]
-    assert select_methods(methods, skip=["B", "E"]) == [MethodD]
-    # Extra 'skip' methods do not matter
-    assert select_methods(methods, skip=["B", "E", "foo", "bar"]) == [
+    assert select_methods(methods, omit=["B"]) == [MethodD, MethodE]
+    assert select_methods(methods, omit=["B", "E"]) == [MethodD]
+    # Extra 'omit' methods do not matter
+    assert select_methods(methods, omit=["B", "E", "foo", "bar"]) == [
         MethodD,
     ]
 

--- a/tests/unit/test_core/test_method.py
+++ b/tests/unit/test_core/test_method.py
@@ -9,7 +9,6 @@ from wakepy.core.method import (
     ExitModeError,
     HeartbeatCallError,
     Method,
-    MethodCurationOpts,
     MethodDefinitionError,
     MethodError,
     SystemName,
@@ -353,49 +352,6 @@ def test_select_methods():
         ),
     ):
         select_methods(methods, use_only=["foo", "bar"])
-
-
-@pytest.mark.usefixtures("provide_methods_a_f")
-def test_method_curation_opts_constructor():
-    MethodA, MethodF = get_methods(["A", "F"])
-
-    opts = MethodCurationOpts.from_names(skip=["A"], higher_priority=["F"])
-    assert opts.skip == [MethodA]
-    assert opts.higher_priority == [MethodF]
-
-    # Should not be possible to define both: use_only and skip
-    with pytest.raises(
-        ValueError,
-        match=re.escape(
-            "Can only define skip (blacklist) or use_only (whitelist), not both!"
-        ),
-    ):
-        MethodCurationOpts.from_names(skip=["A"], use_only=["F"])
-
-    # Should not be possible to define same method in lower and higher priority
-    with pytest.raises(
-        ValueError,
-        match=re.escape(
-            "Cannot have same methods in higher_priority and lower_priority! (Methods: {A})"
-        ),
-    ):
-        MethodCurationOpts.from_names(higher_priority=["A"], lower_priority=["A"])
-
-    # Cannot skip and prioritize methods
-    with pytest.raises(
-        ValueError,
-        match=re.escape(
-            "Cannot have same methods in `skip` and `higher_priority` or `lower_priority`!"
-        ),
-    ):
-        MethodCurationOpts.from_names(higher_priority=["A"], skip=["A"])
-    with pytest.raises(
-        ValueError,
-        match=re.escape(
-            "Cannot have same methods in `skip` and `higher_priority` or `lower_priority`!"
-        ),
-    ):
-        MethodCurationOpts.from_names(lower_priority=["A"], skip=["A"])
 
 
 @pytest.mark.usefixtures("provide_methods_a_f")

--- a/tests/unit/test_modes.py
+++ b/tests/unit/test_modes.py
@@ -1,16 +1,56 @@
 import pytest
 
 from wakepy.modes import keep
+from wakepy.core import ModeName, Method
 
-pytest.skip("These need to be fixed", allow_module_level=True)
+
+def create_methods(monkeypatch, name_prefix: str, modename: ModeName):
+    # empty method registry
+    monkeypatch.setattr("wakepy.core.method.METHOD_REGISTRY", dict())
+
+    class MethodA(Method):
+        name = f"{name_prefix}A"
+        mode = modename
+
+    class MethodB(Method):
+        name = f"{name_prefix}B"
+        mode = modename
+
+    class MethodC(Method):
+        name = f"{name_prefix}C"
+        mode = modename
+
+    return MethodA, MethodB, MethodC
 
 
+def test_keep_running_mode_creation(monkeypatch):
+    name_prefix = "running"
+    MethodA, MethodB, MethodC = create_methods(
+        monkeypatch, name_prefix=name_prefix, modename=ModeName.KEEP_RUNNING
+    )
+
+    mode = keep.running()
+
+    # All the methods for the mode are selected automatically
+    assert set(mode.methods) == {MethodA, MethodB, MethodC}
+
+    # Case: Test "omit" parameter
+    mode = keep.running(omit=[f"{name_prefix}A"])
+    assert set(mode.methods) == {MethodB, MethodC}
+
+    # Case: Test "methods" parameter
+    mode = keep.running(methods=[f"{name_prefix}A", f"{name_prefix}B"])
+    assert set(mode.methods) == {MethodB, MethodA}
+
+
+@pytest.mark.skip("This waits to be fixed")
 def test_keep_running():
     with keep.running() as k:
         assert k.success
         assert not k.failure
 
 
+@pytest.mark.skip("This waits to be fixed")
 def test_keep_presenting():
     with keep.presenting() as k:
         assert k.success

--- a/tests/unit/test_modes.py
+++ b/tests/unit/test_modes.py
@@ -1,6 +1,8 @@
+from unittest.mock import Mock
+
 import pytest
 
-from wakepy.core import Method, ModeName
+from wakepy.core import Method, ModeName, DbusAdapter
 from wakepy.modes import keep
 
 
@@ -23,24 +25,54 @@ def create_methods(monkeypatch, name_prefix: str, modename: ModeName):
     return MethodA, MethodB, MethodC
 
 
-def test_keep_running_mode_creation(monkeypatch):
-    name_prefix = "running"
+@pytest.mark.parametrize(
+    "input_args",
+    [
+        dict(
+            name_prefix="running",
+            function_under_test=keep.running,
+            modename=ModeName.KEEP_RUNNING,
+        ),
+        dict(
+            name_prefix="presenting",
+            function_under_test=keep.presenting,
+            modename=ModeName.KEEP_PRESENTING,
+        ),
+    ],
+)
+def test_keep_running_mode_creation(input_args, monkeypatch):
+    """Simple test for keep.running and keep.presenting. Tests that all input
+    arguments for the functions are passed to the Mode.__init__
+    """
+    name_prefix = input_args["name_prefix"]
+    function_under_test = input_args["function_under_test"]
+
     MethodA, MethodB, MethodC = create_methods(
-        monkeypatch, name_prefix=name_prefix, modename=ModeName.KEEP_RUNNING
+        monkeypatch, name_prefix=name_prefix, modename=input_args["modename"]
     )
 
-    mode = keep.running()
-
+    mode = function_under_test()
     # All the methods for the mode are selected automatically
     assert set(mode.methods) == {MethodA, MethodB, MethodC}
 
     # Case: Test "omit" parameter
-    mode = keep.running(omit=[f"{name_prefix}A"])
+    mode = function_under_test(omit=[f"{name_prefix}A"])
     assert set(mode.methods) == {MethodB, MethodC}
 
     # Case: Test "methods" parameter
-    mode = keep.running(methods=[f"{name_prefix}A", f"{name_prefix}B"])
+    mode = function_under_test(methods=[f"{name_prefix}A", f"{name_prefix}B"])
     assert set(mode.methods) == {MethodB, MethodA}
+
+    # Case: Test "methods_priority" parameter
+    methods_priority = [f"{name_prefix}A", f"{name_prefix}B"]
+    mode = function_under_test(methods_priority=methods_priority)
+    assert mode.methods_priority == methods_priority
+    assert set(mode.methods) == {MethodB, MethodA, MethodC}
+
+    # Case: Test "dbus_adapter" parameter
+    dbus_adapter = Mock(spec_set=DbusAdapter)
+    mode = function_under_test(dbus_adapter=dbus_adapter)
+    assert mode.manager._dbus_adapter == dbus_adapter
 
 
 @pytest.mark.skip("This waits to be fixed")

--- a/tests/unit/test_modes.py
+++ b/tests/unit/test_modes.py
@@ -1,7 +1,7 @@
 import pytest
 
+from wakepy.core import Method, ModeName
 from wakepy.modes import keep
-from wakepy.core import ModeName, Method
 
 
 def create_methods(monkeypatch, name_prefix: str, modename: ModeName):

--- a/wakepy/core/__init__.py
+++ b/wakepy/core/__init__.py
@@ -9,8 +9,8 @@ from .calls import Call as Call
 from .calls import DbusMethodCall as DbusMethodCall
 from .configuration import CURRENT_SYSTEM as CURRENT_SYSTEM
 from .constants import BusType as BusType
-from .constants import SystemName as SystemName
 from .constants import ModeName as ModeName
+from .constants import SystemName as SystemName
 from .dbus import DbusAddress as DbusAddress
 from .dbus import DbusMethod as DbusMethod
 from .method import Method as Method

--- a/wakepy/core/__init__.py
+++ b/wakepy/core/__init__.py
@@ -13,5 +13,6 @@ from .constants import ModeName as ModeName
 from .constants import SystemName as SystemName
 from .dbus import DbusAddress as DbusAddress
 from .dbus import DbusMethod as DbusMethod
+from .dbus import DbusAdapter as DbusAdapter
 from .method import Method as Method
 from .strenum import StrEnum as StrEnum

--- a/wakepy/core/__init__.py
+++ b/wakepy/core/__init__.py
@@ -10,6 +10,7 @@ from .calls import DbusMethodCall as DbusMethodCall
 from .configuration import CURRENT_SYSTEM as CURRENT_SYSTEM
 from .constants import BusType as BusType
 from .constants import SystemName as SystemName
+from .constants import ModeName as ModeName
 from .dbus import DbusAddress as DbusAddress
 from .dbus import DbusMethod as DbusMethod
 from .method import Method as Method

--- a/wakepy/core/method.py
+++ b/wakepy/core/method.py
@@ -91,26 +91,26 @@ def get_methods_for_mode(
 
 def select_methods(
     methods: MethodClsCollection,
-    skip: Optional[StrCollection] = None,
+    omit: Optional[StrCollection] = None,
     use_only: Optional[StrCollection] = None,
 ) -> List[MethodCls]:
-    """Selects Methods from from `methods` using a blacklist (skip) or
-    whitelist (use_only). If `skip` and `use_only` are both None, will return
+    """Selects Methods from from `methods` using a blacklist (omit) or
+    whitelist (use_only). If `omit` and `use_only` are both None, will return
     all the original methods.
 
     Parameters
     ----------
     methods: collection of Method classes
         The collection of methods from which to make the selection.
-    skip: list, tuple or set of str or None
+    omit: list, tuple or set of str or None
         The names of Methods to remove from the `methods`; a "blacklist"
-        filter. Any Method in `skip` but not in `methods` will be silently
+        filter. Any Method in `omit` but not in `methods` will be silently
         ignored. Cannot be used same time with `use_only`. Optional.
     use_only: list, tuple or set of str
         The names of Methods to select from the `methods`; a "whitelist"
         filter. Means "use these and only these Methods". Any Methods in
-        `use_only` but not in `methods` will raise a ValueError. Cannot
-        be used same time with `skip`. Optional.
+        `use_only` but not in `methods` will raise a ValueErrosr. Cannot
+        be used same time with `omit`. Optional.
 
     Returns
     -------
@@ -118,15 +118,15 @@ def select_methods(
         The selected method classes.
     """
 
-    if skip and use_only:
+    if omit and use_only:
         raise ValueError(
-            "Can only define skip (blacklist) or use_only (whitelist), not both!"
+            "Can only define omit (blacklist) or use_only (whitelist), not both!"
         )
 
-    if skip is None and use_only is None:
+    if omit is None and use_only is None:
         selected_methods = list(methods)
-    elif skip:
-        selected_methods = [m for m in methods if m.name not in skip]
+    elif omit:
+        selected_methods = [m for m in methods if m.name not in omit]
     elif use_only:
         selected_methods = [m for m in methods if m.name in use_only]
         if not set(use_only).issubset(m.name for m in selected_methods):

--- a/wakepy/core/mode.py
+++ b/wakepy/core/mode.py
@@ -131,8 +131,8 @@ class Mode(ABC):
 
 def create_mode(
     modename: ModeName,
+    methods: Optional[StrCollection] = None,
     skip: Optional[StrCollection] = None,
-    use_only: Optional[StrCollection] = None,
     dbus_adapter: Type[DbusAdapter] | DbusAdapterTypeSeq | None = None,
 ) -> Mode:
     """
@@ -140,16 +140,16 @@ def create_mode(
 
     Parameters
     ----------
+    methods: list, tuple or set of str
+        The names of Methods to select from the mode defined with `modename`;
+        a "whitelist" filter. Means "use these and only these Methods". Any
+        Methods in `methods` but not in the selected mode will raise a
+        ValueError. Cannot be used same time with `skip`. Optional.
     skip: list, tuple or set of str or None
         The names of Methods to remove from the mode defined with `modename`;
         a "blacklist" filter. Any Method in `skip` but not in the selected mode
-        will be silently ignored. Cannot be used same time with `use_only`.
+        will be silently ignored. Cannot be used same time with `methods`.
         Optional.
-    use_only: list, tuple or set of str
-        The names of Methods to select from the mode defined with `modename`;
-        a "whitelist" filter. Means "use these and only these Methods". Any
-        Methods in `use_only` but not in the selected mode will raise a
-        ValueError. Cannot be used same time with `skip`. Optional.
     dbus_adapter:
         Optional argument which can be used to define a customer DBus adapter.
 
@@ -159,5 +159,5 @@ def create_mode(
         The context manager for the selected mode.
     """
     methods_for_mode = get_methods_for_mode(modename)
-    selected_methods = select_methods(methods_for_mode, use_only=use_only, skip=skip)
+    selected_methods = select_methods(methods_for_mode, use_only=methods, skip=skip)
     return Mode(methods=selected_methods, dbus_adapter=dbus_adapter)

--- a/wakepy/core/mode.py
+++ b/wakepy/core/mode.py
@@ -132,7 +132,7 @@ class Mode(ABC):
 def create_mode(
     modename: ModeName,
     methods: Optional[StrCollection] = None,
-    skip: Optional[StrCollection] = None,
+    omit: Optional[StrCollection] = None,
     dbus_adapter: Type[DbusAdapter] | DbusAdapterTypeSeq | None = None,
 ) -> Mode:
     """
@@ -144,10 +144,10 @@ def create_mode(
         The names of Methods to select from the mode defined with `modename`;
         a "whitelist" filter. Means "use these and only these Methods". Any
         Methods in `methods` but not in the selected mode will raise a
-        ValueError. Cannot be used same time with `skip`. Optional.
-    skip: list, tuple or set of str or None
+        ValueError. Cannot be used same time with `omit`. Optional.
+    omit: list, tuple or set of str or None
         The names of Methods to remove from the mode defined with `modename`;
-        a "blacklist" filter. Any Method in `skip` but not in the selected mode
+        a "blacklist" filter. Any Method in `omit` but not in the selected mode
         will be silently ignored. Cannot be used same time with `methods`.
         Optional.
     dbus_adapter:
@@ -159,5 +159,5 @@ def create_mode(
         The context manager for the selected mode.
     """
     methods_for_mode = get_methods_for_mode(modename)
-    selected_methods = select_methods(methods_for_mode, use_only=methods, skip=skip)
+    selected_methods = select_methods(methods_for_mode, use_only=methods, omit=omit)
     return Mode(methods=selected_methods, dbus_adapter=dbus_adapter)

--- a/wakepy/core/mode.py
+++ b/wakepy/core/mode.py
@@ -133,6 +133,7 @@ def create_mode(
     modename: ModeName,
     methods: Optional[StrCollection] = None,
     omit: Optional[StrCollection] = None,
+    methods_priority: Optional[PriorityOrder] = None,
     dbus_adapter: Type[DbusAdapter] | DbusAdapterTypeSeq | None = None,
 ) -> Mode:
     """
@@ -150,6 +151,8 @@ def create_mode(
         a "blacklist" filter. Any Method in `omit` but not in the selected mode
         will be silently ignored. Cannot be used same time with `methods`.
         Optional.
+    methods_priority: list[str | set[str]]
+        The priority_order parameter for Mode. Used to prioritize methods.
     dbus_adapter:
         Optional argument which can be used to define a customer DBus adapter.
 
@@ -160,4 +163,8 @@ def create_mode(
     """
     methods_for_mode = get_methods_for_mode(modename)
     selected_methods = select_methods(methods_for_mode, use_only=methods, omit=omit)
-    return Mode(methods=selected_methods, dbus_adapter=dbus_adapter)
+    return Mode(
+        methods=selected_methods,
+        priority_order=methods_priority,
+        dbus_adapter=dbus_adapter,
+    )

--- a/wakepy/methods/gnome.py
+++ b/wakepy/methods/gnome.py
@@ -8,8 +8,8 @@ from wakepy.core import (
     DbusMethod,
     DbusMethodCall,
     Method,
-    SystemName,
     ModeName,
+    SystemName,
 )
 
 

--- a/wakepy/methods/gnome.py
+++ b/wakepy/methods/gnome.py
@@ -9,6 +9,7 @@ from wakepy.core import (
     DbusMethodCall,
     Method,
     SystemName,
+    ModeName,
 )
 
 
@@ -95,9 +96,11 @@ class _GnomeSessionManager(Method, ABC):
 
 class GnomeSessionManagerNoSuspend(_GnomeSessionManager):
     name = "org.gnome.SessionManager:Inhibit:Suspend"
+    mode = ModeName.KEEP_RUNNING
     flags = GnomeFlag.INHIBIT_SUSPEND
 
 
 class GnomeSessionManagerNoIdle(_GnomeSessionManager):
     name = "org.gnome.SessionManager:Inhibit:Idle"
+    mode = ModeName.KEEP_PRESENTING
     flags = GnomeFlag.INHIBIT_IDLE

--- a/wakepy/modes/keep.py
+++ b/wakepy/modes/keep.py
@@ -10,7 +10,7 @@ if typing.TYPE_CHECKING:
     from typing import List, Optional, Type
 
     from ..core.dbus import DbusAdapter, DbusAdapterTypeSeq
-    from ..core.method import Method, StrCollection, PriorityOrder
+    from ..core.method import Method, StrCollection, MethodsPriorityOrder
     from ..core.mode import Mode
 
 running_methods: List[Type[Method]] = [
@@ -24,7 +24,7 @@ presenting_methods: List[Type[Method]] = [
 def running(
     methods: Optional[StrCollection] = None,
     omit: Optional[StrCollection] = None,
-    methods_priority: Optional[PriorityOrder] = None,
+    methods_priority: Optional[MethodsPriorityOrder] = None,
     dbus_adapter: Type[DbusAdapter] | DbusAdapterTypeSeq | None = None,
 ) -> Mode:
     """Create a wakepy mode (a context manager) for keeping programs running.
@@ -104,7 +104,7 @@ def running(
 def presenting(
     methods: Optional[StrCollection] = None,
     omit: Optional[StrCollection] = None,
-    methods_priority: Optional[PriorityOrder] = None,
+    methods_priority: Optional[MethodsPriorityOrder] = None,
     dbus_adapter: Type[DbusAdapter] | DbusAdapterTypeSeq | None = None,
 ) -> Mode:
     """Create a wakepy mode (a context manager) for keeping a system running

--- a/wakepy/modes/keep.py
+++ b/wakepy/modes/keep.py
@@ -10,7 +10,7 @@ if typing.TYPE_CHECKING:
     from typing import List, Optional, Type
 
     from ..core.dbus import DbusAdapter, DbusAdapterTypeSeq
-    from ..core.method import Method, StrCollection
+    from ..core.method import Method, StrCollection, PriorityOrder
     from ..core.mode import Mode
 
 running_methods: List[Type[Method]] = [
@@ -24,6 +24,7 @@ presenting_methods: List[Type[Method]] = [
 def running(
     methods: Optional[StrCollection] = None,
     omit: Optional[StrCollection] = None,
+    methods_priority: Optional[PriorityOrder] = None,
     dbus_adapter: Type[DbusAdapter] | DbusAdapterTypeSeq | None = None,
 ) -> Mode:
     """Create a wakepy mode (a context manager) for keeping programs running.
@@ -65,6 +66,23 @@ def running(
         "blacklist" filter. Any Method in `omit` but not in the keep.running
         mode will be silently ignored. Cannot be used same time with
         `methods`. Optional.
+    methods_priority: list[str | set[str]]
+        The priority order for the methods to be used when entering the
+        keep.running mode. You may use this parameter to force or suggest the
+        order in which Methods are used. Any methods not explicitly supported
+        by the current platform will automatically be unused (no need to add
+        them here). The format is a list[str | set[str]], where each
+        string is a Method name. Any method within a set will have equal
+        user-given priority, and they are prioritized with the automatic
+        prioritization rules. The first item in the list has the highest
+        priority. All method names must be unique and must be part of the
+        keep.running Mode.
+
+        The asterisk ('*') can be used to mean "all other methods"
+        and may occur only once in the priority order, and cannot be part of a
+        set. If asterisk is not part of the `methods_priority`, it will be
+        added as the last element automatically.
+
     dbus_adapter:
         Optional argument which can be used to define a customer DBus adapter.
 
@@ -78,6 +96,7 @@ def running(
         modename=ModeName.KEEP_RUNNING,
         omit=omit,
         methods=methods,
+        methods_priority=methods_priority,
         dbus_adapter=dbus_adapter,
     )
 
@@ -85,6 +104,7 @@ def running(
 def presenting(
     methods: Optional[StrCollection] = None,
     omit: Optional[StrCollection] = None,
+    methods_priority: Optional[PriorityOrder] = None,
     dbus_adapter: Type[DbusAdapter] | DbusAdapterTypeSeq | None = None,
 ) -> Mode:
     """Create a wakepy mode (a context manager) for keeping a system running
@@ -103,15 +123,31 @@ def presenting(
     Parameters
     ----------
     methods: list, tuple or set of str
-        The names of Methods to select from the keep.running mode; a
+        The names of Methods to select from the keep.presenting mode; a
         "whitelist" filter. Means "use these and only these Methods". Any
-        Methods in `methods` but not in the keep.running mode will raise a
+        Methods in `methods` but not in the keep.presenting mode will raise a
         ValueError. Cannot be used same time with `omit`. Optional.
     omit: list, tuple or set of str or None
-        The names of Methods to remove from the keep.running mode; a
-        "blacklist" filter. Any Method in `omit` but not in the keep.running
+        The names of Methods to remove from the keep.presenting mode; a
+        "blacklist" filter. Any Method in `omit` but not in the keep.presenting
         mode will be silently ignored. Cannot be used same time with
         `methods`. Optional.
+    methods_priority: list[str | set[str]]
+        The priority order for the methods to be used when entering the
+        keep.presenting mode. You may use this parameter to force or suggest
+        the order in which Methods are used. Any methods not explicitly
+        supported by the current platform will automatically be unused (no need
+        to add them here). The format is a list[str | set[str]], where each
+        string is a Method name. Any method within a set will have equal
+        user-given priority, and they are prioritized with the automatic
+        prioritization rules. The first item in the list has the highest
+        priority. All method names must be unique and must be part of the
+        keep.presenting Mode.
+
+        The asterisk ('*') can be used to mean "all other methods"
+        and may occur only once in the priority order, and cannot be part of a
+        set. If asterisk is not part of the `methods_priority`, it will be
+        added as the last element automatically.
     dbus_adapter:
         Optional argument which can be used to define a customer DBus adapter.
 
@@ -125,5 +161,6 @@ def presenting(
         modename=ModeName.KEEP_PRESENTING,
         methods=methods,
         omit=omit,
+        methods_priority=methods_priority,
         dbus_adapter=dbus_adapter,
     )

--- a/wakepy/modes/keep.py
+++ b/wakepy/modes/keep.py
@@ -2,15 +2,16 @@ from __future__ import annotations
 
 import typing
 
-from ..core.mode import Mode
+from ..core.constants import ModeName
+from ..core.mode import create_mode
 from ..methods.gnome import GnomeSessionManagerNoIdle, GnomeSessionManagerNoSuspend
 
 if typing.TYPE_CHECKING:
-    from typing import List, Type
+    from typing import List, Optional, Type
 
     from ..core.dbus import DbusAdapter, DbusAdapterTypeSeq
-    from ..core.method import Method
-
+    from ..core.method import Method, StrCollection
+    from ..core.mode import Mode
 
 running_methods: List[Type[Method]] = [
     GnomeSessionManagerNoSuspend,
@@ -20,8 +21,12 @@ presenting_methods: List[Type[Method]] = [
 ]
 
 
-def running(dbus_adapter: Type[DbusAdapter] | DbusAdapterTypeSeq | None = None) -> Mode:
-    """A wakepy mode and context manager for keeping programs running.
+def running(
+    skip: Optional[StrCollection] = None,
+    use_only: Optional[StrCollection] = None,
+    dbus_adapter: Type[DbusAdapter] | DbusAdapterTypeSeq | None = None,
+) -> Mode:
+    """Create a wakepy mode (a context manager) for keeping programs running.
 
     Properties
     ----------
@@ -50,6 +55,16 @@ def running(dbus_adapter: Type[DbusAdapter] | DbusAdapterTypeSeq | None = None) 
 
     Parameters
     ----------
+    skip: list, tuple or set of str or None
+        The names of Methods to remove from the keep.running mode; a
+        "blacklist" filter. Any Method in `skip` but not in the keep.running
+        mode will be silently ignored. Cannot be used same time with
+        `use_only`. Optional.
+    use_only: list, tuple or set of str
+        The names of Methods to select from the keep.running mode; a
+        "whitelist" filter. Means "use these and only these Methods". Any
+        Methods in `use_only` but not in the keep.running mode will raise a
+        ValueError. Cannot be used same time with `skip`. Optional.
     dbus_adapter:
         Optional argument which can be used to define a customer DBus adapter.
 
@@ -59,13 +74,21 @@ def running(dbus_adapter: Type[DbusAdapter] | DbusAdapterTypeSeq | None = None) 
         The context manager for keeping a system running.
 
     """
-    return Mode(methods=running_methods, dbus_adapter=dbus_adapter)
+    return create_mode(
+        modename=ModeName.KEEP_RUNNING,
+        skip=skip,
+        use_only=use_only,
+        dbus_adapter=dbus_adapter,
+    )
 
 
 def presenting(
+    skip: Optional[StrCollection] = None,
+    use_only: Optional[StrCollection] = None,
     dbus_adapter: Type[DbusAdapter] | DbusAdapterTypeSeq | None = None,
 ) -> Mode:
-    """The keep.presenting mode context manager.
+    """Create a wakepy mode (a context manager) for keeping a system running
+    and showing content.
 
     Usage:
 
@@ -79,12 +102,28 @@ def presenting(
 
     Parameters
     ----------
+    skip: list, tuple or set of str or None
+        The names of Methods to remove from the keep.running mode; a
+        "blacklist" filter. Any Method in `skip` but not in the keep.running
+        mode will be silently ignored. Cannot be used same time with
+        `use_only`. Optional.
+    use_only: list, tuple or set of str
+        The names of Methods to select from the keep.running mode; a
+        "whitelist" filter. Means "use these and only these Methods". Any
+        Methods in `use_only` but not in the keep.running mode will raise a
+        ValueError. Cannot be used same time with `skip`. Optional.
     dbus_adapter:
         Optional argument which can be used to define a customer DBus adapter.
+
 
     Returns
     -------
     keep_presenting_mode: Mode
         The context manager for keeping a system presenting content.
     """
-    return Mode(methods=presenting_methods, dbus_adapter=dbus_adapter)
+    return create_mode(
+        modename=ModeName.KEEP_PRESENTING,
+        skip=skip,
+        use_only=use_only,
+        dbus_adapter=dbus_adapter,
+    )

--- a/wakepy/modes/keep.py
+++ b/wakepy/modes/keep.py
@@ -22,8 +22,8 @@ presenting_methods: List[Type[Method]] = [
 
 
 def running(
-    skip: Optional[StrCollection] = None,
     methods: Optional[StrCollection] = None,
+    omit: Optional[StrCollection] = None,
     dbus_adapter: Type[DbusAdapter] | DbusAdapterTypeSeq | None = None,
 ) -> Mode:
     """Create a wakepy mode (a context manager) for keeping programs running.
@@ -55,16 +55,16 @@ def running(
 
     Parameters
     ----------
-    skip: list, tuple or set of str or None
-        The names of Methods to remove from the keep.running mode; a
-        "blacklist" filter. Any Method in `skip` but not in the keep.running
-        mode will be silently ignored. Cannot be used same time with
-        `methods`. Optional.
     methods: list, tuple or set of str
         The names of Methods to select from the keep.running mode; a
         "whitelist" filter. Means "use these and only these Methods". Any
         Methods in `methods` but not in the keep.running mode will raise a
-        ValueError. Cannot be used same time with `skip`. Optional.
+        ValueError. Cannot be used same time with `omit`. Optional.
+    omit: list, tuple or set of str or None
+        The names of Methods to remove from the keep.running mode; a
+        "blacklist" filter. Any Method in `omit` but not in the keep.running
+        mode will be silently ignored. Cannot be used same time with
+        `methods`. Optional.
     dbus_adapter:
         Optional argument which can be used to define a customer DBus adapter.
 
@@ -76,15 +76,15 @@ def running(
     """
     return create_mode(
         modename=ModeName.KEEP_RUNNING,
-        skip=skip,
+        omit=omit,
         methods=methods,
         dbus_adapter=dbus_adapter,
     )
 
 
 def presenting(
-    skip: Optional[StrCollection] = None,
     methods: Optional[StrCollection] = None,
+    omit: Optional[StrCollection] = None,
     dbus_adapter: Type[DbusAdapter] | DbusAdapterTypeSeq | None = None,
 ) -> Mode:
     """Create a wakepy mode (a context manager) for keeping a system running
@@ -102,16 +102,16 @@ def presenting(
 
     Parameters
     ----------
-    skip: list, tuple or set of str or None
-        The names of Methods to remove from the keep.running mode; a
-        "blacklist" filter. Any Method in `skip` but not in the keep.running
-        mode will be silently ignored. Cannot be used same time with
-        `methods`. Optional.
     methods: list, tuple or set of str
         The names of Methods to select from the keep.running mode; a
         "whitelist" filter. Means "use these and only these Methods". Any
         Methods in `methods` but not in the keep.running mode will raise a
-        ValueError. Cannot be used same time with `skip`. Optional.
+        ValueError. Cannot be used same time with `omit`. Optional.
+    omit: list, tuple or set of str or None
+        The names of Methods to remove from the keep.running mode; a
+        "blacklist" filter. Any Method in `omit` but not in the keep.running
+        mode will be silently ignored. Cannot be used same time with
+        `methods`. Optional.
     dbus_adapter:
         Optional argument which can be used to define a customer DBus adapter.
 
@@ -123,7 +123,7 @@ def presenting(
     """
     return create_mode(
         modename=ModeName.KEEP_PRESENTING,
-        skip=skip,
         methods=methods,
+        omit=omit,
         dbus_adapter=dbus_adapter,
     )

--- a/wakepy/modes/keep.py
+++ b/wakepy/modes/keep.py
@@ -4,21 +4,13 @@ import typing
 
 from ..core.constants import ModeName
 from ..core.mode import create_mode
-from ..methods.gnome import GnomeSessionManagerNoIdle, GnomeSessionManagerNoSuspend
 
 if typing.TYPE_CHECKING:
-    from typing import List, Optional, Type
+    from typing import Optional, Type
 
     from ..core.dbus import DbusAdapter, DbusAdapterTypeSeq
-    from ..core.method import Method, MethodsPriorityOrder, StrCollection
+    from ..core.method import MethodsPriorityOrder, StrCollection
     from ..core.mode import Mode
-
-running_methods: List[Type[Method]] = [
-    GnomeSessionManagerNoSuspend,
-]
-presenting_methods: List[Type[Method]] = [
-    GnomeSessionManagerNoIdle,
-]
 
 
 def running(

--- a/wakepy/modes/keep.py
+++ b/wakepy/modes/keep.py
@@ -23,7 +23,7 @@ presenting_methods: List[Type[Method]] = [
 
 def running(
     skip: Optional[StrCollection] = None,
-    use_only: Optional[StrCollection] = None,
+    methods: Optional[StrCollection] = None,
     dbus_adapter: Type[DbusAdapter] | DbusAdapterTypeSeq | None = None,
 ) -> Mode:
     """Create a wakepy mode (a context manager) for keeping programs running.
@@ -59,11 +59,11 @@ def running(
         The names of Methods to remove from the keep.running mode; a
         "blacklist" filter. Any Method in `skip` but not in the keep.running
         mode will be silently ignored. Cannot be used same time with
-        `use_only`. Optional.
-    use_only: list, tuple or set of str
+        `methods`. Optional.
+    methods: list, tuple or set of str
         The names of Methods to select from the keep.running mode; a
         "whitelist" filter. Means "use these and only these Methods". Any
-        Methods in `use_only` but not in the keep.running mode will raise a
+        Methods in `methods` but not in the keep.running mode will raise a
         ValueError. Cannot be used same time with `skip`. Optional.
     dbus_adapter:
         Optional argument which can be used to define a customer DBus adapter.
@@ -77,14 +77,14 @@ def running(
     return create_mode(
         modename=ModeName.KEEP_RUNNING,
         skip=skip,
-        use_only=use_only,
+        methods=methods,
         dbus_adapter=dbus_adapter,
     )
 
 
 def presenting(
     skip: Optional[StrCollection] = None,
-    use_only: Optional[StrCollection] = None,
+    methods: Optional[StrCollection] = None,
     dbus_adapter: Type[DbusAdapter] | DbusAdapterTypeSeq | None = None,
 ) -> Mode:
     """Create a wakepy mode (a context manager) for keeping a system running
@@ -106,11 +106,11 @@ def presenting(
         The names of Methods to remove from the keep.running mode; a
         "blacklist" filter. Any Method in `skip` but not in the keep.running
         mode will be silently ignored. Cannot be used same time with
-        `use_only`. Optional.
-    use_only: list, tuple or set of str
+        `methods`. Optional.
+    methods: list, tuple or set of str
         The names of Methods to select from the keep.running mode; a
         "whitelist" filter. Means "use these and only these Methods". Any
-        Methods in `use_only` but not in the keep.running mode will raise a
+        Methods in `methods` but not in the keep.running mode will raise a
         ValueError. Cannot be used same time with `skip`. Optional.
     dbus_adapter:
         Optional argument which can be used to define a customer DBus adapter.
@@ -124,6 +124,6 @@ def presenting(
     return create_mode(
         modename=ModeName.KEEP_PRESENTING,
         skip=skip,
-        use_only=use_only,
+        methods=methods,
         dbus_adapter=dbus_adapter,
     )

--- a/wakepy/modes/keep.py
+++ b/wakepy/modes/keep.py
@@ -10,7 +10,7 @@ if typing.TYPE_CHECKING:
     from typing import List, Optional, Type
 
     from ..core.dbus import DbusAdapter, DbusAdapterTypeSeq
-    from ..core.method import Method, StrCollection, MethodsPriorityOrder
+    from ..core.method import Method, MethodsPriorityOrder, StrCollection
     from ..core.mode import Mode
 
 running_methods: List[Type[Method]] = [


### PR DESCRIPTION
* Update keep.running and keep.presenting. They have now "method", "omit" and "methods_priority" arguments.
* Rename "skip" arguments to "omit" (as per [comment](https://github.com/fohrloop/wakepy/issues/75#issuecomment-1849017334) in #75)
* Rename "use_only" arguments to "methods" in all other places than the `select_methods` (which already has "methods" argument). (as per [comment](https://github.com/fohrloop/wakepy/issues/75#issuecomment-1849017334) in #75)
* Renamed priority_order to methods_priority (as per [comment](https://github.com/fohrloop/wakepy/issues/75#issuecomment-1849017334) in #75)
* Tie GnomeSessionManagerNoSuspend Method to ModeName.KEEP_RUNNING Mode
* Tie GnomeSessionManagerNoIdle Method to ModeName.KEEP_PRESENTING Mode
* Removed MethodCurationOpts. This was replaced with the methods_priority argument