### PR TITLE
Issue 73: Return Mode from Mode.__enter__() instead of ActivationResult

### DIFF
--- a/docs/source/user-guide/index.md
+++ b/docs/source/user-guide/index.md
@@ -35,7 +35,7 @@ If you want to keep a long task running, but do not want to prevent screen from 
 ```{code-block} python
 from wakepy import keep
 
-with keep.running() as k:
+with keep.running():
     # Do something that takes a long time
 ```
 
@@ -46,7 +46,7 @@ with keep.running() as k:
 ```{code-block} python
 from wakepy import keep
 
-with keep.presenting() as k:
+with keep.presenting():
     # Do something that takes a long time
 ```
 

--- a/docs/source/user-guide/modes.md
+++ b/docs/source/user-guide/modes.md
@@ -13,7 +13,7 @@ The available modes are
 The wakepy modes are implemented as context managers of type `wakepy.Mode`. When entering the context, the `wakepy.Mode` instance (`m`) is returned, which has following attributes:
 
 - `m.active`: True, if entering mode was successful. Can be [faked in CI](./tests-and-ci.md#wakepy_fake_success).
-- `m.result`: An ActivationResult instance which gives more detailed information about the activation process.
+- `m.activation_result`: An ActivationResult instance which gives more detailed information about the activation process.
 
 ````{tip} 
 You may want to inform user about failure in activating a mode. For example:

--- a/docs/source/user-guide/modes.md
+++ b/docs/source/user-guide/modes.md
@@ -10,21 +10,17 @@ The available modes are
 
 ## Entering a mode
 
-The wakepy modes are implemented as context managers. When entering the context, a object is returned, which has following attributes:
+The wakepy modes are implemented as context managers of type `wakepy.Mode`. When entering the context, the `wakepy.Mode` instance (`m`) is returned, which has following attributes:
 
-- `k.success`: True, if entering mode was successful. Can be [faked in CI](./tests-and-ci.md#wakepy_fake_success).
-- `k.failure`: Always opposite of `success`.
-
-```{note}
-The new wakepy python API is under development, and once ready, the returned object will have some proper class name and documentation. On version 0.7.0, these are the only attributes available that are guaranteed to be there also in later releases.
-```  
+- `m.active`: True, if entering mode was successful. Can be [faked in CI](./tests-and-ci.md#wakepy_fake_success).
+- `m.result`: An ActivationResult instance which gives more detailed information about the activation process.
 
 ````{tip} 
 You may want to inform user about failure in activating a mode. For example:
 
 ```{code-block} python
-with keep.running() as k:
-    if not k.success:
+with keep.running() as m:
+    if not m.active:
         print('Failed to inhibit system sleep.')
 
     do_something_that_takes_long_time()

--- a/tests/unit/test_core/test_mode.py
+++ b/tests/unit/test_core/test_mode.py
@@ -79,9 +79,12 @@ def test_mode_contextmanager_protocol():
         assert mocks.mock_calls[2] == call.controller_class().activate(
             mocks.methods, methods_priority=None
         )
-        # The __enter__ returns the value from the ModeController.activate()
+        # The __enter__ returns the Mode
+        assert m is mode
+
+        # The m.result contains the value from the ModeController.activate()
         # call
-        assert m == mocks.controller_class.return_value.activate.return_value
+        assert m.result == mocks.controller_class.return_value.activate.return_value
 
     # If we get here, the __exit__ works without errors
     # ModeController.deactivate() is called during __exit__

--- a/tests/unit/test_core/test_mode.py
+++ b/tests/unit/test_core/test_mode.py
@@ -22,7 +22,7 @@ def mocks_for_test_mode():
     methods = [Mock() for _ in range(3)]
 
     # Record calls in a "mock manager"
-    mocks.result = result
+    mocks.activation_result = result
     mocks.methods = methods
     return mocks
 
@@ -82,12 +82,15 @@ def test_mode_contextmanager_protocol(monkeypatch):
         # The __enter__ returns the Mode
         assert m is mode
 
-        # When activating, the .active is set to result.success
-        assert m.active is m.result.success
+        # When activating, the .active is set to activation_result.success
+        assert m.active is m.activation_result.success
 
-        # The m.result contains the value from the ModeController.activate()
+        # The m.activation_result contains the value from the ModeController.activate()
         # call
-        assert m.result == mocks.controller_class.return_value.activate.return_value
+        assert (
+            m.activation_result
+            == mocks.controller_class.return_value.activate.return_value
+        )
 
     # After exiting the mode, Mode.active is set to False
     assert m.active is False

--- a/tests/unit/test_core/test_mode.py
+++ b/tests/unit/test_core/test_mode.py
@@ -38,7 +38,7 @@ def get_mocks_and_testmode():
     return mocks, TestMode
 
 
-def test_mode_contextmanager_protocol():
+def test_mode_contextmanager_protocol(monkeypatch):
     """Test that the Mode fulfills the context manager protocol; i.e. it is
     possible to use instances of Mode in a with statement like this:
 
@@ -82,9 +82,15 @@ def test_mode_contextmanager_protocol():
         # The __enter__ returns the Mode
         assert m is mode
 
+        # When activating, the .active is set to result.success
+        assert m.active is m.result.success
+
         # The m.result contains the value from the ModeController.activate()
         # call
         assert m.result == mocks.controller_class.return_value.activate.return_value
+
+    # After exiting the mode, Mode.active is set to False
+    assert m.active is False
 
     # If we get here, the __exit__ works without errors
     # ModeController.deactivate() is called during __exit__

--- a/tests/unit/test_modes.py
+++ b/tests/unit/test_modes.py
@@ -1,6 +1,6 @@
 import pytest
 
-from wakepy.core import DbusAdapter, Method, ModeName
+from wakepy.core import ActivationResult, DbusAdapter, Method, Mode, ModeName
 from wakepy.modes import keep
 
 
@@ -77,11 +77,14 @@ def test_keep_running_mode_creation(input_args, monkeypatch):
 
 def test_keep_running(fake_dbus_adapter):
     """Simple smoke test for keep.running()"""
-    with keep.running(dbus_adapter=fake_dbus_adapter) as k:
-        assert isinstance(k.success, bool)
+    with keep.running(dbus_adapter=fake_dbus_adapter) as m:
+        assert isinstance(m, Mode)
+        assert isinstance(m.result.success, bool)
+    assert isinstance(m.result, ActivationResult)
 
 
 def test_keep_presenting(fake_dbus_adapter):
     """Simple smoke test for keep.presenting()"""
-    with keep.presenting(dbus_adapter=fake_dbus_adapter) as k:
-        assert isinstance(k.success, bool)
+    with keep.presenting(dbus_adapter=fake_dbus_adapter) as m:
+        assert isinstance(m, Mode)
+        assert isinstance(m.result.success, bool)

--- a/tests/unit/test_modes.py
+++ b/tests/unit/test_modes.py
@@ -75,11 +75,34 @@ def test_keep_running_mode_creation(input_args, monkeypatch):
     assert mode._dbus_adapter_cls == MyDbusAdapter
 
 
-def test_keep_running(fake_dbus_adapter):
+def test_keep_running(monkeypatch, fake_dbus_adapter):
     """Simple smoke test for keep.running()"""
-    with keep.running(dbus_adapter=fake_dbus_adapter) as m:
-        assert isinstance(m, Mode)
-        assert isinstance(m.result.success, bool)
+    monkeypatch.setenv("WAKEPY_FAKE_SUCCESS", "1")
+    mode = keep.running(dbus_adapter=fake_dbus_adapter)
+    assert mode.active is False
+
+    with mode as m:
+        assert mode is m
+        assert m.active is True
+        assert m.result.success is True
+
+    assert m.active is False
+    assert isinstance(m.result, ActivationResult)
+
+
+def test_keep_running(monkeypatch, fake_dbus_adapter):
+    """Simple smoke test for keep.running()"""
+    monkeypatch.setenv("WAKEPY_FAKE_SUCCESS", "0")
+    # This we expect to fail as the only adapter is the fake_dbus_adapter
+    mode = keep.running(dbus_adapter=fake_dbus_adapter)
+    assert mode.active is False
+
+    with mode as m:
+        assert mode is m
+        assert m.active is False
+        assert m.result.success is False
+
+    assert m.active is False
     assert isinstance(m.result, ActivationResult)
 
 

--- a/tests/unit/test_modes.py
+++ b/tests/unit/test_modes.py
@@ -84,10 +84,10 @@ def test_keep_running(monkeypatch, fake_dbus_adapter):
     with mode as m:
         assert mode is m
         assert m.active is True
-        assert m.result.success is True
+        assert m.activation_result.success is True
 
     assert m.active is False
-    assert isinstance(m.result, ActivationResult)
+    assert isinstance(m.activation_result, ActivationResult)
 
 
 def test_keep_running(monkeypatch, fake_dbus_adapter):
@@ -100,14 +100,14 @@ def test_keep_running(monkeypatch, fake_dbus_adapter):
     with mode as m:
         assert mode is m
         assert m.active is False
-        assert m.result.success is False
+        assert m.activation_result.success is False
 
     assert m.active is False
-    assert isinstance(m.result, ActivationResult)
+    assert isinstance(m.activation_result, ActivationResult)
 
 
 def test_keep_presenting(fake_dbus_adapter):
     """Simple smoke test for keep.presenting()"""
     with keep.presenting(dbus_adapter=fake_dbus_adapter) as m:
         assert isinstance(m, Mode)
-        assert isinstance(m.result.success, bool)
+        assert isinstance(m.activation_result.success, bool)

--- a/wakepy/cli.py
+++ b/wakepy/cli.py
@@ -99,10 +99,14 @@ def start(
     with ExitStack() as stack:
         if keep_running:
             m = stack.enter_context(keep.running())
-            real_successes["keep_running"] = m.real_success
+            real_successes["keep_running"] = (
+                m.result.real_success if m.result else False
+            )
         if presentation_mode:
             m = stack.enter_context(keep.presenting())
-            real_successes["presentation_mode"] = m.real_success
+            real_successes["presentation_mode"] = (
+                m.result.real_success if m.result else False
+            )
 
         # A quick fix (Fix this better in next release)
         # On linux, D-Bus methods for keep_running use presentation_mode.

--- a/wakepy/cli.py
+++ b/wakepy/cli.py
@@ -100,12 +100,12 @@ def start(
         if keep_running:
             m = stack.enter_context(keep.running())
             real_successes["keep_running"] = (
-                m.result.real_success if m.result else False
+                m.activation_result.real_success if m.activation_result else False
             )
         if presentation_mode:
             m = stack.enter_context(keep.presenting())
             real_successes["presentation_mode"] = (
-                m.result.real_success if m.result else False
+                m.activation_result.real_success if m.activation_result else False
             )
 
         # A quick fix (Fix this better in next release)

--- a/wakepy/core/mode.py
+++ b/wakepy/core/mode.py
@@ -103,6 +103,8 @@ class Mode(ABC):
     ----------
     method_classes: list[Type[Method]]
         The list of methods associated for this mode.
+    active: bool
+        True if the mode is active. Otherwise, False.
     """
 
     _call_processor_class: Type[CallProcessor] = CallProcessor
@@ -136,6 +138,7 @@ class Mode(ABC):
         self.methods_priority = methods_priority
         self.controller: ModeController | None = None
         self.result: ActivationResult | None = None
+        self.active: bool = False
         self._dbus_adapter_cls = dbus_adapter
 
     def __enter__(self) -> Mode:
@@ -148,6 +151,7 @@ class Mode(ABC):
             self.methods_classes,
             methods_priority=self.methods_priority,
         )
+        self.active = self.result.success
         return self
 
     def __exit__(
@@ -175,6 +179,7 @@ class Mode(ABC):
             raise RuntimeError("Must __enter__ before __exit__!")
 
         self.controller.deactivate()
+        self.active = False
 
         if exception is None or isinstance(exception, ModeExit):
             return True

--- a/wakepy/core/mode.py
+++ b/wakepy/core/mode.py
@@ -134,18 +134,20 @@ class Mode(ABC):
         self.methods_classes = methods
         self.methods_priority = methods_priority
         self.controller: ModeController | None = None
+        self.result: ActivationResult | None = None
         self._dbus_adapter_cls = dbus_adapter
 
-    def __enter__(self) -> ActivationResult:
+    def __enter__(self) -> Mode:
         if self.controller is None:
             call_processor = self._call_processor_class(
                 dbus_adapter=self._dbus_adapter_cls
             )
             self.controller = self._controller_class(call_processor=call_processor)
-        return self.controller.activate(
+        self.result = self.controller.activate(
             self.methods_classes,
             methods_priority=self.methods_priority,
         )
+        return self
 
     def __exit__(
         self,

--- a/wakepy/core/mode.py
+++ b/wakepy/core/mode.py
@@ -26,8 +26,9 @@ class ModeExit(Exception):
     Example
     -------
     ```
-    with keep.running() as k:
-        if not k.success:
+    with keep.running():
+        # do something
+        if some_condition:
             print('failure')
             raise ModeExit
         print('success')

--- a/wakepy/core/mode.py
+++ b/wakepy/core/mode.py
@@ -105,7 +105,7 @@ class Mode(ABC):
         The list of methods associated for this mode.
     active: bool
         True if the mode is active. Otherwise, False.
-    result: ActivationResult | None
+    activation_result: ActivationResult | None
         The activation result which tells more about the activation process
         outcome. None if Mode has not yet been activated.
     """
@@ -140,7 +140,7 @@ class Mode(ABC):
         self.methods_classes = methods
         self.methods_priority = methods_priority
         self.controller: ModeController | None = None
-        self.result: ActivationResult | None = None
+        self.activation_result: ActivationResult | None = None
         self.active: bool = False
         self._dbus_adapter_cls = dbus_adapter
 
@@ -150,11 +150,11 @@ class Mode(ABC):
                 dbus_adapter=self._dbus_adapter_cls
             )
             self.controller = self._controller_class(call_processor=call_processor)
-        self.result = self.controller.activate(
+        self.activation_result = self.controller.activate(
             self.methods_classes,
             methods_priority=self.methods_priority,
         )
-        self.active = self.result.success
+        self.active = self.activation_result.success
         return self
 
     def __exit__(

--- a/wakepy/core/mode.py
+++ b/wakepy/core/mode.py
@@ -105,6 +105,9 @@ class Mode(ABC):
         The list of methods associated for this mode.
     active: bool
         True if the mode is active. Otherwise, False.
+    result: ActivationResult | None
+        The activation result which tells more about the activation process
+        outcome. None if Mode has not yet been activated.
     """
 
     _call_processor_class: Type[CallProcessor] = CallProcessor


### PR DESCRIPTION
Return Mode (self) from Mode.__enter__(), instead of returning 
an ActivationResult instance.

Add Mode.active attribute (bool)
Add Mode.result attribute (ActivationResult)