### PR TITLE
register all wakepy methods

### DIFF
--- a/wakepy/__init__.py
+++ b/wakepy/__init__.py
@@ -1,3 +1,6 @@
 from .modes import keep as keep
 
+# This is imported for registering all the methods.
+from . import methods as methods
+
 __version__ = "0.8.0dev"

--- a/wakepy/methods/__init__.py
+++ b/wakepy/methods/__init__.py
@@ -21,3 +21,9 @@ Examples
     is more widespread than systemd, and you may have D-Bus without systemd
     but not vice versa. 
 """
+
+# NOTE: All modules containing wakepy.Methods must be imported here! The reason
+# is that the Methods are registered into the method registry only if the class
+# definition is executed (if the module containing the Method class definition
+# is imported)
+from . import gnome as gnome


### PR DESCRIPTION
This is done by importing the methods to be available at

wakepy.methods.<package/module>