### PR TITLE
Issue 136: Method return values & exception handling update

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -14,7 +14,7 @@ from wakepy.core import BusType, DbusAddress, DbusMethod
 
 logger = logging.getLogger(__name__)
 
-calculator_service_addr = DbusAddress(
+_calculator_service_addr = DbusAddress(
     bus=BusType.SESSION,
     service="org.github.wakepy.TestCalculatorService",
     path="/org/github/wakepy/TestCalculatorService",
@@ -27,7 +27,7 @@ _numberadd_method = DbusMethod(
     params=("first_number", "second_number"),
     output_signature="u",
     output_params=("result",),
-).of(calculator_service_addr)
+).of(_calculator_service_addr)
 
 _numbermultiply_method = DbusMethod(
     name="SimpleNumberMultiply",
@@ -35,11 +35,11 @@ _numbermultiply_method = DbusMethod(
     params=("first_number", "second_number"),
     output_signature="i",
     output_params=("result",),
-).of(calculator_service_addr)
+).of(_calculator_service_addr)
 
 
 class TestCalculatorService(DbusService):
-    addr = calculator_service_addr
+    addr = _calculator_service_addr
 
     def handle_method(self, method: str, args):
         if method == _numberadd_method.name:
@@ -81,6 +81,11 @@ class TestStringOperationService(DbusService):
                 shortened_string,
                 n_removed,
             )
+
+
+@pytest.fixture(scope="session")
+def calculator_service_addr():
+    return _calculator_service_addr
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/test_dbus_adapters.py
+++ b/tests/integration/test_dbus_adapters.py
@@ -104,13 +104,6 @@ def test_jeepney_dbus_adapter_wrong_service_definition():
         adapter.process(DbusMethodCall(wrong_method, (-5, 2)))
 
 
-@pytest.mark.usefixtures("dbus_calculator_service")
-def test_jeepney_dbus_adapter_number_multiply_tmp(numbermultiply_method):
-    adapter = JeepneyDbusAdapter()
-    call = DbusMethodCall(numbermultiply_method, (-5, 3))
-    assert adapter.process(call) == (-15,)
-
-
 @pytest.mark.usefixtures("dbus_string_operation_service")
 def test_jeepney_dbus_adapter_string_shorten(string_shorten_method):
     # The service shortens a string to a given number of characters and tells

--- a/tests/integration/test_dbus_adapters.py
+++ b/tests/integration/test_dbus_adapters.py
@@ -1,6 +1,10 @@
+import re
+import struct
+
+import jeepney
 import pytest
 
-from wakepy.core import DbusMethodCall
+from wakepy.core import BusType, DbusAddress, DbusMethod, DbusMethodCall
 from wakepy.io.dbus.jeepney import JeepneyDbusAdapter
 
 
@@ -13,6 +17,95 @@ def test_jeepney_dbus_adapter_numberadd(numberadd_method):
 
 @pytest.mark.usefixtures("dbus_calculator_service")
 def test_jeepney_dbus_adapter_number_multiply(numbermultiply_method):
+    adapter = JeepneyDbusAdapter()
+    call = DbusMethodCall(numbermultiply_method, (-5, 3))
+    assert adapter.process(call) == (-15,)
+
+
+@pytest.mark.usefixtures("dbus_calculator_service")
+def test_jeepney_dbus_adapter_wrong_arguments(numbermultiply_method):
+    adapter = JeepneyDbusAdapter()
+    with pytest.raises(struct.error, match="required argument is not an intege"):
+        # Bad input arg type
+        adapter.process(DbusMethodCall(numbermultiply_method, (-5, "foo")))
+    with pytest.raises(
+        ValueError, match=re.escape("Expected args to have 2 items! (has: 3)")
+    ):
+        # Too many input args
+        adapter.process(DbusMethodCall(numbermultiply_method, (-5, 3, 3)))
+
+
+@pytest.mark.usefixtures("dbus_calculator_service")
+def test_jeepney_dbus_adapter_wrong_signature(calculator_service_addr):
+    wrong_method = DbusMethod(
+        name="SimpleNumberMultiply",
+        signature="is",  # this is wrong: should be "ii"
+        params=("first_number", "second_number"),
+        output_signature="i",
+        output_params=("result",),
+    ).of(calculator_service_addr)
+
+    adapter = JeepneyDbusAdapter()
+    with pytest.raises(
+        jeepney.wrappers.DBusErrorResponse,
+        match="org.github.wakepy.TestCalculatorService.Error.OtherError",
+    ):
+        # The args are correct for the DbusMethod, but the DbusMethod is not
+        # correct for the service (signature is wrong)
+        adapter.process(DbusMethodCall(wrong_method, (-5, "sdaasd")))
+
+
+@pytest.mark.usefixtures("dbus_calculator_service")
+def test_jeepney_dbus_adapter_nonexisting_method(calculator_service_addr):
+    non_existing_method = DbusMethod(
+        name="ThisDoesNotExist",
+        signature="ii",
+        params=("first_number", "second_number"),
+        output_signature="i",
+        output_params=("result",),
+    ).of(calculator_service_addr)
+    adapter = JeepneyDbusAdapter()
+
+    with pytest.raises(
+        jeepney.wrappers.DBusErrorResponse,
+        match="org.github.wakepy.TestCalculatorService.Error.NoMethod",
+    ):
+        # No such method: ThisDoesNotExist
+        adapter.process(DbusMethodCall(non_existing_method, (-5, 2)))
+
+
+@pytest.mark.usefixtures("dbus_calculator_service")
+def test_jeepney_dbus_adapter_wrong_service_definition():
+    adapter = JeepneyDbusAdapter()
+
+    wrong_service_addr = DbusAddress(
+        bus=BusType.SESSION,
+        service="org.github.wakepy.WrongService",
+        path="/org/github/wakepy/TestCalculatorService",
+        interface="org.github.wakepy.TestCalculatorService",
+    )
+    wrong_method = DbusMethod(
+        name="SimpleNumberMultiply",
+        signature="ii",
+        params=("first_number", "second_number"),
+        output_signature="i",
+        output_params=("result",),
+    ).of(wrong_service_addr)
+
+    # The args are correct for the DbusMethod, but the DbusMethod is not
+    # correct for the service (signature is wrong)
+    with pytest.raises(
+        jeepney.wrappers.DBusErrorResponse,
+        match=re.escape(
+            "The name org.github.wakepy.WrongService was not provided by any .service "
+            "files"
+        ),
+    ):
+        adapter.process(DbusMethodCall(wrong_method, (-5, 2)))
+
+
+@pytest.mark.usefixtures("dbus_calculator_service")
+def test_jeepney_dbus_adapter_number_multiply_tmp(numbermultiply_method):
     adapter = JeepneyDbusAdapter()
     call = DbusMethodCall(numbermultiply_method, (-5, 3))
     assert adapter.process(call) == (-15,)

