### PR TITLE
MethodActivationResult: .success, .failure_reason (renames)

### DIFF
--- a/tests/unit/test_core/test_activation/test_activation.py
+++ b/tests/unit/test_core/test_activation/test_activation.py
@@ -162,7 +162,7 @@ def test_activate_method_method_caniuse_fails():
     res, heartbeat = activate_method(method)
     assert res.success == False
     assert res.failure_stage == StageName.REQUIREMENTS
-    assert res.message == ""
+    assert res.failure_reason == ""
     assert heartbeat is None
 
     # Case 2: Fail by returning some error reason from caniuse
@@ -172,7 +172,7 @@ def test_activate_method_method_caniuse_fails():
     res, heartbeat = activate_method(method)
     assert res.success == False
     assert res.failure_stage == StageName.REQUIREMENTS
-    assert res.message == "SomeSW version <2.1.5 not supported"
+    assert res.failure_reason == "SomeSW version <2.1.5 not supported"
     assert heartbeat is None
 
 
@@ -182,7 +182,7 @@ def test_activate_method_method_enter_mode_fails():
     res, heartbeat = activate_method(method)
     assert res.success == False
     assert res.failure_stage == StageName.ACTIVATION
-    assert "Original error: failed" in res.message
+    assert "Original error: failed" in res.failure_reason
     assert heartbeat is None
 
 
@@ -191,7 +191,7 @@ def test_activate_method_enter_mode_success():
     res, heartbeat = activate_method(method)
     assert res.success == True
     assert res.failure_stage is None
-    assert res.message == ""
+    assert res.failure_reason == ""
     # No heartbeat on success, as the used Method does not have heartbeat()
     assert heartbeat is None
 
@@ -201,7 +201,7 @@ def test_activate_method_heartbeat_success():
     res, heartbeat = activate_method(method)
     assert res.success == True
     assert res.failure_stage is None
-    assert res.message == ""
+    assert res.failure_reason == ""
     # We get a Heartbeat instance on success, as the used Method does has a
     # heartbeat()
     assert isinstance(heartbeat, Heartbeat)
@@ -491,7 +491,7 @@ def test_caniuse_fails(params):
     ],
 )
 def test_method_usage_result(
-    status,
+    status,  # TODO: rename
     failure_stage,
     method_name,
     message,
@@ -501,13 +501,13 @@ def test_method_usage_result(
         success=status,
         failure_stage=failure_stage,
         method_name=method_name,
-        message=message,
+        failure_reason=message,
     )
     # These attributes are available
+    assert mur.method_name == method_name
     assert mur.success == status
     assert mur.failure_stage == failure_stage
-    assert mur.method_name == method_name
-    assert mur.message == message
+    assert mur.failure_reason == message
 
     assert str(mur) == expected_string_representation
 

--- a/tests/unit/test_core/test_activation/test_activation.py
+++ b/tests/unit/test_core/test_activation/test_activation.py
@@ -152,7 +152,7 @@ def test_activate_method_method_without_platform_support(monkeypatch):
     # should fail.
     res, heartbeat = activate_method(winmethod)
     assert res.failure_stage == StageName.PLATFORM_SUPPORT
-    assert res.success == False
+    assert res.success is False
     assert heartbeat is None
 
 
@@ -160,7 +160,7 @@ def test_activate_method_method_caniuse_fails():
     # Case 1: Fail by returning False from caniuse
     method = get_test_method_class(caniuse=False, enter_mode=True, exit_mode=True)()
     res, heartbeat = activate_method(method)
-    assert res.success == False
+    assert res.success is False
     assert res.failure_stage == StageName.REQUIREMENTS
     assert res.failure_reason == ""
     assert heartbeat is None
@@ -170,7 +170,7 @@ def test_activate_method_method_caniuse_fails():
         caniuse="SomeSW version <2.1.5 not supported", enter_mode=True, exit_mode=True
     )()
     res, heartbeat = activate_method(method)
-    assert res.success == False
+    assert res.success is False
     assert res.failure_stage == StageName.REQUIREMENTS
     assert res.failure_reason == "SomeSW version <2.1.5 not supported"
     assert heartbeat is None
@@ -180,7 +180,7 @@ def test_activate_method_method_enter_mode_fails():
     # Case: Fail by returning False from enter_mode
     method = get_test_method_class(caniuse=True, enter_mode=RuntimeError("failed"))()
     res, heartbeat = activate_method(method)
-    assert res.success == False
+    assert res.success is False
     assert res.failure_stage == StageName.ACTIVATION
     assert "Original error: failed" in res.failure_reason
     assert heartbeat is None
