### PR TITLE
DbusMethodCall args

### DIFF
--- a/tests/unit/test_core/test_calls.py
+++ b/tests/unit/test_core/test_calls.py
@@ -86,3 +86,9 @@ def test_dbusmethod_args_as_tuple_using_dict(method: DbusMethod):
     args = dict(first=1, second="2", third=3)
     call = DbusMethodCall(method, args=args)
     assert call._args_as_tuple(args, method) == (1, "2", 3)
+
+
+def test_dbusmethod_args_as_tuple_using_dict_different_order(method: DbusMethod):
+    args = dict(third=3, first=1, second="2")
+    call = DbusMethodCall(method, args=args)
+    assert call._args_as_tuple(args, method) == (1, "2", 3)

--- a/tests/unit/test_core/test_calls.py
+++ b/tests/unit/test_core/test_calls.py
@@ -67,3 +67,16 @@ def test_dbusmethod_args_dict_too_few_keys(method: DbusMethod):
         match=re.escape("Expected args to have 3 keys! (has: 2)"),
     ):
         DbusMethodCall(method, args=args)
+
+
+def test_dbusmethod_args_dict_wrong_keys(method: DbusMethod):
+    args = dict(first=1, second="2", fifth="2")
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "The keys in `args` do not match the keys in the DbusMethod params! "
+            "Expected: ('first', 'second', 'third'). Got: ('first', 'second', 'fifth')"
+        ),
+    ):
+        DbusMethodCall(method, args=args)

--- a/tests/unit/test_core/test_calls.py
+++ b/tests/unit/test_core/test_calls.py
@@ -92,3 +92,15 @@ def test_dbusmethod_args_dict_different_order(method: DbusMethod):
     args = dict(third=3, first=1, second="2")
     call = DbusMethodCall(method, args=args)
     assert call.args == (1, "2", 3)
+
+
+def test_dbusmethod_get_kwargs(method: DbusMethod):
+    args = (1, "2", 3)
+    call = DbusMethodCall(method, args=args)
+    assert call.get_kwargs() == dict(first=1, second="2", third=3)
+
+
+def test_dbusmethod_get_kwargs(method_without_params: DbusMethod):
+    args = (1, "2", 3)
+    call = DbusMethodCall(method_without_params, args=args)
+    assert call.get_kwargs() == None

--- a/tests/unit/test_core/test_calls.py
+++ b/tests/unit/test_core/test_calls.py
@@ -1,0 +1,16 @@
+from wakepy.core import DbusMethod, DbusMethodCall, DbusAddress
+import pytest
+
+
+@pytest.fixture
+def method():
+    service = DbusAddress(path="/foo", service="wakepy.foo", interface="/foo")
+    return DbusMethod(
+        name="test-method", signature="isi", params=("first", "second", "third")
+    ).of(service)
+
+
+def test_dbusmethod_args_as_tuple_using_tuple(method: DbusMethod):
+    args = (1, "2", 3)
+    call = DbusMethodCall(method, args=args)
+    assert call._args_as_tuple(args, method) == args

--- a/tests/unit/test_core/test_calls.py
+++ b/tests/unit/test_core/test_calls.py
@@ -47,3 +47,23 @@ def test_dbusmethod_args_as_tuple_using_dict_method_without_params(
         ),
     ):
         DbusMethodCall(method_without_params, args=args)
+
+
+def test_dbusmethod_args_dict_too_many_keys(method: DbusMethod):
+    args = dict(first=1, second="2", third=3, fourth=4)
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape("Expected args to have 3 keys! (has: 4)"),
+    ):
+        DbusMethodCall(method, args=args)
+
+
+def test_dbusmethod_args_dict_too_few_keys(method: DbusMethod):
+    args = dict(first=1, second="2")
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape("Expected args to have 3 keys! (has: 2)"),
+    ):
+        DbusMethodCall(method, args=args)

--- a/tests/unit/test_core/test_calls.py
+++ b/tests/unit/test_core/test_calls.py
@@ -1,6 +1,8 @@
-from wakepy.core import DbusMethod, DbusMethodCall, DbusAddress
-import pytest
 import re
+
+import pytest
+
+from wakepy.core import DbusAddress, DbusMethod, DbusMethodCall
 
 
 @pytest.fixture