--- a/tests/integration/testutils.py
+++ b/tests/integration/testutils.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import logging
+
 import time
 import typing
 from typing import Optional, Tuple
@@ -115,7 +117,7 @@ class DbusService:
         out = self.handle_method(method, args=msg.body)
 
         if out is None:
-            rep = new_error(msg, self.bus_name + ".Error.NoMethod")
+            rep = self._get_error_message(msg)
         elif (
             isinstance(out, tuple)
             and len(out) == 2
@@ -127,7 +129,15 @@ class DbusService:
         else:
             raise ValueError("The output of handle_method must be Tuple[str, Tuple]!")
 
-        connection.send_message(rep)
+        try:
+            connection.send_message(rep)
+        except Exception as e:
+            logging.info("Error occured:" + str(e))
+            connection.send_message(self._get_error_message(msg, ".Error.OtherError"))
+
+    def _get_error_message(self, msg, method=".Error.NoMethod"):
+        """Create an error message for replying to a message"""
+        return new_error(msg, self.bus_name + method)
 
     def handle_method(self, method: str, args: Tuple) -> Optional[Tuple[str, Tuple]]:
         """Should return either None (when method does not exist), or tuple of

--- a/tests/integration/testutils.py
+++ b/tests/integration/testutils.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-
 import time
 import typing
 from typing import Optional, Tuple

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,12 @@
+import pytest
+
+from wakepy import DbusAdapter
+
+
+class TestDbusAdapter(DbusAdapter):
+    """A fake dbus adapter used in tests"""
+
+
+@pytest.fixture(scope="session")
+def fake_dbus_adapter():
+    return TestDbusAdapter

--- a/tests/unit/test_core/test_activation/test_activation.py
+++ b/tests/unit/test_core/test_activation/test_activation.py
@@ -179,16 +179,16 @@ def test_activate_method_method_caniuse_fails():
 
 def test_activate_method_method_enter_mode_fails():
     # Case: Fail by returning False from enter_mode
-    method = get_test_method_class(caniuse=True, enter_mode=False)()
+    method = get_test_method_class(caniuse=True, enter_mode=RuntimeError("failed"))()
     res, heartbeat = activate_method(method)
     assert res.status == UsageStatus.FAIL
     assert res.failure_stage == StageName.ACTIVATION
-    assert res.message == ""
+    assert "Original error: failed" in res.message
     assert heartbeat is None
 
 
 def test_activate_method_enter_mode_success():
-    method = get_test_method_class(caniuse=True, enter_mode=True)()
+    method = get_test_method_class(caniuse=True, enter_mode=None)()
     res, heartbeat = activate_method(method)
     assert res.status == UsageStatus.SUCCESS
     assert res.failure_stage is None
@@ -198,7 +198,7 @@ def test_activate_method_enter_mode_success():
 
 
 def test_activate_method_heartbeat_success():
-    method = get_test_method_class(heartbeat=True)()
+    method = get_test_method_class(heartbeat=None)()
     res, heartbeat = activate_method(method)
     assert res.status == UsageStatus.SUCCESS
     assert res.failure_stage is None
@@ -234,31 +234,20 @@ Methods   Expected result
 def test_try_enter_and_heartbeat_failing_enter_mode():
     """Tests 1) F* from TABLE 1; enter_mode failing"""
 
-    # Case: when enter_mode returns False
+    # Case: enter_mode raises exception
     for method in iterate_test_methods(
-        enter_mode=[False],
+        enter_mode=[RuntimeError(FAILURE_REASON)],
         heartbeat=METHOD_OPTIONS,
         exit_mode=METHOD_OPTIONS,
     ):
-        res = try_enter_and_heartbeat(method)
+        success, err_message, heartbeat_call_time = try_enter_and_heartbeat(method)
         # Expecting
-        # * entering to FAIL (False)
-        # * empty error message (''), as returning False
-        # * No heartbeat_call_time (None)
-        assert res == (False, "", None)
-
-    # Case: enter_mode returns a string (error message)
-    for method in iterate_test_methods(
-        enter_mode=[FAILURE_REASON],
-        heartbeat=METHOD_OPTIONS,
-        exit_mode=METHOD_OPTIONS,
-    ):
-        res = try_enter_and_heartbeat(method)
-        # Expecting
-        # * entering to FAIL (False)
+        # * entering to FAIL
         # * error message (FAILURE_REASON)
         # * No heartbeat_call_time (None)
-        assert res == (False, FAILURE_REASON, None)
+        assert success is False
+        assert FAILURE_REASON in err_message
+        assert heartbeat_call_time is None
 
 
 def test_try_enter_and_heartbeat_missing_missing():
@@ -268,16 +257,18 @@ def test_try_enter_and_heartbeat_missing_missing():
         heartbeat=[METHOD_MISSING],
         exit_mode=METHOD_OPTIONS,
     ):
+        expected_errmsg = (
+            f"Method {method.__class__.__name__} ({method.name}) is not properly "
+            "defined! Missing implementation for both, enter_mode() "
+            "and heartbeat()!"
+        )
+
+        success, err_message, heartbeat_call_time = try_enter_and_heartbeat(method)
+
         # Expecting an error as missing enter_mode and heartbeat
-        with pytest.raises(
-            RuntimeError,
-            match=re.escape(
-                f"Method {method.__class__.__name__} ({method.name}) is not properly "
-                "defined! Missing implementation for both, enter_mode() "
-                "and heartbeat()!"
-            ),
-        ):
-            try_enter_and_heartbeat(method)
+        assert success is False
+        assert err_message == expected_errmsg
+        assert heartbeat_call_time is None
 
 
 def test_try_enter_and_heartbeat_missing_failing():
@@ -287,21 +278,27 @@ def test_try_enter_and_heartbeat_missing_failing():
         heartbeat=[False],
         exit_mode=METHOD_OPTIONS,
     ):
-        res = try_enter_and_heartbeat(method)
+        success, err_message, heartbeat_call_time = try_enter_and_heartbeat(method)
         # Expecting
-        # * heartbeat to FAIL (-> False)
-        # * No error message (''), as returing False
+        # * heartbeat to FAIL (-> success is False)
+        # * Error message saying that can only return None
         # * No heartbeat_call_time (None)
-        assert res == (False, "", None)
+        assert success is False
+        assert "returned an unsupported value False." in err_message
+        assert "The only accepted return value is None" in err_message
+        assert heartbeat_call_time is None
 
     for method in iterate_test_methods(
         enter_mode=[METHOD_MISSING],
         heartbeat=[FAILURE_REASON],
         exit_mode=METHOD_OPTIONS,
     ):
-        res = try_enter_and_heartbeat(method)
+        success, err_message, heartbeat_call_time = try_enter_and_heartbeat(method)
         # Expecting same as above, but with failing message
-        assert res == (False, FAILURE_REASON, None)
+        assert success is False
+        assert f"returned an unsupported value {FAILURE_REASON}." in err_message
+        assert "The only accepted return value is None" in err_message
+        assert heartbeat_call_time is None
 
 
 @time_machine.travel(
@@ -315,7 +312,7 @@ def test_try_enter_and_heartbeat_missing_success():
     ).replace(tzinfo=dt.timezone.utc)
     for method in iterate_test_methods(
         enter_mode=[METHOD_MISSING],
-        heartbeat=[True],
+        heartbeat=[None],
         exit_mode=METHOD_OPTIONS,
     ):
         res = try_enter_and_heartbeat(method)
@@ -327,7 +324,7 @@ def test_try_enter_and_heartbeat_success_missing():
     """Tests 5) SM from TABLE 1; enter_mode success, heartbeat missing"""
 
     for method in iterate_test_methods(
-        enter_mode=[True],
+        enter_mode=[None],
         heartbeat=[METHOD_MISSING],
         exit_mode=METHOD_OPTIONS,
     ):
@@ -343,30 +340,22 @@ def test_try_enter_and_heartbeat_success_failing():
     This call of exit_mode might be failing, so we test that separately
     """
 
