### PR TITLE
Issue 136: org.gnome.SessionManager based method

### DIFF
--- a/wakepy/core/calls.py
+++ b/wakepy/core/calls.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import typing
 
 if typing.TYPE_CHECKING:
@@ -114,8 +115,10 @@ class CallProcessor:
             use a custom DBus implementation.
         """
         self.dbus_adapter = get_dbus_adapter(dbus_adapter)
+        self.logger = logging.getLogger(__name__)
 
     def process(self, call: Call):
+        self.logger.debug("Processing: %s", call)
         if isinstance(call, DbusMethodCall) and self.dbus_adapter:
             return self.dbus_adapter.process(call)
 

--- a/wakepy/core/dbus.py
+++ b/wakepy/core/dbus.py
@@ -34,7 +34,7 @@ class DbusAddress(NamedTuple):
     """The path of the object to connect with. One object, defined by the
     bus, service and path, might have multiple interfaces.
 
-    Example: "org/spam/Manager"
+    Example: "/org/spam/Manager"
     """
 
     interface: str

--- a/wakepy/methods/gnome.py
+++ b/wakepy/methods/gnome.py
@@ -87,8 +87,6 @@ class _GnomeSessionManager(Method, ABC):
                 "Could not get inhibit cookie from org.gnome.SessionManager"
             )
 
-        return
-
     def exit_mode(self):
         if self.inhibit_cookie is None:
             # Nothing to exit from.
@@ -100,7 +98,6 @@ class _GnomeSessionManager(Method, ABC):
         )
         self.process_call(call)
         self.inhibit_cookie = None
-        return
 
 
 class GnomeSessionManagerNoSuspend(_GnomeSessionManager):

--- a/wakepy/methods/gnome.py
+++ b/wakepy/methods/gnome.py
@@ -54,7 +54,7 @@ class _GnomeSessionManager(Method, ABC):
     ).of(session_manager)
 
     method_uninhibit = DbusMethod(
-        name="UnInhibit",
+        name="Uninhibit",
         signature="u",
         params=("inhibit_cookie",),
     ).of(session_manager)
@@ -81,11 +81,12 @@ class _GnomeSessionManager(Method, ABC):
             ),
         )
 
-        self.inhibit_cookie = self.process_call(call)
-        if self.inhibit_cookie is None:
+        retval = self.process_call(call)
+        if retval is None:
             raise RuntimeError(
                 "Could not get inhibit cookie from org.gnome.SessionManager"
             )
+        self.inhibit_cookie = retval[0]
 
     def exit_mode(self):
         if self.inhibit_cookie is None:

--- a/wakepy/methods/gnome.py
+++ b/wakepy/methods/gnome.py
@@ -33,7 +33,7 @@ class _GnomeSessionManager(Method, ABC):
     session_manager = DbusAddress(
         bus=BusType.SESSION,
         service="org.gnome.SessionManager",
-        path="org/gnome/SessionManager",
+        path="/org/gnome/SessionManager",
         interface="org.gnome.SessionManager",
     )
 
@@ -77,7 +77,7 @@ class _GnomeSessionManager(Method, ABC):
                 app_id="wakepy",
                 toplevel_xid=42,  # The value does not seem to matter.
                 reason="wakelock active",
-                flags=self.flags,
+                flags=int(self.flags),
             ),
         )
 


### PR DESCRIPTION
Now the org.gnome.SessionManager based keep.running and keep.presenting context
managers work as expected. Tested manually on Ubuntu with GNOME. 