@@ -43,7 +45,9 @@ def test_dbusmethod_args_dict_method_without_params(
     with pytest.raises(
         ValueError,
         match=re.escape(
-            "args cannot be a dictionary if method does not have the params defined! Either add params to the DbusMethod 'test-method' or give args as a tuple or a list."
+            "args cannot be a dictionary if method does not have the params defined! "
+            "Either add params to the DbusMethod 'test-method' or give args as a tuple "
+            "or a list."
         ),
     ):
         DbusMethodCall(method_without_params, args=args)
@@ -100,7 +104,8 @@ def test_dbusmethod_get_kwargs(method: DbusMethod):
     assert call.get_kwargs() == dict(first=1, second="2", third=3)
 
 
-def test_dbusmethod_get_kwargs(method_without_params: DbusMethod):
+def test_dbusmethod_get_kwargs_noparams(method_without_params: DbusMethod):
     args = (1, "2", 3)
     call = DbusMethodCall(method_without_params, args=args)
-    assert call.get_kwargs() == None
+    # Not possible to convert to args to dict as the params are not named.
+    assert call.get_kwargs() is None

--- a/tests/unit/test_core/test_calls.py
+++ b/tests/unit/test_core/test_calls.py
@@ -32,6 +32,24 @@ def test_dbusmethod_args_tuple(method: DbusMethod):
     assert call.args == args
 
 
+def test_dbusmethod_args_tuple_too_long(method: DbusMethod):
+    args = (1, "2", 3, 4)
+    with pytest.raises(
+        ValueError,
+        match=re.escape("Expected args to have 3 items! (has: 4)"),
+    ):
+        DbusMethodCall(method, args=args)
+
+
+def test_dbusmethod_args_tuple_too_short(method: DbusMethod):
+    args = (1, "2")
+    with pytest.raises(
+        ValueError,
+        match=re.escape("Expected args to have 3 items! (has: 2)"),
+    ):
+        DbusMethodCall(method, args=args)
+
+
 def test_dbusmethod_args_list(method: DbusMethod):
     args = [1, "2", 3]
     call = DbusMethodCall(method, args=args)
@@ -58,7 +76,7 @@ def test_dbusmethod_args_dict_too_many_keys(method: DbusMethod):
 
     with pytest.raises(
         ValueError,
-        match=re.escape("Expected args to have 3 keys! (has: 4)"),
+        match=re.escape("Expected args to have 3 items! (has: 4)"),
     ):
         DbusMethodCall(method, args=args)
 
@@ -68,7 +86,7 @@ def test_dbusmethod_args_dict_too_few_keys(method: DbusMethod):
 
     with pytest.raises(
         ValueError,
-        match=re.escape("Expected args to have 3 keys! (has: 2)"),
+        match=re.escape("Expected args to have 3 items! (has: 2)"),
     ):
         DbusMethodCall(method, args=args)
 

--- a/tests/unit/test_core/test_calls.py
+++ b/tests/unit/test_core/test_calls.py
@@ -24,19 +24,19 @@ def method_without_params(service):
     ).of(service)
 
 
-def test_dbusmethod_args_as_tuple_using_tuple(method: DbusMethod):
+def test_dbusmethod_args_tuple(method: DbusMethod):
     args = (1, "2", 3)
     call = DbusMethodCall(method, args=args)
-    assert call._args_as_tuple(args, method) == args
+    assert call.args == args
 
 
-def test_dbusmethod_args_as_tuple_using_list(method: DbusMethod):
+def test_dbusmethod_args_list(method: DbusMethod):
     args = [1, "2", 3]
     call = DbusMethodCall(method, args=args)
-    assert call._args_as_tuple(args, method) == (1, "2", 3)
+    assert call.args == (1, "2", 3)
 
 
-def test_dbusmethod_args_as_tuple_using_dict_method_without_params(
+def test_dbusmethod_args_dict_method_without_params(
     method_without_params: DbusMethod,
 ):
     args = dict(first=1, second="2", third=3)
@@ -82,13 +82,13 @@ def test_dbusmethod_args_dict_wrong_keys(method: DbusMethod):
         DbusMethodCall(method, args=args)
 
 
-def test_dbusmethod_args_as_tuple_using_dict(method: DbusMethod):
+def test_dbusmethod_args_dict(method: DbusMethod):
     args = dict(first=1, second="2", third=3)
     call = DbusMethodCall(method, args=args)
-    assert call._args_as_tuple(args, method) == (1, "2", 3)
+    assert call.args == (1, "2", 3)
 
 
-def test_dbusmethod_args_as_tuple_using_dict_different_order(method: DbusMethod):
+def test_dbusmethod_args_dict_different_order(method: DbusMethod):
     args = dict(third=3, first=1, second="2")
     call = DbusMethodCall(method, args=args)
-    assert call._args_as_tuple(args, method) == (1, "2", 3)
+    assert call.args == (1, "2", 3)

--- a/tests/unit/test_core/test_calls.py
+++ b/tests/unit/test_core/test_calls.py
@@ -80,3 +80,9 @@ def test_dbusmethod_args_dict_wrong_keys(method: DbusMethod):
         ),
     ):
         DbusMethodCall(method, args=args)