-    # Case: empty error message ("") as heartbeat returns False
+    # Case: Heartbeate fails by raising RuntimeError
     for method in iterate_test_methods(
-        enter_mode=[True],
-        heartbeat=[False],
-        exit_mode=[True, METHOD_MISSING],
+        enter_mode=[None],
+        heartbeat=[RuntimeError(FAILURE_REASON)],
+        exit_mode=[None, METHOD_MISSING],
     ):
-        res = try_enter_and_heartbeat(method)
-        assert res == (False, "", None)
-
-    # Case: non-empty error message (FAILURE_REASON) as heartbeat returns that
-    # message
-    for method in iterate_test_methods(
-        enter_mode=[True],
-        heartbeat=[FAILURE_REASON],
-        exit_mode=[True, METHOD_MISSING],
-    ):
-        res = try_enter_and_heartbeat(method)
-        assert res == (False, FAILURE_REASON, None)
+        success, err_message, heartbeat_call_time = try_enter_and_heartbeat(method)
+        assert success is False
+        assert f"Original error: {FAILURE_REASON}" in err_message
+        assert heartbeat_call_time is None
 
     # Case: The heartbeat fails, and because enter_mode() has succeed, wakepy
     # tries to call exit_mode(). If that fails, the program must crash, as we
     # are in an unknown state and this is clearly an error.
     for method in iterate_test_methods(
-        enter_mode=[True],
+        enter_mode=[None],
         heartbeat=[False, FAILURE_REASON],
         exit_mode=[False, FAILURE_REASON],
     ):
@@ -383,7 +372,7 @@ def test_try_enter_and_heartbeat_success_failing():
     # WakepyMethodTestError. That is raised (and not catched), instead.
     # If this happens, the Method.exit_mode() has a bug.
     for method in iterate_test_methods(
-        enter_mode=[True],
+        enter_mode=[None],
         heartbeat=[False, FAILURE_REASON],
         exit_mode=[WakepyMethodTestError("foo")],
     ):
@@ -404,8 +393,8 @@ def test_try_enter_and_heartbeat_success_success():
     ).replace(tzinfo=dt.timezone.utc)
 
     for method in iterate_test_methods(
-        enter_mode=[True],
-        heartbeat=[True],
+        enter_mode=[None],
+        heartbeat=[None],
         exit_mode=METHOD_OPTIONS,
     ):
         res = try_enter_and_heartbeat(method)
@@ -417,15 +406,11 @@ def test_try_enter_and_heartbeat_special_cases():
     # Case: returning bad value (only bool and str accepted)
     for method_name in ("enter_mode", "heartbeat"):
         method = get_test_method_class(**{method_name: 132})()
