### PR TITLE
Fix DeprecationWarning: datetime.utcfromtimestamp() on Python 3.12 when running tox

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ doc = [
 ]
 dev = [
     "sphinx-autobuild",
-    "freezegun",
+    "time-machine",
     "IPython",
     "black==23.3.0",
     "pytest",

--- a/tests/unit/test_core/test_activation/test_activation.py
+++ b/tests/unit/test_core/test_activation/test_activation.py
@@ -9,7 +9,7 @@ import re
 from unittest.mock import Mock
 
 import pytest
-from freezegun import freeze_time
+import time_machine
 from testmethods import (
     FAILURE_REASON,
     METHOD_MISSING,
@@ -201,7 +201,9 @@ def test_try_enter_and_heartbeat_missing_failing():
         assert res == (False, FAILURE_REASON, None)
 
 
-@freeze_time("2023-12-21 16:17:00")
+@time_machine.travel(
+    dt.datetime(2023, 12, 21, 16, 17, tzinfo=dt.timezone.utc), tick=False
+)
 def test_try_enter_and_heartbeat_missing_success():
     """Tests 4) MS from TABLE 1; enter_mode missing, heartbeat success"""
 
@@ -289,7 +291,9 @@ def test_try_enter_and_heartbeat_success_failing():
             try_enter_and_heartbeat(method)
 
 
-@freeze_time("2023-12-21 16:17:00")
+@time_machine.travel(
+    dt.datetime(2023, 12, 21, 16, 17, tzinfo=dt.timezone.utc), tick=False
+)
 def test_try_enter_and_heartbeat_success_success():
     """Tests 7) SS from TABLE 1; enter_mode success & heartbeat success"""
     expected_time = dt.datetime.strptime(

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ passenv =
 setenv = 
     WAKEPY_FAKE_SUCCESS = "yes"
 deps =
-    freezegun
+    time-machine
     pytest>=6
     jeepney >= 0.7.1;sys_platform=='linux'
 commands =


### PR DESCRIPTION
Motivation
1) Fixes following deprecation warning when testing on Python 3.12:
```
========================================================= warnings summary ==========================================================
.tox/py312/lib/python3.12/site-packages/dateutil/tz/tz.py:37
  /home/niko/code/wakepy/.tox/py312/lib/python3.12/site-packages/dateutil/tz/tz.py:37: DeprecationWarning: datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.fromtimestamp(timestamp, datetime.UTC).
    EPOCH = datetime.datetime.utcfromtimestamp(0)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================= 61 passed, 3 skipped, 1 warning in 0.45s ==============================================
```
which is essentially coming from
```
niko@niko-ubuntu-home:~$ python -Werror -c "from freezegun import freeze_time"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/niko/.pyenv/versions/3.12.0b2/lib/python3.12/site-packages/freezegun/__init__.py", line 8, in <module>
    from .api import freeze_time
  File "/home/niko/.pyenv/versions/3.12.0b2/lib/python3.12/site-packages/freezegun/api.py", line 19, in <module>
    from dateutil import parser
  File "/home/niko/.pyenv/versions/3.12.0b2/lib/python3.12/site-packages/dateutil/parser/__init__.py", line 2, in <module>
    from ._parser import parse, parser, parserinfo, ParserError
  File "/home/niko/.pyenv/versions/3.12.0b2/lib/python3.12/site-packages/dateutil/parser/_parser.py", line 50, in <module>
    from .. import tz
  File "/home/niko/.pyenv/versions/3.12.0b2/lib/python3.12/site-packages/dateutil/tz/__init__.py", line 2, in <module>
    from .tz import *
  File "/home/niko/.pyenv/versions/3.12.0b2/lib/python3.12/site-packages/dateutil/tz/tz.py", line 37, in <module>
    EPOCH = datetime.datetime.utcfromtimestamp(0)
 ```

This was tested with current latest freezegun (1.4.0)

2. time-machine claims to be faster

Ref: https://adamj.eu/tech/2020/06/03/introducing-time-machine/



