### PR TITLE
register_method updates

### DIFF
--- a/tests/unit/test_core/test_method.py
+++ b/tests/unit/test_core/test_method.py
@@ -10,6 +10,7 @@ from wakepy.core.method import (
     get_methods_for_mode,
     method_names_to_classes,
     select_methods,
+    register_method,
 )
 
 
@@ -217,3 +218,20 @@ def test_select_methods():
         ),
     ):
         select_methods(methods, use_only=["foo", "bar"])
+
+
+def test_register_method(monkeypatch):
+    # Make the registry empty
+    monkeypatch.setattr("wakepy.core.method._method_registry", dict())
+
+    class MethodA(Method):
+        name = "A"
+
+    assert get_method("A") is MethodA
+
+    # It is possible to register the same method many times without issues.
+    register_method(MethodA)
+    register_method(MethodA)
+    register_method(MethodA)
+
+    assert get_method("A") is MethodA

--- a/wakepy/core/method.py
+++ b/wakepy/core/method.py
@@ -131,7 +131,7 @@ class Method(ABC, metaclass=MethodMeta):
         cls._has_enter = cls.enter_mode is not Method.enter_mode
         cls._has_exit = cls.exit_mode is not Method.exit_mode
         cls._has_heartbeat = cls.heartbeat is not Method.heartbeat
-        _register_method(cls)
+        register_method(cls)
 
         return super().__init_subclass__(**kwargs)
 
@@ -365,7 +365,7 @@ def select_methods(
     return selected_methods
 
 
-def _register_method(cls: Type[Method]):
+def register_method(cls: Type[Method]):
     """Registers a subclass of Method to the method registry"""
 
     if cls.name is None:
@@ -373,9 +373,12 @@ def _register_method(cls: Type[Method]):
         return
 
     if cls.name in _method_registry:
-        raise MethodDefinitionError(
-            f'Duplicate Method name "{cls.name}": {cls.__qualname__} '
-            f"(already registered to {_method_registry[cls.name].__qualname__})"
-        )
+        if _method_registry[cls.name] is not cls:
+            raise MethodDefinitionError(
+                f'Duplicate Method name "{cls.name}": {cls.__qualname__} '
+                f"(already registered to {_method_registry[cls.name].__qualname__})"
+            )
+        else:
+            return
 
     _method_registry[cls.name] = cls


### PR DESCRIPTION
* Renamed. Old name: _register_method
* Only raise the MethodDefinitionError if trying to register another
  Method with the same name. Registering the same class again has no
  effect (previously: raised MethodDefinitionError)
* Add more tests to register_method