-        with pytest.raises(
-            RuntimeError,
-            match=re.escape(
-                f"The {method_name} of {method.__class__.__name__} ({method.name}) "
-                "returned a value of unsupported type. The supported types are: bool, "
-                "str. Returned value: 132"
-            ),
-        ):
-            try_enter_and_heartbeat(method)
+        success, err_message, heartbeat_call_time = try_enter_and_heartbeat(method)
+
+        assert success is False
+        assert "The only accepted return value is None" in err_message
+        assert heartbeat_call_time is None
 
 
 @pytest.mark.usefixtures("provide_methods_different_platforms")
@@ -529,33 +514,34 @@ def test_method_usage_result(
 
 
 def test_deactivate_success_no_heartbeat():
-    method = get_test_method_class(enter_mode=True, exit_mode=True)()
+    method = get_test_method_class(enter_mode=None, exit_mode=None)()
     deactivate_method(method)
 
 
 def test_deactivate_success_with_heartbeat():
     heartbeat = Mock(spec_set=Heartbeat)
     heartbeat.stop.return_value = True
-    method = get_test_method_class(enter_mode=True, exit_mode=True)()
+    method = get_test_method_class(enter_mode=None, exit_mode=None)()
     deactivate_method(method, heartbeat=heartbeat)
 
 
 def test_deactivate_success_with_heartbeat_and_no_exit():
     heartbeat = Mock(spec_set=Heartbeat)
     heartbeat.stop.return_value = True
-    method = get_test_method_class(enter_mode=True)()
+    method = get_test_method_class(enter_mode=None)()
     deactivate_method(method, heartbeat=heartbeat)
 
 
 def test_deactivate_fail_exit_mode_returning_bad_value():
-    method = get_test_method_class(enter_mode=True, exit_mode=123)()
+    method = get_test_method_class(enter_mode=None, exit_mode=123)()
     with pytest.raises(
         MethodError,
         match=re.escape(
-            f"The exit_mode of {method.__class__.__name__} ({method.name}) returned a "
-            "value of unsupported type. The supported types are: bool, str. "
-            "Returned value: 123"
-        ),
+            f"The exit_mode of '{method.__class__.__name__}' ({method.name}) was "
+            "unsuccessful!"
+        )
+        + " .* "
+        + re.escape("Original error: exit_mode returned a value other than None!"),
     ):
         deactivate_method(method)
 
@@ -577,7 +563,7 @@ def test_deactivate_failing_exit_mode():
 def test_deactivate_fail_heartbeat_not_stopping():
     heartbeat = Mock(spec_set=Heartbeat)
     heartbeat.stop.return_value = "Bad value"