+
+
+def test_dbusmethod_args_as_tuple_using_dict(method: DbusMethod):
+    args = dict(first=1, second="2", third=3)
+    call = DbusMethodCall(method, args=args)
+    assert call._args_as_tuple(args, method) == (1, "2", 3)

--- a/tests/unit/test_core/test_calls.py
+++ b/tests/unit/test_core/test_calls.py
@@ -1,12 +1,26 @@
 from wakepy.core import DbusMethod, DbusMethodCall, DbusAddress
 import pytest
+import re
 
 
 @pytest.fixture
-def method():
-    service = DbusAddress(path="/foo", service="wakepy.foo", interface="/foo")
+def service():
+    return DbusAddress(path="/foo", service="wakepy.foo", interface="/foo")
+
+
+@pytest.fixture
+def method(service):
     return DbusMethod(
         name="test-method", signature="isi", params=("first", "second", "third")
+    ).of(service)
+
+
+@pytest.fixture
+def method_without_params(service):
+    service = DbusAddress(path="/foo", service="wakepy.foo", interface="/foo")
+    return DbusMethod(
+        name="test-method",
+        signature="isi",
     ).of(service)
 
 
@@ -20,3 +34,16 @@ def test_dbusmethod_args_as_tuple_using_list(method: DbusMethod):
     args = [1, "2", 3]
     call = DbusMethodCall(method, args=args)
     assert call._args_as_tuple(args, method) == (1, "2", 3)
+
+
+def test_dbusmethod_args_as_tuple_using_dict_method_without_params(
+    method_without_params: DbusMethod,
+):
+    args = dict(first=1, second="2", third=3)
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "args cannot be a dictionary if method does not have the params defined! Either add params to the DbusMethod 'test-method' or give args as a tuple or a list."
+        ),
+    ):
+        DbusMethodCall(method_without_params, args=args)

--- a/tests/unit/test_core/test_calls.py
+++ b/tests/unit/test_core/test_calls.py
@@ -14,3 +14,9 @@ def test_dbusmethod_args_as_tuple_using_tuple(method: DbusMethod):
     args = (1, "2", 3)
     call = DbusMethodCall(method, args=args)
     assert call._args_as_tuple(args, method) == args
+
+
+def test_dbusmethod_args_as_tuple_using_list(method: DbusMethod):
+    args = [1, "2", 3]
+    call = DbusMethodCall(method, args=args)
+    assert call._args_as_tuple(args, method) == (1, "2", 3)

--- a/tests/unit/test_methods/test_gnome.py
+++ b/tests/unit/test_methods/test_gnome.py
@@ -45,12 +45,13 @@ def test_gnome_enter_mode(method_cls, flag):
     class TestAdapter(DbusAdapter):
         def process(self, call):
             assert call.method == method_inhibit
