### PR TITLE
ActivationResults: only one active method + renames

### DIFF
--- a/tests/unit/test_core/test_activation/test_activation.py
+++ b/tests/unit/test_core/test_activation/test_activation.py
@@ -38,7 +38,7 @@ from wakepy.core.method import Method, MethodError, PlatformName, get_methods
 def test_activate_without_methods(monkeypatch):
     _arrange_for_test_activate(monkeypatch)
     res, active_method, heartbeat = activate_one_of_multiple([], None)
-    assert res.get_details() == []
+    assert res.list_methods() == []
     assert res.success is False
     assert active_method is None
     assert heartbeat is None
@@ -74,7 +74,7 @@ def test_activate_function_success(monkeypatch):
 
     # The failing method is tried first because there is prioritization step
     # which honors the `methods_priority``
-    assert [x.method_name for x in result.get_details()] == [
+    assert [x.method_name for x in result.list_methods()] == [
         methodcls_fail.name,
         methodcls_success.name,
     ]

--- a/tests/unit/test_core/test_activation/test_activationresult.py
+++ b/tests/unit/test_core/test_activation/test_activationresult.py
@@ -103,7 +103,7 @@ def test_activation_result_get_details():
     ]
 
 
-def test_activation_result_get_detailed_results():
+def test_activation_result_query():
     ar = ActivationResult()
     ar._results = [
         PLATFORM_SUPPORT_FAIL,
@@ -113,7 +113,7 @@ def test_activation_result_get_detailed_results():
     ]
 
     # When no arguments given, return everything