-    method = get_test_method_class(enter_mode=True, exit_mode=True)()
+    method = get_test_method_class(enter_mode=None, exit_mode=None)()
     with pytest.raises(
         MethodError,
         match=re.escape(

--- a/tests/unit/test_core/test_activation/test_activation.py
+++ b/tests/unit/test_core/test_activation/test_activation.py
@@ -560,8 +560,8 @@ def test_deactivate_fail_exit_mode_returning_bad_value():
         deactivate_method(method)
 
 
-def test_deactivate_fail_exit_mode_returning_string():
-    method = get_test_method_class(enter_mode=True, exit_mode="oh no")()
+def test_deactivate_failing_exit_mode():
+    method = get_test_method_class(enter_mode=None, exit_mode=Exception("oh no"))()
     with pytest.raises(
         MethodError,
         match=re.escape(
@@ -569,7 +569,7 @@ def test_deactivate_fail_exit_mode_returning_string():
             "unsuccessful"
         )
         + ".*"
-        + re.escape("Returned value: oh no"),
+        + re.escape("Original error: oh no"),
     ):
         deactivate_method(method)
 

--- a/tests/unit/test_core/test_activation/test_activation.py
+++ b/tests/unit/test_core/test_activation/test_activation.py
@@ -369,7 +369,7 @@ def test_try_enter_and_heartbeat_success_failing():
             try_enter_and_heartbeat(method)
 
     # Case: Same as the one above, but this time exit_mode() raises a
-    # WakepyMethodTestError. That is raised (and not catched), instead.
+    # WakepyMethodTestError. That is re-raised as RuntimeError, instead.
     # If this happens, the Method.exit_mode() has a bug.
     for method in iterate_test_methods(
         enter_mode=[None],
@@ -377,7 +377,7 @@ def test_try_enter_and_heartbeat_success_failing():
         exit_mode=[WakepyMethodTestError("foo")],
     ):
         with pytest.raises(
-            WakepyMethodTestError,
+            RuntimeError,
             match="foo",
         ):
             try_enter_and_heartbeat(method)

--- a/tests/unit/test_core/test_calls.py
+++ b/tests/unit/test_core/test_calls.py
@@ -127,3 +127,9 @@ def test_dbusmethod_get_kwargs_noparams(method_without_params: DbusMethod):
     call = DbusMethodCall(method_without_params, args=args)
     # Not possible to convert to args to dict as the params are not named.
     assert call.get_kwargs() is None
+
+
+def test_dbusmethod_string_representation(method: DbusMethod):
+    args = (1, "2", 3)
+    call = DbusMethodCall(method, args=args)
+    assert call.__repr__() == "<wakepy.foo (1, '2', 3) | bus: SESSION>"

--- a/tests/unit/test_core/test_method.py
+++ b/tests/unit/test_core/test_method.py
@@ -250,9 +250,9 @@ def test_register_method(monkeypatch):
 def test_method_defaults():
     """tests the Method enter_mode, exit_mode and heartbeat defaults"""
     m = Method()
-    assert m.enter_mode() is True
-    assert m.heartbeat() is True
-    assert m.exit_mode() is True
+    assert m.enter_mode() is None
+    assert m.heartbeat() is None
+    assert m.exit_mode() is None
 
 
 @pytest.mark.usefixtures("provide_methods_a_f")

--- a/tests/unit/test_core/test_mode.py
+++ b/tests/unit/test_core/test_mode.py
@@ -157,7 +157,7 @@ def _assert_context_manager_used_correctly(mocks):
 
 
 def test_modecontroller():
-    method_cls = get_test_method_class(enter_mode=True, heartbeat=True, exit_mode=True)
+    method_cls = get_test_method_class(enter_mode=None, heartbeat=None, exit_mode=None)
     controller = ModeController(Mock(spec_set=CallProcessor))
 
     # When controller was created, it has not active method or heartbeat

--- a/tests/unit/test_methods/test_gnome.py
+++ b/tests/unit/test_methods/test_gnome.py
@@ -90,7 +90,7 @@ def test_gnome_exit_mode(method_cls):
     exit_retval = method.exit_mode()
 
     # Assert
-    assert exit_retval is True
+    assert exit_retval is None
     # exiting mode unsets the inhibit_cookie
     assert method.inhibit_cookie is None
 
@@ -102,5 +102,4 @@ def test_gnome_exit_mode(method_cls):
 def test_gnome_exit_before_enter(method_cls):
     method = method_cls(CallProcessor(dbus_adapter=DbusAdapter))
     assert method.inhibit_cookie is None
-    with pytest.raises(RuntimeError, match="Cannot exit before entering"):
-        method.exit_mode()
+    assert method.exit_mode() is None

--- a/tests/unit/test_methods/test_gnome.py
+++ b/tests/unit/test_methods/test_gnome.py
@@ -63,7 +63,7 @@ def test_gnome_enter_mode(method_cls, flag):
     enter_retval = method.enter_mode()
 
     # Assert
-    assert enter_retval is True
+    assert enter_retval is None
     # Entering mode sets a inhibit_cookie to value returned by the DbusAdapter
     assert method.inhibit_cookie == fake_cookie
 

--- a/tests/unit/test_methods/test_gnome.py
+++ b/tests/unit/test_methods/test_gnome.py
@@ -58,9 +58,10 @@ def test_gnome_enter_mode(method_cls, flag):
     assert method.inhibit_cookie is None
 
     # Act
-    method.enter_mode()
+    enter_retval = method.enter_mode()
 
     # Assert
+    assert enter_retval is True
     # Entering mode sets a inhibit_cookie to value returned by the DbusAdapter
     assert method.inhibit_cookie == fake_cookie
 
@@ -86,9 +87,10 @@ def test_gnome_exit_mode(method_cls):
     method.inhibit_cookie = fake_cookie
 
     # Act
-    method.exit_mode()
+    exit_retval = method.exit_mode()
 
     # Assert
+    assert exit_retval is True
     # exiting mode unsets the inhibit_cookie
     assert method.inhibit_cookie is None
 

--- a/tests/unit/test_modes.py
+++ b/tests/unit/test_modes.py
@@ -75,14 +75,12 @@ def test_keep_running_mode_creation(input_args, monkeypatch):
     assert mode._dbus_adapter_cls == MyDbusAdapter
 
 
-@pytest.mark.skip("This waits to be fixed")
 def test_keep_running():
     with keep.running() as k:
         assert k.success
         assert not k.failure
 
 
-@pytest.mark.skip("This waits to be fixed")
 def test_keep_presenting():
     with keep.presenting() as k:
         assert k.success

--- a/tests/unit/test_modes.py
+++ b/tests/unit/test_modes.py
@@ -75,13 +75,13 @@ def test_keep_running_mode_creation(input_args, monkeypatch):
     assert mode._dbus_adapter_cls == MyDbusAdapter
 
 
-def test_keep_running():
-    with keep.running() as k:
-        assert k.success
-        assert not k.failure
+def test_keep_running(fake_dbus_adapter):
+    """Simple smoke test for keep.running()"""
+    with keep.running(dbus_adapter=fake_dbus_adapter) as k:
+        assert isinstance(k.success, bool)
 
 
-def test_keep_presenting():
-    with keep.presenting() as k:
-        assert k.success
-        assert not k.failure
+def test_keep_presenting(fake_dbus_adapter):
+    """Simple smoke test for keep.presenting()"""
+    with keep.presenting(dbus_adapter=fake_dbus_adapter) as k:
+        assert isinstance(k.success, bool)

--- a/wakepy/__init__.py
+++ b/wakepy/__init__.py
@@ -1,5 +1,6 @@
 # NOTE The methods sub-package is imported for registering all the methods.
 from . import methods as methods
+from .core import DbusAdapter as DbusAdapter
 from .core import Method as Method
 from .core import Mode as Mode
 from .modes import keep as keep

--- a/wakepy/core/activation.py
+++ b/wakepy/core/activation.py
@@ -563,7 +563,7 @@ def deactivate_method(method: Method, heartbeat: Optional[Heartbeat] = None) -> 
     heartbeat_stopped = heartbeat.stop() if heartbeat is not None else True
 
     if method.has_exit:
-        error = MethodError(
+        errortxt = (
             f"The exit_mode of '{method.__class__.__name__}' ({method.name}) was "
             "unsuccessful! This should never happen, and could mean that the "
             "implementation has a bug. Entering the mode has been successful, and "
@@ -574,7 +574,7 @@ def deactivate_method(method: Method, heartbeat: Optional[Heartbeat] = None) -> 
         try:
             method.exit_mode()
         except Exception as e:
-            raise error from e
+            raise MethodError(errortxt + "Original error: " + str(e))
 
     if heartbeat_stopped is not True:
         raise MethodError(

--- a/wakepy/core/activation.py
+++ b/wakepy/core/activation.py
@@ -563,23 +563,18 @@ def deactivate_method(method: Method, heartbeat: Optional[Heartbeat] = None) -> 
     heartbeat_stopped = heartbeat.stop() if heartbeat is not None else True
 
     if method.has_exit:
-        retval = method.exit_mode()
-        if not isinstance(retval, (bool, str)):
-            raise MethodError(
-                f"The exit_mode of {method.__class__.__name__} ({method.name}) "
-                "returned a value of unsupported type. The supported types are: "
-                f"bool, str. Returned value: {retval}"
-            )
-        if isinstance(retval, str) or retval is False:
-            raise MethodError(
-                f"The exit_mode of '{method.__class__.__name__}' ({method.name}) was "
-                "unsuccessful! This should never happen, and could mean that the "
-                "implementation has a bug. Entering the mode has been successful, and "
-                "since exiting was not, your system might stil be in the mode defined "
-                f"by the '{method.__class__.__name__}', or not.  Suggesting submitting "
-                f"a bug report and rebooting for clearing the mode. "
-                f"Returned value: {retval}"
-            )
+        error = MethodError(
+            f"The exit_mode of '{method.__class__.__name__}' ({method.name}) was "
+            "unsuccessful! This should never happen, and could mean that the "
+            "implementation has a bug. Entering the mode has been successful, and "
+            "since exiting was not, your system might stil be in the mode defined "
+            f"by the '{method.__class__.__name__}', or not.  Suggesting submitting "
+            f"a bug report and rebooting for clearing the mode. "
+        )
+        try:
+            method.exit_mode()
+        except Exception as e:
+            raise error from e
 
     if heartbeat_stopped is not True:
         raise MethodError(

--- a/wakepy/core/activation.py
+++ b/wakepy/core/activation.py
@@ -761,12 +761,14 @@ def _try_method_call(method: Method, mthdname: str) -> Tuple[MethodOutcome, str]
         outcome = MethodOutcome.SUCCESS
         err_message = ""
     except Exception as exc:
-        err_message = f"Error in the {mthdname} of {method.__class__.__name__} ({method.name})! Original error: {str(exc)}"
+        err_message = (
+            f"Error in the {mthdname} of {method.__class__.__name__} "
+            f"({method.name})! Original error: {str(exc)}"
+        )
         outcome = MethodOutcome.FAILURE
     return outcome, err_message
 
 
-# TODO: Rename similarly with the enter_mode call function?
 def _rollback_with_exit(method):
     """Roll back entering a mode by exiting it.
 
@@ -783,7 +785,6 @@ def _rollback_with_exit(method):
         # Nothing to exit from.
         return
 
-    # TODO: Add try..except
     exit_outcome = method.exit_mode()
     if exit_outcome is not None:
         raise RuntimeError(

--- a/wakepy/core/activation.py
+++ b/wakepy/core/activation.py
@@ -651,6 +651,7 @@ def try_enter_and_heartbeat(method: Method) -> Tuple[bool, str, Optional[dt.date
     exit_mode() to be called, and if this exit_mode() also fails (as this
     leaves system uncertain state).
 
+    TODO: Update this ^
 
     Detailed explanation
     --------------------
@@ -719,6 +720,7 @@ def _try_enter_mode(method: Method) -> Tuple[MethodOutcome, str]:
     if not method.has_enter:
         return MethodOutcome.NOT_IMPLEMENTED, ""
 
+    # TODO: Only accept True as return value
     retval = method.enter_mode()
     if not isinstance(retval, (bool, str)):
         raise MethodError(
@@ -746,6 +748,7 @@ def _try_heartbeat(method: Method) -> Tuple[MethodOutcome, str, Optional[dt.date
     heartbeat_call_time = dt.datetime.now(dt.timezone.utc)
     retval = method.heartbeat()
 
+    # TODO: Only accept True as return value
     if not isinstance(retval, (bool, str)):
         raise MethodError(
             f"The heartbeat of {method.__class__.__name__} ({method.name}) returned a"
@@ -758,6 +761,7 @@ def _try_heartbeat(method: Method) -> Tuple[MethodOutcome, str, Optional[dt.date
     return outcome, message, heartbeat_call_time
 
 
+# TODO: Rename similarly with the enter_mode call function?
 def _rollback_with_exit(method):
     """Roll back entering a mode by exiting it.
 
@@ -774,6 +778,7 @@ def _rollback_with_exit(method):
         # Nothing to exit from.
         return
 
+    # TODO: Add try..except
     exit_outcome = method.exit_mode()
     if exit_outcome is not True:
         raise RuntimeError(

--- a/wakepy/core/activation.py
+++ b/wakepy/core/activation.py
@@ -520,7 +520,6 @@ def activate_method(method: Method) -> Tuple[MethodActivationResult, Heartbeat |
         succeeds, this is a Heartbeat object. Otherwise, this is None.
     """
     if method.name is None:
-        # TODO: Should not raise exceptions.
         raise ValueError("Methods without a name may not be used to activate modes!")
 
     result = MethodActivationResult(status=UsageStatus.FAIL, method_name=method.name)

--- a/wakepy/core/calls.py
+++ b/wakepy/core/calls.py
@@ -96,6 +96,9 @@ class DbusMethodCall(Call):
             )
         return tuple(args[p] for p in method.params)
 
+    def __repr__(self) -> str:
+        return f"<{self.method.service} {self.args} | bus: {self.method.bus}>"
+
 
 class CallProcessor:
     """A call processor. Determines *how* to process a call object and

--- a/wakepy/core/method.py
+++ b/wakepy/core/method.py
@@ -138,21 +138,7 @@ class Method(ABC, metaclass=MethodMeta):
     def caniuse(
         self,
     ) -> bool | None | str:
-        """Tells if the Method is suitable or unsuitable. Implement this is a
-        subclass. This is optional, but highly recommended. With `caniuse()` it
-        is possible to give more information about why some Method is not
-        supported.
-
-        NOTE: You do not have to test for the current platform here as it is
-        automatically tested if Method has `supported_platforms` attribute set!
-
-        Examples
-        --------
-        - Test that system is running KDE using DbusMethodCalls to some service
-          that should be running on KDE. Could also test that the version of
-          KDE is something that is needed.
-        - If a Method depends on availability of certain software on PATH,
-          could test that it exist on PATH. (and that the version is suitable)
+        """Tells if the Method is suitable or unsuitable.
 
         Returns
         ------
@@ -163,47 +149,79 @@ class Method(ABC, metaclass=MethodMeta):
             Method is unsuitable.
         """
 
-    def enter_mode(self) -> bool | str:
+        # Notes for subclassing
+        # =====================
+        # This is optional, but highly recommended. With `caniuse()` it
+        # is possible to give more information about why some Method is not
+        # supported.
+
+        # NOTE: You do not have to test for the current platform here as it is
+        # automatically tested if Method has `supported_platforms` attribute
+        # set!
+
+        # Examples
+        # --------
+        # - Test that system is running KDE using DbusMethodCalls to some service
+        #   that should be running on KDE. Could also test that the version of
+        #   KDE is something that is needed.
+        # - If a Method depends on availability of certain software on PATH,
+        #   could test that it exist on PATH. (and that the version is suitable)
+
+    def enter_mode(self) -> bool:
         """Enter to a Mode using this Method. Pair with a `exit_mode`.
 
         Returns
         -------
-        (a) If entering the mode was successful, return True
-        (b) If entering the mode was not successful, return a string
-        explaining the reason. You may also simply return False, but this is
-        discouraged.
+        If entering the mode was successful, returns True. Otherwise, raises
+        an Exception.
 
-        Any other type of return value will raise an Exception.
-
-        Notes for subclassing
-        ---------------------
-        The .enter_mode() should always leave anything in a clean in case of
-        errors; When subclassing, make sure that in case of any exceptions,
-        everything is cleaned (and .exit_mode() does not need to be called.)
+        Raises
+        -------
+        Could raise an Exception of any type.
         """
+
+        # Notes for subclassing
+        # =====================
+        # The only acceptable return value from this method is True. Any other
+        # return value (also None) is considered as an error.
+        #
+        # Errors
+        # -------
+        # If the mode enter was not succesful, raise an Exception of any type.
+        # This is catched by the mode activation process and handled.
+        #
+        # Note: The .enter_mode() should always leave anything in a clean in
+        # case of errors; When subclassing, make sure that in case of any
+        # exceptions, everything is cleaned; everything should be left in
+        # a state which does not require .exit_mode() to be called.
+        #
         return True
 
-    def exit_mode(self) -> bool | str:
+    def exit_mode(self) -> bool:
         """Exit from a Mode using this Method. Paired with `enter_mode`
 
         Returns
         -------
-        (a) If exiting the mode was successful, return True
-        (b) If exiting the mode was not successful, return a string
-        explaining the reason. You may also simply return False, but this is
-        discouraged.
+        If exiting the mode was successful, or if there was no need to exit
+        from the mode, returns True. Otherwise, raises an Exception.
 
         Any other type of return value will raise an Exception.
-
-        When subclassing, pay special attention to the fact that `enter_mode()`
-        should never raise any exceptions, unless something really is broken.
-        This is because if any exceptions are raised in `method.enter_mode()`
-        or `method.heartbeat()`, that method will simply not be used. But, if
-        exceptions are risen in `method.exit_mode()`, there is no way to
-        "correct" the situation (cannot just disregard the method and say:
-        "sorry, I'm not sure about this but you're possibly stuck in the mode
-         until you reboot").
         """
+
+        # Notes for subclassing
+        # =====================
+        # The only acceptable return value from this method is True. Any other
+        # return value (also None) is considered as an error.
+        #
+        # Pay special attention to the fact that `exit_mode()`
+        # should never raise any exceptions, unless something really is broken.
+        # This is because if any exceptions are raised in `method.enter_mode()`
+        # or `method.heartbeat()`, that method will simply not be used. But, if
+        # exceptions are risen in `method.exit_mode()`, there is no way to
+        # "correct" the situation (cannot just disregard the method and say:
+        # "sorry, I'm not sure about this but you're possibly stuck in the mode
+        #  until you reboot").
+
         return True
 
     heartbeat_period: int | float = 55
@@ -211,18 +229,15 @@ class Method(ABC, metaclass=MethodMeta):
     `heartbeat()`.
     """
 
-    def heartbeat(self) -> bool | str:
+    def heartbeat(self) -> bool:
         """Called periodically, every `heartbeat_period` seconds.
 
         Returns
         -------
-        (a) If calling the heartbeatwas successful, return True
-        (b) If calling the heartbeat was not successful, return a string
-        explaining the reason. You may also simply return False, but this is
-        discouraged.
-
-        Any other type of return value will raise an Exception.
+        If calling the heartbeat was successful, returns True. Otherwise,
+        raises an Exception.
         """
+
         return True
 
     def process_call(self, call: Call) -> Any:

--- a/wakepy/core/method.py
+++ b/wakepy/core/method.py
@@ -167,12 +167,12 @@ class Method(ABC, metaclass=MethodMeta):
         # - If a Method depends on availability of certain software on PATH,
         #   could test that it exist on PATH. (and that the version is suitable)
 
-    def enter_mode(self) -> bool:
+    def enter_mode(self):
         """Enter to a Mode using this Method. Pair with a `exit_mode`.
 
         Returns
         -------
-        If entering the mode was successful, returns True. Otherwise, raises
+        If entering the mode was successful, returns None. Otherwise, raises
         an Exception.
 
         Raises
@@ -182,8 +182,8 @@ class Method(ABC, metaclass=MethodMeta):
 
         # Notes for subclassing
         # =====================
-        # The only acceptable return value from this method is True. Any other
-        # return value (also None) is considered as an error.
+        # The only acceptable return value from this method is None. Any other
+        # return value is considered as an error.
         #
         # Errors
         # -------
@@ -195,23 +195,21 @@ class Method(ABC, metaclass=MethodMeta):
         # exceptions, everything is cleaned; everything should be left in
         # a state which does not require .exit_mode() to be called.
         #
-        return True
+        return
 
-    def exit_mode(self) -> bool:
+    def exit_mode(self):
         """Exit from a Mode using this Method. Paired with `enter_mode`
 
         Returns
         -------
         If exiting the mode was successful, or if there was no need to exit
-        from the mode, returns True. Otherwise, raises an Exception.
-
-        Any other type of return value will raise an Exception.
+        from the mode, returns None. Otherwise, raises an Exception.
         """
 
         # Notes for subclassing
         # =====================
-        # The only acceptable return value from this method is True. Any other
-        # return value (also None) is considered as an error.
+        # The only acceptable return value from this method is None. Any other
+        # return value is considered as an error.
         #
         # Pay special attention to the fact that `exit_mode()`
         # should never raise any exceptions, unless something really is broken.
@@ -222,23 +220,22 @@ class Method(ABC, metaclass=MethodMeta):
         # "sorry, I'm not sure about this but you're possibly stuck in the mode
         #  until you reboot").
 
-        return True
+        return
 
     heartbeat_period: int | float = 55
     """This is the amount of time (in seconds) between two consecutive calls of
     `heartbeat()`.
     """
 
-    def heartbeat(self) -> bool:
+    def heartbeat(self):
         """Called periodically, every `heartbeat_period` seconds.
 
         Returns
         -------
-        If calling the heartbeat was successful, returns True. Otherwise,
+        If calling the heartbeat was successful, returns None. Otherwise,
         raises an Exception.
         """
-
-        return True
+        return
 
     def process_call(self, call: Call) -> Any:
         if self._call_processor is None:

--- a/wakepy/io/dbus/jeepney.py
+++ b/wakepy/io/dbus/jeepney.py
@@ -7,6 +7,9 @@ from wakepy.core.dbus import DbusAdapter
 
 
 class JeepneyDbusAdapter(DbusAdapter):
+    """An implementation of DbusAdapter using jeepney. Can be used to process
+    DbusMethodCalls (communication with Dbus services over a dbus-daemon)."""
+
     # timeout for dbus calls, in seconds
     timeout = 2
 

--- a/wakepy/methods/gnome.py
+++ b/wakepy/methods/gnome.py
@@ -87,7 +87,7 @@ class _GnomeSessionManager(Method, ABC):
                 "Could not get inhibit cookie from org.gnome.SessionManager"
             )
 
-        return True
+        return
 
     def exit_mode(self):
         if self.inhibit_cookie is None:

--- a/wakepy/methods/gnome.py
+++ b/wakepy/methods/gnome.py
@@ -70,7 +70,7 @@ class _GnomeSessionManager(Method, ABC):
         super().__init__(*args, **kwargs)
         self.inhibit_cookie: Optional[int] = None
 
-    def enter_mode(self):
+    def enter_mode(self) -> bool | str:
         call = DbusMethodCall(
             method=self.method_inhibit,
             args=dict(
@@ -80,9 +80,11 @@ class _GnomeSessionManager(Method, ABC):
                 flags=self.flags,
             ),
         )
-        self.inhibit_cookie = self.process_call(call)
 
-    def exit_mode(self):
+        self.inhibit_cookie = self.process_call(call)
+        return True
+
+    def exit_mode(self) -> bool | str:
         if self.inhibit_cookie is None:
             raise RuntimeError("Cannot exit before entering")
 
@@ -92,6 +94,7 @@ class _GnomeSessionManager(Method, ABC):
         )
         self.process_call(call)
         self.inhibit_cookie = None
+        return True
 
 
 class GnomeSessionManagerNoSuspend(_GnomeSessionManager):

--- a/wakepy/methods/gnome.py
+++ b/wakepy/methods/gnome.py
@@ -70,7 +70,7 @@ class _GnomeSessionManager(Method, ABC):
         super().__init__(*args, **kwargs)
         self.inhibit_cookie: Optional[int] = None
 
-    def enter_mode(self) -> bool | str:
+    def enter_mode(self):
         call = DbusMethodCall(
             method=self.method_inhibit,
             args=dict(
@@ -82,11 +82,17 @@ class _GnomeSessionManager(Method, ABC):
         )
 
         self.inhibit_cookie = self.process_call(call)
+        if self.inhibit_cookie is None:
+            raise RuntimeError(
+                "Could not get inhibit cookie from org.gnome.SessionManager"
+            )
+
         return True
 
-    def exit_mode(self) -> bool | str:
+    def exit_mode(self):
         if self.inhibit_cookie is None:
-            raise RuntimeError("Cannot exit before entering")
+            # Nothing to exit from.
+            return
 
         call = DbusMethodCall(
             method=self.method_uninhibit,
@@ -94,7 +100,7 @@ class _GnomeSessionManager(Method, ABC):
         )
         self.process_call(call)
         self.inhibit_cookie = None
-        return True
+        return
 
 
 class GnomeSessionManagerNoSuspend(_GnomeSessionManager):


### PR DESCRIPTION
This is Part 1 for #136

Return values of Method methods: enter_mode, exit_mode, heartbeat
* Previously, return True when success, and string when failure
* Now: return None on success and raise Exception on failure.
* Also: Move subclassing instructions to be comments (as docstrings
   are inherited by subclasses)

Catch all Exceptions when trying to activate modes with methods
* This logic is now in a function called  _try_method_call, which is
 part of activate_method(method) call. 
 

Other changes
* Add more jeepney dbus adapter tests
* Make the test DbusService more robust
* Add DbusMethod.__repr__

