### PR TITLE
Issue 63: "platform" instead of "system"

### DIFF
--- a/docs/source/user-guide/modes.md
+++ b/docs/source/user-guide/modes.md
@@ -120,7 +120,7 @@ The systemd mask method will inhibit all forms of sleep (including hibernation a
 
 **How to check it?**:  For D-Bus  `org.freedesktop.ScreenSaver` based solution, there is no possibility to check it afterwards. You may monitor the call with [`dbus-monitor`](https://dbus.freedesktop.org/doc/dbus-monitor.1.html), though. For systemd mask based solution, you'll see that the Suspend option is removed from the menu altogether.
 
-**What systems are supported?** For D-Bus `org.freedesktop.ScreenSaver` method, you have to use a Freedesktop-compliant Desktop Environment, for example GNOME or KDE. The list of supported systems will be expanded in the future. For systemd solution, any Linux running systemd works, but you need sudo.
+**Which Desktop Environments are supported?** For D-Bus `org.freedesktop.ScreenSaver` method, you have to use a Freedesktop-compliant Desktop Environment, for example GNOME or KDE. The list of supported DEs will be expanded in the future. For systemd solution, any Linux running systemd works, but you need sudo.
 
 **Multiprocess safe?**: DBus: yes, systemd mask: no.
 

--- a/docs/source/user-guide/technical-details.md
+++ b/docs/source/user-guide/technical-details.md
@@ -56,7 +56,7 @@ m = mode.__enter__()
 
 
 When entering into a Mode, a lot of things occur. One of the things is that wakepy needs to determine, from all the [***Methods***](#wakepy-methods) in `Mode.methods`, which ones can be used. There might be multiple reasons why a method could not be used
-- Wrong operating system
+- Wrong operating system or platform
 - Wrong Desktop Environment
 - Required software not found
 - Wrong version of Desktop Environment or software
@@ -95,5 +95,5 @@ When the context manager is exited, a `EXIT` command is automatically sent from 
 (wakepy-methods)=
 ## Wakepy Methods
 
-**Methods** are different ways of entering/keeping in a Mode. A Method may support one or more operating systems, and may have one or more requirements for software it should be able to talk to or execute. For example, on Linux. using the Inhibit method of the [org.gnome.SessionManager](https://lira.no-ip.org:8443/doc/gnome-session/dbus/gnome-session.html) D-Bus service is one way of entering `keep.running` mode, and it required D-Bus and (a certain version of) GNOME. 
+**Methods** are different ways of entering/keeping in a Mode. A Method may support one or more platforms, and may have one or more requirements for software it should be able to talk to or execute. For example, on Linux. using the Inhibit method of the [org.gnome.SessionManager](https://lira.no-ip.org:8443/doc/gnome-session/dbus/gnome-session.html) D-Bus service is one way of entering `keep.running` mode, and it required D-Bus and (a certain version of) GNOME. 
 

--- a/tests/integration/test_modes_end_to_end.py
+++ b/tests/integration/test_modes_end_to_end.py
@@ -2,7 +2,7 @@
 """
 import pytest
 
-from wakepy.core import CURRENT_SYSTEM
+from wakepy.core import CURRENT_PLATFORM
 from wakepy.core.method import Method
 from wakepy.core.mode import Mode
 
@@ -10,7 +10,7 @@ pytest.skip("These need to be fixed", allow_module_level=True)
 
 
 class MethodEnterExit(Method):
-    supported_platforms = (CURRENT_SYSTEM,)
+    supported_platforms = (CURRENT_PLATFORM,)
 
     def enter_mode(self):
         ...
@@ -20,7 +20,7 @@ class MethodEnterExit(Method):
 
 
 class HeartBeatMethod(Method):
-    supported_platforms = (CURRENT_SYSTEM,)
+    supported_platforms = (CURRENT_PLATFORM,)
 
     def heartbeat(self):
         ...

--- a/tests/integration/test_modes_end_to_end.py
+++ b/tests/integration/test_modes_end_to_end.py
@@ -10,7 +10,7 @@ pytest.skip("These need to be fixed", allow_module_level=True)
 
 
 class MethodEnterExit(Method):
-    supported_systems = (CURRENT_SYSTEM,)
+    supported_platforms = (CURRENT_SYSTEM,)
 
     def enter_mode(self):
         ...
@@ -20,7 +20,7 @@ class MethodEnterExit(Method):
 
 
 class HeartBeatMethod(Method):
-    supported_systems = (CURRENT_SYSTEM,)
+    supported_platforms = (CURRENT_SYSTEM,)
 
     def heartbeat(self):
         ...

--- a/tests/unit/test_core/test_method.py
+++ b/tests/unit/test_core/test_method.py
@@ -11,7 +11,7 @@ from wakepy.core.method import (
     Method,
     MethodDefinitionError,
     MethodError,
-    SystemName,
+    PlatformName,
     check_methods_priority,
     get_method,
     get_methods,
@@ -59,37 +59,41 @@ def provide_methods_a_f(monkeypatch):
 
 
 @pytest.fixture(scope="function")
-def provide_methods_different_systems(monkeypatch):
+def provide_methods_different_platforms(monkeypatch):
     # empty method registry
     monkeypatch.setattr("wakepy.core.method.METHOD_REGISTRY", dict())
 
     class WindowsA(Method):
         name = "WinA"
-        supported_platforms = (SystemName.WINDOWS,)
+        supported_platforms = (PlatformName.WINDOWS,)
 
     class WindowsB(Method):
         name = "WinB"
-        supported_platforms = (SystemName.WINDOWS,)
+        supported_platforms = (PlatformName.WINDOWS,)
 
     class WindowsC(Method):
         name = "WinC"
-        supported_platforms = (SystemName.WINDOWS,)
+        supported_platforms = (PlatformName.WINDOWS,)
 
     class LinuxA(Method):
         name = "LinuxA"
-        supported_platforms = (SystemName.LINUX,)
+        supported_platforms = (PlatformName.LINUX,)
 
     class LinuxB(Method):
         name = "LinuxB"
-        supported_platforms = (SystemName.LINUX,)
+        supported_platforms = (PlatformName.LINUX,)
 
     class LinuxC(Method):
         name = "LinuxC"
-        supported_platforms = (SystemName.LINUX,)
+        supported_platforms = (PlatformName.LINUX,)
 
     class MultiPlatformA(Method):
         name = "multiA"
-        supported_platforms = (SystemName.LINUX, SystemName.WINDOWS, SystemName.DARWIN)
+        supported_platforms = (
+            PlatformName.LINUX,
+            PlatformName.WINDOWS,
+            PlatformName.DARWIN,
+        )
 
 
 def test_overridden_methods_autodiscovery():
@@ -485,32 +489,32 @@ def test_get_prioritized_methods_groups():
     ]
 
 
-@pytest.mark.usefixtures("provide_methods_different_systems")
+@pytest.mark.usefixtures("provide_methods_different_platforms")
 def test_sort_methods_by_priority(monkeypatch):
     WindowsA, WindowsB, WindowsC, LinuxA, LinuxB, LinuxC, MultiPlatformA = get_methods(
         ["WinA", "WinB", "WinC", "LinuxA", "LinuxB", "LinuxC", "multiA"]
     )
 
-    monkeypatch.setattr("wakepy.core.method.CURRENT_SYSTEM", SystemName.LINUX)
+    monkeypatch.setattr("wakepy.core.method.CURRENT_PLATFORM", PlatformName.LINUX)
     # Expecting to see Linux methods prioritized, and then by method name
     assert sort_methods_by_priority(
         {WindowsA, WindowsB, WindowsC, LinuxA, LinuxB, LinuxC, MultiPlatformA}
     ) == [LinuxA, LinuxB, LinuxC, MultiPlatformA, WindowsA, WindowsB, WindowsC]
 
-    monkeypatch.setattr("wakepy.core.method.CURRENT_SYSTEM", SystemName.WINDOWS)
+    monkeypatch.setattr("wakepy.core.method.CURRENT_PLATFORM", PlatformName.WINDOWS)
     # Expecting to see windows methods prioritized, and then by method name
     assert sort_methods_by_priority(
         {WindowsA, WindowsB, WindowsC, LinuxA, LinuxB, LinuxC, MultiPlatformA}
     ) == [MultiPlatformA, WindowsA, WindowsB, WindowsC, LinuxA, LinuxB, LinuxC]
 
 
-@pytest.mark.usefixtures("provide_methods_different_systems")
+@pytest.mark.usefixtures("provide_methods_different_platforms")
 def test_get_prioritized_methods(monkeypatch):
     WindowsA, WindowsB, WindowsC, LinuxA, LinuxB, LinuxC, MultiPlatformA = get_methods(
         ["WinA", "WinB", "WinC", "LinuxA", "LinuxB", "LinuxC", "multiA"]
     )
 
-    monkeypatch.setattr("wakepy.core.method.CURRENT_SYSTEM", SystemName.LINUX)
+    monkeypatch.setattr("wakepy.core.method.CURRENT_PLATFORM", PlatformName.LINUX)
 
     assert get_prioritized_methods(
         [
@@ -565,7 +569,7 @@ def test_get_prioritized_methods(monkeypatch):
         ],
     ) == [LinuxA, LinuxB, LinuxC, MultiPlatformA, WindowsA, WindowsB]
 
-    monkeypatch.setattr("wakepy.core.method.CURRENT_SYSTEM", SystemName.WINDOWS)
+    monkeypatch.setattr("wakepy.core.method.CURRENT_PLATFORM", PlatformName.WINDOWS)
     # No user-defined order -> Just alphabetical, but current platform (Windows) first.
     assert get_prioritized_methods(
         [LinuxA, LinuxB, WindowsA, WindowsB, LinuxC, MultiPlatformA],

--- a/tests/unit/test_core/test_method.py
+++ b/tests/unit/test_core/test_method.py
@@ -65,31 +65,31 @@ def provide_methods_different_systems(monkeypatch):
 
     class WindowsA(Method):
         name = "WinA"
-        supported_systems = (SystemName.WINDOWS,)
+        supported_platforms = (SystemName.WINDOWS,)
 
     class WindowsB(Method):
         name = "WinB"
-        supported_systems = (SystemName.WINDOWS,)
+        supported_platforms = (SystemName.WINDOWS,)
 
     class WindowsC(Method):
         name = "WinC"
-        supported_systems = (SystemName.WINDOWS,)
+        supported_platforms = (SystemName.WINDOWS,)
 
     class LinuxA(Method):
         name = "LinuxA"
-        supported_systems = (SystemName.LINUX,)
+        supported_platforms = (SystemName.LINUX,)
 
     class LinuxB(Method):
         name = "LinuxB"
-        supported_systems = (SystemName.LINUX,)
+        supported_platforms = (SystemName.LINUX,)
 
     class LinuxC(Method):
         name = "LinuxC"
-        supported_systems = (SystemName.LINUX,)
+        supported_platforms = (SystemName.LINUX,)
 
     class MultiPlatformA(Method):
         name = "multiA"
-        supported_systems = (SystemName.LINUX, SystemName.WINDOWS, SystemName.DARWIN)
+        supported_platforms = (SystemName.LINUX, SystemName.WINDOWS, SystemName.DARWIN)
 
 
 def test_overridden_methods_autodiscovery():

--- a/tests/unit/test_core/test_method.py
+++ b/tests/unit/test_core/test_method.py
@@ -92,7 +92,7 @@ def provide_methods_different_platforms(monkeypatch):
         supported_platforms = (
             PlatformName.LINUX,
             PlatformName.WINDOWS,
-            PlatformName.DARWIN,
+            PlatformName.MACOS,
         )
 
 

--- a/tests/unit/test_core/testmethods.py
+++ b/tests/unit/test_core/testmethods.py
@@ -1,7 +1,7 @@
 import enum
 import itertools
 
-from wakepy.core.configuration import CURRENT_PLATFORM
+from wakepy.core import CURRENT_PLATFORM
 from wakepy.core.method import Method
 
 

--- a/tests/unit/test_core/testmethods.py
+++ b/tests/unit/test_core/testmethods.py
@@ -1,7 +1,7 @@
 import enum
 import itertools
 
-from wakepy.core.configuration import CURRENT_SYSTEM
+from wakepy.core.configuration import CURRENT_PLATFORM
 from wakepy.core.method import Method
 
 
@@ -26,7 +26,7 @@ def create_test_method_classes():
 
     for enter_mode, heartbeat, exit_mode in itertools.product(MethodIs, repeat=3):
         clsname = f"M{enter_mode.value}{heartbeat.value}{exit_mode.value}"
-        clskwargs = {"supported_platforms": CURRENT_SYSTEM, "name": clsname}
+        clskwargs = {"supported_platforms": CURRENT_PLATFORM, "name": clsname}
         for mode, name in zip(
             (enter_mode, heartbeat, exit_mode), ("enter_mode", "heartbeat", "exit_mode")
         ):

--- a/tests/unit/test_core/testmethods.py
+++ b/tests/unit/test_core/testmethods.py
@@ -26,7 +26,7 @@ def create_test_method_classes():
 
     for enter_mode, heartbeat, exit_mode in itertools.product(MethodIs, repeat=3):
         clsname = f"M{enter_mode.value}{heartbeat.value}{exit_mode.value}"
-        clskwargs = {"supported_systems": CURRENT_SYSTEM, "name": clsname}
+        clskwargs = {"supported_platforms": CURRENT_SYSTEM, "name": clsname}
         for mode, name in zip(
             (enter_mode, heartbeat, exit_mode), ("enter_mode", "heartbeat", "exit_mode")
         ):

--- a/tests/unit/test_modes.py
+++ b/tests/unit/test_modes.py
@@ -2,7 +2,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from wakepy.core import Method, ModeName, DbusAdapter
+from wakepy.core import DbusAdapter, Method, ModeName
 from wakepy.modes import keep
 
 

--- a/wakepy/cli.py
+++ b/wakepy/cli.py
@@ -11,7 +11,7 @@ import time
 import warnings
 from contextlib import ExitStack
 
-from wakepy.core.system import CURRENT_SYSTEM, SystemName
+from wakepy.core.system import CURRENT_PLATFORM, PlatformName
 from wakepy.modes import keep
 
 WAKEPY_TEXT_TEMPLATE = r"""                  _                       
@@ -105,7 +105,9 @@ def start(
 
         # A quick fix (Fix this better in next release)
         # On linux, D-Bus methods for keep_running use presentation_mode.
-        if CURRENT_SYSTEM == SystemName.LINUX and real_successes.get("keep_running"):
+        if CURRENT_PLATFORM == PlatformName.LINUX and real_successes.get(
+            "keep_running"
+        ):
             real_successes["presentation_mode"] = True
 
         print_on_start(**real_successes)

--- a/wakepy/core/__init__.py
+++ b/wakepy/core/__init__.py
@@ -7,10 +7,10 @@ See the public Python API at: https://wakepy.readthedocs.io/
 from .activationresult import ActivationResult as ActivationResult
 from .calls import Call as Call
 from .calls import DbusMethodCall as DbusMethodCall
-from .configuration import CURRENT_SYSTEM as CURRENT_SYSTEM
+from .configuration import CURRENT_PLATFORM as CURRENT_PLATFORM
 from .constants import BusType as BusType
 from .constants import ModeName as ModeName
-from .constants import SystemName as SystemName
+from .constants import PlatformName as PlatformName
 from .dbus import DbusAddress as DbusAddress
 from .dbus import DbusMethod as DbusMethod
 from .dbus import DbusAdapter as DbusAdapter

--- a/wakepy/core/__init__.py
+++ b/wakepy/core/__init__.py
@@ -7,12 +7,12 @@ See the public Python API at: https://wakepy.readthedocs.io/
 from .activationresult import ActivationResult as ActivationResult
 from .calls import Call as Call
 from .calls import DbusMethodCall as DbusMethodCall
-from .configuration import CURRENT_PLATFORM as CURRENT_PLATFORM
 from .constants import BusType as BusType
 from .constants import ModeName as ModeName
 from .constants import PlatformName as PlatformName
+from .dbus import DbusAdapter as DbusAdapter
 from .dbus import DbusAddress as DbusAddress
 from .dbus import DbusMethod as DbusMethod
-from .dbus import DbusAdapter as DbusAdapter
 from .method import Method as Method
+from .platform import CURRENT_PLATFORM as CURRENT_PLATFORM
 from .strenum import StrEnum as StrEnum

--- a/wakepy/core/configuration.py
+++ b/wakepy/core/configuration.py
@@ -1,8 +1,8 @@
 import platform
 
-from .constants import SystemName
+from .constants import PlatformName
 
 # E.g.: 'windows', 'linux' or 'darwin'
 # TODO: consider splitting this information to "platform", which would also include wsl
 # and cygwin and "os" which would just tell the operating system?
-CURRENT_SYSTEM = SystemName(platform.system().lower())
+CURRENT_PLATFORM = PlatformName(platform.system().lower())

--- a/wakepy/core/configuration.py
+++ b/wakepy/core/configuration.py
@@ -1,8 +1,0 @@
-import platform
-
-from .constants import PlatformName
-
-# E.g.: 'windows', 'linux' or 'darwin'
-# TODO: consider splitting this information to "platform", which would also include wsl
-# and cygwin and "os" which would just tell the operating system?
-CURRENT_PLATFORM = PlatformName(platform.system().lower())

--- a/wakepy/core/constants.py
+++ b/wakepy/core/constants.py
@@ -3,11 +3,10 @@ from .strenum import StrEnum, auto
 
 
 class PlatformName(StrEnum):
-    """The names of supported platforms"""
-
     WINDOWS = auto()
     LINUX = auto()
     MACOS = auto()
+    OTHER = auto()
 
 
 class ModeName(StrEnum):

--- a/wakepy/core/constants.py
+++ b/wakepy/core/constants.py
@@ -5,9 +5,9 @@ from .strenum import StrEnum, auto
 class PlatformName(StrEnum):
     """The names of supported platforms"""
 
-    WINDOWS = "windows"
-    LINUX = "linux"
-    DARWIN = "darwin"
+    WINDOWS = auto()
+    LINUX = auto()
+    MACOS = auto()
 
 
 class ModeName(StrEnum):

--- a/wakepy/core/constants.py
+++ b/wakepy/core/constants.py
@@ -2,8 +2,8 @@
 from .strenum import StrEnum, auto
 
 
-class SystemName(StrEnum):
-    """The names of supported systems"""
+class PlatformName(StrEnum):
+    """The names of supported platforms"""
 
     WINDOWS = "windows"
     LINUX = "linux"

--- a/wakepy/core/method.py
+++ b/wakepy/core/method.py
@@ -5,9 +5,9 @@ import warnings
 from abc import ABC, ABCMeta
 from typing import Any, List, Optional, Set, Tuple, Type, TypeVar, Union
 
-from . import CURRENT_SYSTEM
+from . import CURRENT_PLATFORM
 from .calls import DbusMethodCall
-from .constants import ModeName, SystemName
+from .constants import ModeName, PlatformName
 from .strenum import StrEnum, auto
 
 if typing.TYPE_CHECKING:
@@ -203,10 +203,10 @@ class SuitabilityCheckResult(StrEnum):
 class UnsuitabilityTag(StrEnum):
     """These are used to distiguish between different reasons for unsuitability
 
-    SYSTEM: Used when system is not supported by the method.
+    PLATFORM: Used when platform is not supported by the method.
     """
 
-    SYSTEM = auto()
+    PLATFORM = auto()
     OTHER = auto()
 
 
@@ -235,11 +235,10 @@ class Method(ABC, metaclass=MethodMeta):
     """The mode for the method. Each method may be connected to single mode.
     Use None for methods which do not implement any mode."""
 
-    supported_platforms: Tuple[SystemName, ...] = tuple()
-    """All the supported platforms. If a system is not listed here, this method
-    if not going to be used on the system (when used as part of a Mode)
-    
-    Modify this in the subclass"""
+    supported_platforms: Tuple[PlatformName, ...] = tuple()
+    """All the supported platforms. If a platform is not listed here, this
+    method is not going to be used on the platform (when used as part of a
+    Mode). Modify this in the subclass"""
 
     description: Optional[str] = None
     """Human-readable description for the method. Markdown allowed. Used to
@@ -295,7 +294,7 @@ class Method(ABC, metaclass=MethodMeta):
         is possible to give more information about why some Method is not
         supported.
 
-        NOTE: You do not have to test for (operating) system here as it is
+        NOTE: You do not have to test for the current platform here as it is
         automatically tested if Method has `supported_platforms` attribute set!
 
         Examples
@@ -468,10 +467,10 @@ class Method(ABC, metaclass=MethodMeta):
 
     def get_suitability(
         self,
-        system: SystemName | str,
+        platform: PlatformName | str,
     ) -> Suitability:
         """This is a method used to check the suitability of a method when
-        running on a specific system with a set of software installed on it
+        running on a specific platform with a set of software installed on it
         (which wakepy does not know beforehand).
 
         This method is not meant to be overridden in a subclass; override the
@@ -479,21 +478,21 @@ class Method(ABC, metaclass=MethodMeta):
 
         Parameters
         ---------
-        system:
-            The system for which to check suitability. Usually, should be the
-            CURRENT_SYSTEM (if not testing). Can als be a lower-case string
+        platform:
+            The platform for which to check suitability. Usually, should be the
+            CURRENT_PLATFORM (if not testing). Can als be a lower-case string
             like "windows", "linux" or "darwin".
         """
 
         if (
             hasattr(self, "supported_platforms")
-            and system not in self.supported_platforms
+            and platform not in self.supported_platforms
         ):
             return Suitability(
                 SuitabilityCheckResult.UNSUITABLE,
-                UnsuitabilityTag.SYSTEM,
-                f"Supported systems are: {self.supported_platforms}. "
-                f"(detected system: {system})",
+                UnsuitabilityTag.PLATFORM,
+                f"Supported platform are: {self.supported_platforms}. "
+                f"(detected platform: {platform})",
             )
 
         canuse = self.caniuse()
@@ -673,15 +672,15 @@ def sort_methods_by_priority(methods: Set[MethodCls]) -> List[MethodCls]:
     Methods with highest priority first.
 
     The logic is:
-    (1) Any Methods supporting the CURRENT_SYSTEM are placed before any other
+    (1) Any Methods supporting the CURRENT_PLATFORM are placed before any other
         Methods (the others are not expected to work at all)
     (2) Sort alphabetically by Method name, ignoring the case
     """
     return sorted(
         methods,
         key=lambda m: (
-            # Prioritize methods supporting CURRENT_SYSTEM over any others
-            0 if CURRENT_SYSTEM in m.supported_platforms else 1,
+            # Prioritize methods supporting CURRENT_PLATFORM over any others
+            0 if CURRENT_PLATFORM in m.supported_platforms else 1,
             m.name.lower() if m.name else "",
         ),
     )

--- a/wakepy/core/method.py
+++ b/wakepy/core/method.py
@@ -5,9 +5,9 @@ import warnings
 from abc import ABC, ABCMeta
 from typing import Any, List, Optional, Set, Tuple, Type, TypeVar, Union
 
-from . import CURRENT_PLATFORM
 from .calls import DbusMethodCall
 from .constants import ModeName, PlatformName
+from .platform import CURRENT_PLATFORM
 from .strenum import StrEnum, auto
 
 if typing.TYPE_CHECKING:

--- a/wakepy/core/method.py
+++ b/wakepy/core/method.py
@@ -235,8 +235,8 @@ class Method(ABC, metaclass=MethodMeta):
     """The mode for the method. Each method may be connected to single mode.
     Use None for methods which do not implement any mode."""
 
-    supported_systems: Tuple[SystemName, ...] = tuple()
-    """All the supported systems. If a system is not listed here, this method
+    supported_platforms: Tuple[SystemName, ...] = tuple()
+    """All the supported platforms. If a system is not listed here, this method
     if not going to be used on the system (when used as part of a Mode)
     
     Modify this in the subclass"""
@@ -296,7 +296,7 @@ class Method(ABC, metaclass=MethodMeta):
         supported.
 
         NOTE: You do not have to test for (operating) system here as it is
-        automatically tested if Method has `supported_systems` attribute set!
+        automatically tested if Method has `supported_platforms` attribute set!
 
         Examples
         --------
@@ -485,11 +485,14 @@ class Method(ABC, metaclass=MethodMeta):
             like "windows", "linux" or "darwin".
         """
 
-        if hasattr(self, "supported_systems") and system not in self.supported_systems:
+        if (
+            hasattr(self, "supported_platforms")
+            and system not in self.supported_platforms
+        ):
             return Suitability(
                 SuitabilityCheckResult.UNSUITABLE,
                 UnsuitabilityTag.SYSTEM,
-                f"Supported systems are: {self.supported_systems}. "
+                f"Supported systems are: {self.supported_platforms}. "
                 f"(detected system: {system})",
             )
 
@@ -678,7 +681,7 @@ def sort_methods_by_priority(methods: Set[MethodCls]) -> List[MethodCls]:
         methods,
         key=lambda m: (
             # Prioritize methods supporting CURRENT_SYSTEM over any others
-            0 if CURRENT_SYSTEM in m.supported_systems else 1,
+            0 if CURRENT_SYSTEM in m.supported_platforms else 1,
             m.name.lower() if m.name else "",
         ),
     )

--- a/wakepy/core/modeactivator.py
+++ b/wakepy/core/modeactivator.py
@@ -4,7 +4,7 @@ import typing
 from queue import Empty, Queue
 from threading import Thread
 
-from . import CURRENT_SYSTEM, SystemName
+from . import CURRENT_PLATFORM, PlatformName
 from .constants import ControlMsg, WorkerThreadMsgType
 from .method import Suitability
 
@@ -63,13 +63,13 @@ class ModeWorkerThread(Thread):
         methods: List[Method],
         queue_in: Queue,
         queue_out: Queue,
-        system: SystemName = CURRENT_SYSTEM,
+        platform: PlatformName = CURRENT_PLATFORM,
         *args,
         **kwargs,
     ):
         super().__init__(*args, name="wakepy-mode-manager", **kwargs)
         self.methods = methods
-        self.system = system
+        self.platform = platform
         self.queue_in = queue_in
         self.queue_out = queue_out
 
@@ -89,7 +89,7 @@ class ModeWorkerThread(Thread):
         candidate_methods = []
         for method in methods:
             self.check_input_queue()
-            method.set_suitability(system=self.system)
+            method.set_suitability(platform=self.platform)
             if method.suitability == Suitability.UNSUITABLE:
                 continue
             candidate_methods.append(method)

--- a/wakepy/core/platform.py
+++ b/wakepy/core/platform.py
@@ -1,0 +1,23 @@
+import platform
+import warnings
+
+from .constants import PlatformName
+
+
+def get_current_platform() -> PlatformName:
+    # Ref: https://docs.python.org/3/library/platform.html#platform.system
+    system = platform.system()
+    if system == "Windows":
+        return PlatformName.WINDOWS
+    elif system == "Darwin":
+        return PlatformName.MACOS
+    elif system == "Linux":
+        return PlatformName.LINUX
+
+    warnings.warn(
+        f"Could not detect current platform! platform.system() returned {system}"
+    )
+    return PlatformName.OTHER
+
+
+CURRENT_PLATFORM = get_current_platform()

--- a/wakepy/methods/__init__.py
+++ b/wakepy/methods/__init__.py
@@ -14,7 +14,7 @@ multiple dependencies of this type, use the name of the "most specific" or
 Examples
 (1) If a method needs D-Bus and GNOME, it is listed in gnome.py since GNOME is
     a desktop environment.
-(2) If a method needs a hypothetical (not well knwon) programX and systemd and
+(2) If a method needs a hypothetical (not well known) programX and systemd and
     D-Bus, it is listed under programx.py, because programX is the "most specific"
     or "least widespread" software.
 (3) If a method needs systemd and D-Bus, it is listed under systemd, as D-Bus

--- a/wakepy/methods/gnome.py
+++ b/wakepy/methods/gnome.py
@@ -9,7 +9,7 @@ from wakepy.core import (
     DbusMethodCall,
     Method,
     ModeName,
-    SystemName,
+    PlatformName,
 )
 
 
@@ -59,7 +59,7 @@ class _GnomeSessionManager(Method, ABC):
         params=("inhibit_cookie",),
     ).of(session_manager)
 
-    supported_platforms = (SystemName.LINUX,)
+    supported_platforms = (PlatformName.LINUX,)
 
     @property
     @abstractmethod

--- a/wakepy/methods/gnome.py
+++ b/wakepy/methods/gnome.py
@@ -59,7 +59,7 @@ class _GnomeSessionManager(Method, ABC):
         params=("inhibit_cookie",),
     ).of(session_manager)
 
-    supported_systems = (SystemName.LINUX,)
+    supported_platforms = (SystemName.LINUX,)
 
     @property
     @abstractmethod


### PR DESCRIPTION
Use term "platform" instead of "system" in places where it's applicable.

* Replace CURRENT_SYSTEM with CURRENT_PLATFORM
* Add function: get_current_platform

Closes #63