-    assert ar.get_detailed_results() == [
+    assert ar.query() == [
         PLATFORM_SUPPORT_FAIL,
         REQUIREMENTS_FAIL,
         SUCCESS_RESULT,
@@ -121,20 +121,20 @@ def test_activation_result_get_detailed_results():
     ]
 
     # Possible to filter with status
-    assert ar.get_detailed_results(success=(False,)) == [
+    assert ar.query(success=(False,)) == [
         PLATFORM_SUPPORT_FAIL,
         REQUIREMENTS_FAIL,
     ]
 
     # Possible to filter with fail_stage
-    assert ar.get_detailed_results(fail_stages=("REQUIREMENTS",)) == [
+    assert ar.query(fail_stages=("REQUIREMENTS",)) == [
         REQUIREMENTS_FAIL,
         SUCCESS_RESULT,
         UNUSED_RESULT,
     ]
 
     # or with both
-    assert ar.get_detailed_results(success=(False,), fail_stages=("REQUIREMENTS",)) == [
+    assert ar.query(success=(False,), fail_stages=("REQUIREMENTS",)) == [
         REQUIREMENTS_FAIL,
     ]
 

--- a/tests/unit/test_core/test_activation/test_activationresult.py
+++ b/tests/unit/test_core/test_activation/test_activationresult.py
@@ -63,7 +63,7 @@ METHODACTIVATIONRESULTS_3_FAIL = [
 ]
 
 
-def test_activation_result_get_details():
+def test_activation_result_list_methods():
     ar = ActivationResult()
     ar._results = [
         PLATFORM_SUPPORT_FAIL,
@@ -72,23 +72,23 @@ def test_activation_result_get_details():
         UNUSED_RESULT,
     ]
 
-    # By default, the get_details drops out failures occuring in the
+    # By default, the list_methods drops out failures occuring in the
     # platform stage
-    assert ar.get_details() == [
+    assert ar.list_methods() == [
         REQUIREMENTS_FAIL,
         SUCCESS_RESULT,
         UNUSED_RESULT,
     ]
 
     # The same as above but with explicit arguments.
-    assert ar.get_details(ignore_platform_fails=True) == [
+    assert ar.list_methods(ignore_platform_fails=True) == [
         REQUIREMENTS_FAIL,
         SUCCESS_RESULT,
         UNUSED_RESULT,
     ]
 
     # Do not ignore platform fails
-    assert ar.get_details(ignore_platform_fails=False) == [
+    assert ar.list_methods(ignore_platform_fails=False) == [
         PLATFORM_SUPPORT_FAIL,
         REQUIREMENTS_FAIL,
         SUCCESS_RESULT,
@@ -96,7 +96,7 @@ def test_activation_result_get_details():
     ]
 
     # ignore unused
-    assert ar.get_details(ignore_platform_fails=False, ignore_unused=True) == [
+    assert ar.list_methods(ignore_platform_fails=False, ignore_unused=True) == [
         PLATFORM_SUPPORT_FAIL,
         REQUIREMENTS_FAIL,
         SUCCESS_RESULT,

--- a/wakepy/core/activation.py
+++ b/wakepy/core/activation.py
@@ -76,8 +76,8 @@ class ActivationResult:
     -------
     get_details:
         Get details of the activation results. This is the higher-level
-        interface. If you want more control, use .get_detailed_results().
-    get_detailed_results:
+        interface. If you want more control, use .query().
+    query:
         Lower-level interface for getting details of the activation results.
         If you want easier access, use .get_details().
     """
@@ -138,7 +138,7 @@ class ActivationResult:
         ignore_unused: bool = False,
     ) -> list[MethodActivationResult]:
         """Get details of the activation results. This is the higher-level
-        interface. If you want more control, use .get_detailed_results().
+        interface. If you want more control, use .query().
 
         Parameters
         ----------
@@ -156,11 +156,9 @@ class ActivationResult:
         if not ignore_platform_fails:
             fail_stages.insert(0, StageName.PLATFORM_SUPPORT)
 
-        return self.get_detailed_results(
-            success=success_values, fail_stages=fail_stages
-        )
+        return self.query(success=success_values, fail_stages=fail_stages)
 
-    def get_detailed_results(
+    def query(
         self,
         success: Sequence[bool | None] = (True, False, None),
         fail_stages: Sequence[StageName] = (

--- a/wakepy/core/activation.py
+++ b/wakepy/core/activation.py
@@ -74,12 +74,12 @@ class ActivationResult:
 
     Methods
     -------
-    get_details:
+    list_methods:
         Get details of the activation results. This is the higher-level
         interface. If you want more control, use .query().
     query:
         Lower-level interface for getting details of the activation results.
-        If you want easier access, use .get_details().
+        If you want easier access, use .list_methods().
     """
 
     def __init__(self, results: Optional[List[MethodActivationResult]] = None):
@@ -132,13 +132,14 @@ class ActivationResult:
                 f"Active methods: {methods}"
             )
 
-    def get_details(
+    def list_methods(
         self,
         ignore_platform_fails: bool = True,
         ignore_unused: bool = False,
     ) -> list[MethodActivationResult]:
-        """Get details of the activation results. This is the higher-level
-        interface. If you want more control, use .query().
+        """Get a list of the methods in present in the activation process, and
+        their activation results. This is the higher-level interface. If you
+        want more control, use .query().
 
         Parameters
         ----------
@@ -168,7 +169,7 @@ class ActivationResult:
         ),
     ) -> list[MethodActivationResult]:
         """Get details of the activation results. This is the lower-level
-        interface. If you want easier access, use .get_details().
+        interface. If you want easier access, use .list_methods().
 
         Parameters
         ----------

--- a/wakepy/core/activation.py
+++ b/wakepy/core/activation.py
@@ -75,11 +75,13 @@ class ActivationResult:
     Methods
     -------
     list_methods:
-        Get details of the activation results. This is the higher-level
-        interface. If you want more control, use .query().
+        Get a list of the methods present in the activation process, and their
+        activation results. This is the higher-level interface. If you want
+        more control, use .query().
     query:
-        Lower-level interface for getting details of the activation results.
-        If you want easier access, use .list_methods().
+        Lower level interface for getting the list of the methods present in
+        the activation process, and their activation results. If you want
+        easier access, use .list_methods().
     """
 
     def __init__(self, results: Optional[List[MethodActivationResult]] = None):
@@ -137,7 +139,7 @@ class ActivationResult:
         ignore_platform_fails: bool = True,
         ignore_unused: bool = False,
     ) -> list[MethodActivationResult]:
-        """Get a list of the methods in present in the activation process, and
+        """Get a list of the methods present in the activation process, and
         their activation results. This is the higher-level interface. If you
         want more control, use .query().
 
@@ -168,8 +170,9 @@ class ActivationResult:
             StageName.ACTIVATION,
         ),
     ) -> list[MethodActivationResult]:
-        """Get details of the activation results. This is the lower-level
-        interface. If you want easier access, use .list_methods().
+        """Get a list of the methods present in the activation process, and
+        their activation results. This is the lower-level interface. If you
+        want easier access, use .list_methods().
 
         Parameters
         ----------

--- a/wakepy/core/activation.py
+++ b/wakepy/core/activation.py
@@ -53,14 +53,9 @@ class StageName(StrEnum):
 
 
 class ActivationResult:
-    """The result returned by activating a mode, i.e. the `x` in
-    `with mode as x: ...`.
-
-    The ActivationResult is responsible of keeping track on successful and
-    failed methods and providing different views on the results of the
-    activation process. All results are lazily loaded; if you access any of the
-    ActivationResult attributes, you will have to wait until the results
-    are ready.
+    """The ActivationResult is responsible of keeping track on the possibly
+    successful (max 1), failed and unused methods and providing different views
+    on the results of the activation process.
 
     Attributes
     ----------
@@ -73,11 +68,8 @@ class ActivationResult:
         may not faked with WAKEPY_FAKE_SUCCESS environment variable.
     failure: bool
         Always opposite of `success`. Included for convenience.
-    active_methods: list[str]
-        List of the names of all the successful (active) methods.
-    active_methods_string: str
-        A single string containing the names of all the successful (active)
-        methods.
+    active_method: str | None
+        The name of the the active (successful) method, if any.
 
 
     Methods
@@ -126,23 +118,19 @@ class ActivationResult:
         return not self.success
 
     @property
-    def active_methods(self) -> list[str]:
-        """List of the names of all the successful (active) methods"""
-        return [res.method_name for res in self._results if res.success]
-
-    @property
-    def active_methods_string(self) -> str:
-        """A single string containing the names of all the successful (active)
-        methods. For example:
-
-        if `active_methods` is ['fist-method', 'SecondMethod',
-        'some.third.Method'], the `active_methods_string` will be:
-        'fist-method, SecondMethod & some.third.Method'
-        """
-        active_methods = self.active_methods
-        if len(active_methods) == 1:
-            return active_methods[0]
-        return ", ".join(active_methods[:-1]) + f" & {active_methods[-1]}"
+    def active_method(self) -> str | None:
+        """The name of the active (successful) method. If no methods are
+        active, this is None."""
+        methods = [res.method_name for res in self._results if res.success]
+        if not methods:
+            return None
+        elif len(methods) == 1:
+            return methods[0]
+        else:
+            raise ValueError(
+                "The ActivationResult cannot have more than one active methods! "
+                f"Active methods: {methods}"
+            )
 
     def get_details(
         self,


### PR DESCRIPTION
Only one method may be active at any given time.

Remove .active_methods and .active_methods_string attributes and add
.active_method (str) attribute.
    
Rename two methods:
get_detailed_results() -> query()
get_details() -> list_methods()