### PR TITLE
Make args optional in DbusMethodCall

### DIFF
--- a/tests/unit/test_core/test_calls.py
+++ b/tests/unit/test_core/test_calls.py
@@ -26,6 +26,16 @@ def method_without_params(service):
     ).of(service)
 
 
+def test_dbusmethod_args_none(method: DbusMethod):
+    call = DbusMethodCall(method, args=None)
+    assert call.args == tuple()
+
+
+def test_dbusmethod_args_missing(method: DbusMethod):
+    call = DbusMethodCall(method)
+    assert call.args == tuple()
+
+
 def test_dbusmethod_args_tuple(method: DbusMethod):
     args = (1, "2", 3)
     call = DbusMethodCall(method, args=args)

--- a/wakepy/core/calls.py
+++ b/wakepy/core/calls.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import logging
 import typing
+from typing import Any, List, Optional, Tuple, Type
 
 if typing.TYPE_CHECKING:
-    from typing import Any, List, Optional, Tuple, Type
-
     from .dbus import DbusAdapter, DbusAdapterTypeSeq, DbusMethod
+
+
+CallArguments = Optional[dict[str, Any] | Tuple[Any, ...] | List[Any]]
 
 
 class Call:
@@ -35,9 +37,7 @@ class DbusMethodCall(Call):
     args: Tuple[Any, ...]
     """The method args (positional). This is used"""
 
-    def __init__(
-        self, method: DbusMethod, args: dict[str, Any] | Tuple[Any, ...] | List[Any]
-    ):
+    def __init__(self, method: DbusMethod, args: CallArguments):
         """Converts the `args` argument is converted into a tuple and makes it
         available at DbusMethodCall.args."""
         if not method.completely_defined():
@@ -58,7 +58,7 @@ class DbusMethodCall(Call):
         return {p: arg for p, arg in zip(self.method.params, self.args)}
 
     def _args_as_tuple(
-        self, args: dict[str, Any] | Tuple[Any, ...] | List[Any], method: DbusMethod
+        self, args: CallArguments, method: DbusMethod
     ) -> Tuple[Any, ...]:
         if isinstance(args, tuple) or isinstance(args, list):
             args = tuple(args)

--- a/wakepy/core/calls.py
+++ b/wakepy/core/calls.py
@@ -37,7 +37,7 @@ class DbusMethodCall(Call):
     args: Tuple[Any, ...]
     """The method args (positional). This is used"""
 
-    def __init__(self, method: DbusMethod, args: CallArguments):
+    def __init__(self, method: DbusMethod, args: CallArguments = None):
         """Converts the `args` argument is converted into a tuple and makes it
         available at DbusMethodCall.args."""
         if not method.completely_defined():
@@ -60,6 +60,9 @@ class DbusMethodCall(Call):
     def _args_as_tuple(
         self, args: CallArguments, method: DbusMethod
     ) -> Tuple[Any, ...]:
+        if args is None:
+            return tuple()
+
         if isinstance(args, tuple) or isinstance(args, list):
             args = tuple(args)
             self.__check_args_length(args, method)

--- a/wakepy/core/dbus.py
+++ b/wakepy/core/dbus.py
@@ -158,7 +158,7 @@ class DbusMethod(NamedTuple):
             x is not None for x in (self.service, self.path, self.interface, self.bus)
         )
 
-    def to_call(self, args: CallArguments) -> DbusMethodCall:
+    def to_call(self, args: CallArguments = None) -> DbusMethodCall:
         return DbusMethodCall(self, args)
 
 

--- a/wakepy/core/dbus.py
+++ b/wakepy/core/dbus.py
@@ -7,7 +7,8 @@ from . import BusType
 from .calls import DbusMethodCall
 
 if typing.TYPE_CHECKING:
-    from typing import Any, Optional
+    from typing import Optional
+    from .calls import CallArguments
 
 
 DbusAdapterSeq = typing.Union[List["DbusAdapter"], Tuple["DbusAdapter", ...]]
@@ -157,9 +158,7 @@ class DbusMethod(NamedTuple):
             x is not None for x in (self.service, self.path, self.interface, self.bus)
         )
 
-    def to_call(
-        self, args: dict[str, Any] | Tuple[Any, ...] | List[Any]
-    ) -> DbusMethodCall:
+    def to_call(self, args: CallArguments) -> DbusMethodCall:
         return DbusMethodCall(self, args)
 
 


### PR DESCRIPTION
Accept no args and None as args.

Not all Dbus methods need arguments, and passing explicit `args=tuple()` does not look so clean.