### PR TITLE
Add DbusMethod.to_call()

### DIFF
--- a/tests/unit/test_core/test_dbus.py
+++ b/tests/unit/test_core/test_dbus.py
@@ -1,0 +1,44 @@
+from wakepy.core.dbus import DbusMethod, DbusMethodCall, DbusAddress, BusType
+import pytest
+
+
+session_manager = DbusAddress(
+    bus=BusType.SESSION,
+    service="org.gnome.SessionManager",
+    path="/org/gnome/SessionManager",
+    interface="org.gnome.SessionManager",
+)
+
+
+@pytest.fixture
+def method_inhibit():
+    return DbusMethod(
+        name="Inhibit",
+        signature="susu",
+        params=("app_id", "toplevel_xid", "reason", "flags"),
+        output_signature="u",
+        output_params=("inhibit_cookie",),
+    )
+
+
+@pytest.fixture
+def args_for_inhibit():
+    return "first", 123, "third", 567
+
+
+def test_dbus_method_to_call(method_inhibit, args_for_inhibit):
+    method_inhibit = method_inhibit.of(session_manager)
+
+    call = method_inhibit.to_call(args_for_inhibit)
+
+    assert isinstance(call, DbusMethodCall)
+    assert call.args == args_for_inhibit
+    assert call.method == method_inhibit
+
+
+def test_dbus_method_to_call_not_fully_defined_method(method_inhibit, args_for_inhibit):
+    # The method is not fully defined as it is not tied to any address.
+    with pytest.raises(
+        ValueError, match="DbusMethodCall requires completely defined DBusMethod"
+    ):
+        method_inhibit.to_call(args_for_inhibit)

--- a/tests/unit/test_core/test_dbus.py
+++ b/tests/unit/test_core/test_dbus.py
@@ -1,6 +1,6 @@
-from wakepy.core.dbus import DbusMethod, DbusMethodCall, DbusAddress, BusType
 import pytest
 
+from wakepy.core.dbus import BusType, DbusAddress, DbusMethod, DbusMethodCall
 
 session_manager = DbusAddress(
     bus=BusType.SESSION,

--- a/wakepy/core/dbus.py
+++ b/wakepy/core/dbus.py
@@ -4,11 +4,10 @@ import typing
 from typing import List, NamedTuple, Tuple, Type, Union
 
 from . import BusType
+from .calls import DbusMethodCall
 
 if typing.TYPE_CHECKING:
-    from typing import Optional
-
-    from .calls import DbusMethodCall
+    from typing import Any, Optional
 
 
 DbusAdapterSeq = typing.Union[List["DbusAdapter"], Tuple["DbusAdapter", ...]]
@@ -157,6 +156,11 @@ class DbusMethod(NamedTuple):
         return all(
             x is not None for x in (self.service, self.path, self.interface, self.bus)
         )
+
+    def to_call(
+        self, args: dict[str, Any] | Tuple[Any, ...] | List[Any]
+    ) -> DbusMethodCall:
+        return DbusMethodCall(self, args)
 
 
 class DbusAdapter:

--- a/wakepy/methods/gnome.py
+++ b/wakepy/methods/gnome.py
@@ -37,14 +37,6 @@ class _GnomeSessionManager(Method, ABC):
         interface="org.gnome.SessionManager",
     )
 
-    method_isinhibited = DbusMethod(
-        name="IsInhibited",
-        signature="u",
-        params=("flags",),
-        output_signature="b",
-        output_params=("is_inhibited",),
-    ).of(session_manager)
-
     method_inhibit = DbusMethod(
         name="Inhibit",
         signature="susu",


### PR DESCRIPTION
Add a DbusMethod.to_call() which can be used to easily create DbusMethodCall from DbusMethod

In addition removing one unused DbusMethod definition (isinhibited) 