-            assert call.args == {
+            assert call.get_kwargs() == {
                 "app_id": "wakepy",
                 "toplevel_xid": 42,
                 "reason": "wakelock active",
                 "flags": flag,
             }
+
             return fake_cookie
 
     method = method_cls(CallProcessor(dbus_adapter=TestAdapter))
@@ -79,7 +80,7 @@ def test_gnome_exit_mode(method_cls):
     class TestAdapter(DbusAdapter):
         def process(self, call):
             assert call.method == method_uninhibit
-            assert call.args == {"inhibit_cookie": fake_cookie}
+            assert call.get_kwargs() == {"inhibit_cookie": fake_cookie}
 
     method = method_cls(CallProcessor(dbus_adapter=TestAdapter))
     method.inhibit_cookie = fake_cookie

--- a/wakepy/core/calls.py
+++ b/wakepy/core/calls.py
@@ -22,7 +22,6 @@ class DbusMethodCall(Call):
     method: DbusMethod
     """The method which is the target of the call. Must be completely defined.
     """
-    method: DbusMethod
     args: Tuple[Any, ...]
 
     def __init__(

--- a/wakepy/core/calls.py
+++ b/wakepy/core/calls.py
@@ -61,6 +61,11 @@ class DbusMethodCall(Call):
                 f"Expected args to have {len(method.params)} keys! (has: {len(args)})"
             )
 
+        if set(method.params) != set(args):
+            raise ValueError(
+                "The keys in `args` do not match the keys in the DbusMethod params!"
+                f" Expected: {method.params}. Got: {tuple(args)}"
+            )
         raise NotImplementedError()
 
 

--- a/wakepy/core/calls.py
+++ b/wakepy/core/calls.py
@@ -42,6 +42,15 @@ class DbusMethodCall(Call):
             return args
         elif isinstance(args, list):
             return tuple(args)
+
+        assert isinstance(args, dict), "args may only be tuple, list or dict"
+
+        if method.params is None:
+            raise ValueError(
+                "args cannot be a dictionary if method does not have the params "
+                f"defined! Either add params to the DbusMethod '{method.name}' or give "
+                "args as a tuple or a list."
+            )
         raise NotImplementedError()
 
 

--- a/wakepy/core/calls.py
+++ b/wakepy/core/calls.py
@@ -27,6 +27,8 @@ class DbusMethodCall(Call):
     def __init__(
         self, method: DbusMethod, args: dict[str, Any] | Tuple[Any, ...] | List[Any]
     ):
+        """Converts the `args` argument is converted into a tuple and makes it
+        available at DbusMethodCall.args."""
         if not method.completely_defined():
             raise ValueError(
                 f"{self.__class__.__name__} requires completely defined DBusMethod!"

--- a/wakepy/core/calls.py
+++ b/wakepy/core/calls.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import typing
-from dataclasses import dataclass
 
 if typing.TYPE_CHECKING:
     from typing import Any, List, Optional, Tuple, Type

--- a/wakepy/core/calls.py
+++ b/wakepy/core/calls.py
@@ -22,7 +22,9 @@ class DbusMethodCall(Call):
     method: DbusMethod
     """The method which is the target of the call. Must be completely defined.
     """
+
     args: Tuple[Any, ...]
+    """The method args (positional). This is used"""
 
     def __init__(
         self, method: DbusMethod, args: dict[str, Any] | Tuple[Any, ...] | List[Any]
@@ -68,6 +70,16 @@ class DbusMethodCall(Call):
                 f" Expected: {method.params}. Got: {tuple(args)}"
             )
         return tuple(args[p] for p in method.params)
+
+    def get_kwargs(self) -> dict[str, Any] | None:
+        """Get a keyword-argument representation (dict) of the self.args. If
+        the DbusMethod (self.method) does not have params defined, returns
+        None."""
+        if self.method.params is None:
+            return None
+        assert isinstance(self.method.params, tuple)
+
+        return {p: arg for p, arg in zip(self.method.params, self.args)}
 
 
 class CallProcessor:

--- a/wakepy/core/calls.py
+++ b/wakepy/core/calls.py
@@ -18,19 +18,27 @@ class Call:
     """
 
 
-@dataclass
 class DbusMethodCall(Call):
     method: DbusMethod
     """The method which is the target of the call. Must be completely defined.
     """
-
+    method: DbusMethod
     args: dict[str, Any] | Tuple[Any, ...] | List[Any]
 
-    def __post_init__(self):
-        if not self.method.completely_defined():
+    def __init__(
+        self, method: DbusMethod, args: dict[str, Any] | Tuple[Any, ...] | List[Any]
+    ):
+        if not method.completely_defined():
             raise ValueError(
                 f"{self.__class__.__name__} requires completely defined DBusMethod!"
             )
+        self.method = method
+        self.args = self._args_as_tuple(args, method)
+
+    def _args_as_tuple(
+        self, args: dict[str, Any] | Tuple[Any, ...] | List[Any], method: DbusMethod
+    ) -> Tuple[Any, ...]:
+        return args
 
 
 class CallProcessor:

--- a/wakepy/core/calls.py
+++ b/wakepy/core/calls.py
@@ -61,19 +61,17 @@ class DbusMethodCall(Call):
     ) -> Tuple[Any, ...]:
         if isinstance(args, tuple) or isinstance(args, list):
             args = tuple(args)
-            self.__check_tuple_args(args, method)
+            self.__check_args_length(args, method)
             return args
 
         assert isinstance(args, dict), "args may only be tuple, list or dict"
         return self.__dict_args_as_tuple(args, method)
 
-    def __check_tuple_args(self, args: Tuple[Any, ...], method: DbusMethod) -> None:
+    def __check_args_length(self, args: Tuple[Any, ...], method: DbusMethod):
         if method.params is None:
+            # not possible to check.
             return
 
-        self.__check_args_length(args, method)
-
-    def __check_args_length(self, args: Tuple[Any, ...], method: DbusMethod):
         if len(method.params) != len(args):
             raise ValueError(
                 f"Expected args to have {len(method.params)} items! (has: {len(args)})"

--- a/wakepy/core/calls.py
+++ b/wakepy/core/calls.py
@@ -67,7 +67,7 @@ class DbusMethodCall(Call):
                 "The keys in `args` do not match the keys in the DbusMethod params!"
                 f" Expected: {method.params}. Got: {tuple(args)}"
             )
-        raise NotImplementedError()
+        return tuple(args[p] for p in method.params)
 
 
 class CallProcessor:

--- a/wakepy/core/calls.py
+++ b/wakepy/core/calls.py
@@ -49,16 +49,12 @@ class DbusMethodCall(Call):
     def __dict_args_as_tuple(
         self, args: dict[str, Any], method: DbusMethod
     ) -> Tuple[Any, ...]:
-        if method.params is None:
+        if not isinstance(method.params, tuple):
             raise ValueError(
                 "args cannot be a dictionary if method does not have the params "
                 f"defined! Either add params to the DbusMethod '{method.name}' or give "
                 "args as a tuple or a list."
             )
-
-        assert isinstance(
-            method.params, tuple
-        ), "method.params must be a tuple if not None."
 
         if len(method.params) != len(args):
             raise ValueError(

--- a/wakepy/core/calls.py
+++ b/wakepy/core/calls.py
@@ -18,6 +18,15 @@ class Call:
 
 
 class DbusMethodCall(Call):
+    """Represents a Dbus method call with its arguments. Has basic validation
+    for the number of arguments (compare args agains the DbusMethod.params, if
+    the DbusMethod.params are defined).
+
+    Note: Does not check for validity of args against the input parameter
+    signature. This is done only by the underlying Dbus library when doing the
+    dbus method calls.
+    """
+
     method: DbusMethod
     """The method which is the target of the call. Must be completely defined.
     """

--- a/wakepy/core/calls.py
+++ b/wakepy/core/calls.py
@@ -51,6 +51,16 @@ class DbusMethodCall(Call):
                 f"defined! Either add params to the DbusMethod '{method.name}' or give "
                 "args as a tuple or a list."
             )
+
+        assert isinstance(
+            method.params, tuple
+        ), "method.params must be a tuple if not None."
+
+        if len(method.params) != len(args):
+            raise ValueError(
+                f"Expected args to have {len(method.params)} keys! (has: {len(args)})"
+            )
+
         raise NotImplementedError()
 
 

--- a/wakepy/core/calls.py
+++ b/wakepy/core/calls.py
@@ -38,7 +38,11 @@ class DbusMethodCall(Call):
     def _args_as_tuple(
         self, args: dict[str, Any] | Tuple[Any, ...] | List[Any], method: DbusMethod
     ) -> Tuple[Any, ...]:
-        return args
+        if isinstance(args, tuple):
+            return args
+        elif isinstance(args, list):
+            return tuple(args)
+        raise NotImplementedError()
 
 
 class CallProcessor:

--- a/wakepy/core/calls.py
+++ b/wakepy/core/calls.py
@@ -23,7 +23,7 @@ class DbusMethodCall(Call):
     """The method which is the target of the call. Must be completely defined.
     """
     method: DbusMethod
-    args: dict[str, Any] | Tuple[Any, ...] | List[Any]
+    args: Tuple[Any, ...]
 
     def __init__(
         self, method: DbusMethod, args: dict[str, Any] | Tuple[Any, ...] | List[Any]

--- a/wakepy/core/calls.py
+++ b/wakepy/core/calls.py
@@ -44,7 +44,11 @@ class DbusMethodCall(Call):
             return tuple(args)
 
         assert isinstance(args, dict), "args may only be tuple, list or dict"
+        return self.__dict_args_as_tuple(args, method)
 
+    def __dict_args_as_tuple(
+        self, args: dict[str, Any], method: DbusMethod
+    ) -> Tuple[Any, ...]:
         if method.params is None:
             raise ValueError(
                 "args cannot be a dictionary if method does not have the params "


### PR DESCRIPTION
args 
* These are now always a tuple (previously could also be a list or a
 dict)
* DbusMethodCall.\_\_init\_\_ still accepts list a dict type of `args`.

get_kwargs()
* This returns a dict version of .args, if possible. Otherwise, return
  None.

Added some basic validation to DbusMethodCall initialization: `args`
against the `method.params`. These check for the names and the number
of the params, if available. The args types are not checked against
the signature (assumed to be handled by the used dbus library)