@@ -189,7 +189,7 @@ def test_activate_method_method_enter_mode_fails():
 def test_activate_method_enter_mode_success():
     method = get_test_method_class(caniuse=True, enter_mode=None)()
     res, heartbeat = activate_method(method)
-    assert res.success == True
+    assert res.success is True
     assert res.failure_stage is None
     assert res.failure_reason == ""
     # No heartbeat on success, as the used Method does not have heartbeat()
@@ -199,7 +199,7 @@ def test_activate_method_enter_mode_success():
 def test_activate_method_heartbeat_success():
     method = get_test_method_class(heartbeat=None)()
     res, heartbeat = activate_method(method)
-    assert res.success == True
+    assert res.success is True
     assert res.failure_stage is None
     assert res.failure_reason == ""
     # We get a Heartbeat instance on success, as the used Method does has a

--- a/tests/unit/test_core/test_activation/test_activation.py
+++ b/tests/unit/test_core/test_activation/test_activation.py
@@ -456,7 +456,7 @@ def test_caniuse_fails(params):
 
 
 @pytest.mark.parametrize(
-    "status, failure_stage, method_name, message, expected_string_representation",
+    "success, failure_stage, method_name, message, expected_string_representation",
     [
         (
             False,
@@ -491,21 +491,21 @@ def test_caniuse_fails(params):
     ],
 )
 def test_method_usage_result(
-    status,  # TODO: rename
+    success,
     failure_stage,
     method_name,
     message,
     expected_string_representation,
 ):
     mur = MethodActivationResult(
-        success=status,
+        success=success,
         failure_stage=failure_stage,
         method_name=method_name,
         failure_reason=message,
     )
     # These attributes are available
     assert mur.method_name == method_name
-    assert mur.success == status
+    assert mur.success == success
     assert mur.failure_stage == failure_stage
     assert mur.failure_reason == message
 

--- a/tests/unit/test_core/test_activation/test_activationresult.py
+++ b/tests/unit/test_core/test_activation/test_activationresult.py
@@ -7,13 +7,13 @@ PLATFORM_SUPPORT_FAIL = MethodActivationResult(
     success=False,
     failure_stage=StageName.PLATFORM_SUPPORT,
     method_name="fail-platform",
-    message="Platform XYZ not supported!",
+    failure_reason="Platform XYZ not supported!",
 )
 REQUIREMENTS_FAIL = MethodActivationResult(
     success=False,
     failure_stage=StageName.REQUIREMENTS,
     method_name="fail-requirements",
-    message="Missing requirement: Some SW v.1.2.3",
+    failure_reason="Missing requirement: Some SW v.1.2.3",
 )
 SUCCESS_RESULT = MethodActivationResult(
     success=True,
@@ -51,13 +51,13 @@ METHODACTIVATIONRESULTS_3_FAIL = [
         success=False,
         failure_stage=StageName.PLATFORM_SUPPORT,
         method_name="fail-platform",
-        message="Platform XYZ not supported!",
+        failure_reason="Platform XYZ not supported!",
     ),
     MethodActivationResult(
         success=False,
         failure_stage=StageName.REQUIREMENTS,
         method_name="fail-requirements",
-        message="Missing requirement: Some SW v.1.2.3",
+        failure_reason="Missing requirement: Some SW v.1.2.3",
     ),
 ]
 

--- a/tests/unit/test_core/test_activation/test_activationresult.py
+++ b/tests/unit/test_core/test_activation/test_activationresult.py
@@ -1,26 +1,26 @@
 import pytest
 
 from wakepy.core import ActivationResult, MethodActivationResult
-from wakepy.core.activation import StageName, UsageStatus
+from wakepy.core.activation import StageName
 
 PLATFORM_SUPPORT_FAIL = MethodActivationResult(
-    status=UsageStatus.FAIL,
+    success=False,
     failure_stage=StageName.PLATFORM_SUPPORT,
     method_name="fail-platform",
     message="Platform XYZ not supported!",
 )
 REQUIREMENTS_FAIL = MethodActivationResult(
-    status=UsageStatus.FAIL,
+    success=False,
     failure_stage=StageName.REQUIREMENTS,
     method_name="fail-requirements",
     message="Missing requirement: Some SW v.1.2.3",
 )
 SUCCESS_RESULT = MethodActivationResult(
-    status=UsageStatus.SUCCESS,
+    success=True,
     method_name="a-successful-method",
 )
 UNUSED_RESULT = MethodActivationResult(
-    status=UsageStatus.UNUSED,
+    success=None,
     method_name="some-unused-method",
 )
 METHODACTIVATIONRESULTS_1 = [
@@ -32,29 +32,29 @@ METHODACTIVATIONRESULTS_1 = [
 
 METHODACTIVATIONRESULTS_2 = [
     MethodActivationResult(
-        status=UsageStatus.SUCCESS,
+        success=True,
         method_name="1st.successfull.method",
     ),
     REQUIREMENTS_FAIL,
     MethodActivationResult(
-        status=UsageStatus.SUCCESS,
+        success=True,
         method_name="2nd-successful-method",
     ),
     MethodActivationResult(
-        status=UsageStatus.SUCCESS,
+        success=True,
         method_name="last-successful-method",
     ),
 ]
 
 METHODACTIVATIONRESULTS_3_FAIL = [
     MethodActivationResult(
-        status=UsageStatus.FAIL,
+        success=False,
         failure_stage=StageName.PLATFORM_SUPPORT,
         method_name="fail-platform",
         message="Platform XYZ not supported!",
     ),
     MethodActivationResult(
-        status=UsageStatus.FAIL,
+        success=False,
         failure_stage=StageName.REQUIREMENTS,
         method_name="fail-requirements",
         message="Missing requirement: Some SW v.1.2.3",
@@ -120,7 +120,7 @@ def test_activation_result_get_detailed_results():
     ]
 
     # Possible to filter with status
-    assert ar.get_detailed_results(statuses=("FAIL",)) == [
+    assert ar.get_detailed_results(success=(False,)) == [
         PLATFORM_SUPPORT_FAIL,
         REQUIREMENTS_FAIL,
     ]
@@ -133,9 +133,7 @@ def test_activation_result_get_detailed_results():
     ]
 
     # or with both
-    assert ar.get_detailed_results(
-        statuses=("FAIL",), fail_stages=("REQUIREMENTS",)
-    ) == [
+    assert ar.get_detailed_results(success=(False,), fail_stages=("REQUIREMENTS",)) == [
         REQUIREMENTS_FAIL,
     ]
 

--- a/wakepy/core/activation.py
+++ b/wakepy/core/activation.py
@@ -210,12 +210,12 @@ class ActivationResult:
 class MethodActivationResult:
     """This class is a result from using a single Method to activate a mode."""
 
+    method_name: str
+
     # True: Using Method was successful
     # False: Using Method failed
     # None: Method is unused
     success: bool | None
-
-    method_name: str
 
     # None if the method did not fail. Otherwise, the name of the stage where
     # the method failed.

--- a/wakepy/core/activation.py
+++ b/wakepy/core/activation.py
@@ -199,7 +199,7 @@ class ActivationResult:
         for res in self._results:
             if res.success not in success:
                 continue
-            if res.success == False and res.failure_stage not in fail_stages:
+            if res.success is False and res.failure_stage not in fail_stages:
                 continue
             out.append(res)
 

--- a/wakepy/core/activation.py
+++ b/wakepy/core/activation.py
@@ -221,15 +221,15 @@ class MethodActivationResult:
     # the method failed.
     failure_stage: Optional[StageName] = None
 
-    message: str = ""
+    failure_reason: str = ""
 
     def __repr__(self):
         error_at = " @" + self.failure_stage if self.failure_stage else ""
-        message_part = f', "{self.message}"' if self.success is False else ""
+        failure_reason = f', "{self.failure_reason}"' if self.success is False else ""
         success_str = (
             "SUCCESS" if self.success else "FAIL" if self.success is False else "UNUSED"
         )
-        return f"({success_str}{error_at}, {self.method_name}{message_part})"
+        return f"({success_str}{error_at}, {self.method_name}{failure_reason})"
 
 
 def activate_one_of_multiple(
@@ -520,13 +520,13 @@ def activate_method(method: Method) -> Tuple[MethodActivationResult, Heartbeat |
     requirements_fail, err_message = caniuse_fails(method)
     if requirements_fail:
         result.failure_stage = StageName.REQUIREMENTS
-        result.message = err_message
+        result.failure_reason = err_message
         return result, None
 
     success, err_message, heartbeat_call_time = try_enter_and_heartbeat(method)
     if not success:
         result.failure_stage = StageName.ACTIVATION
-        result.message = err_message
+        result.failure_reason = err_message
         return result, None
 
     result.success = True


### PR DESCRIPTION
Two renames:

MethodActivationResult.status (UsageStatus) -> MethodActivationResult.success (bool | None)
MethodActivationResult.message -> MethodActivationResult.failure_reason

Also, remove UsageStatus (not needed anymore, as replaced by bool / None)
