### PR TITLE
Issue 149: Add WakepyFakeSuccess

### DIFF
--- a/tests/unit/test_core/test_activation/test_activation.py
+++ b/tests/unit/test_core/test_activation/test_activation.py
@@ -3,10 +3,10 @@
 Exception: ActivationResult is tested in it's own file
 """
 
-from contextlib import contextmanager
 import datetime as dt
 import os
 import re
+from contextlib import contextmanager
 from unittest.mock import Mock
 
 import pytest
@@ -114,7 +114,7 @@ def _arrange_for_test_activate(monkeypatch):
         try:
             assert method.enter_mode() is None
             success = True
-        except:
+        except Exception:
             success = False
 
         return (
@@ -610,7 +610,7 @@ def test_wakepy_fake_success_without_the_env_var_set(monkeypatch):
     if "WAKEPY_FAKE_SUCCESS" in os.environ:
         monkeypatch.delenv("WAKEPY_FAKE_SUCCESS")
 
-    with pytest.raises(RuntimeError, match=f"WAKEPY_FAKE_SUCCESS not set"):
+    with pytest.raises(RuntimeError, match="WAKEPY_FAKE_SUCCESS not set"):
         method.enter_mode()
 
 

--- a/tests/unit/test_core/test_activation/test_activation.py
+++ b/tests/unit/test_core/test_activation/test_activation.py
@@ -3,6 +3,7 @@
 Exception: ActivationResult is tested in it's own file
 """
 
+from contextlib import contextmanager
 import datetime as dt
 import os
 import re
@@ -52,7 +53,7 @@ def test_activate_function_success(monkeypatch):
     # Arrange
     mocks = _arrange_for_test_activate(monkeypatch)
     methodcls_fail = get_test_method_class(enter_mode=False)
-    methodcls_success = get_test_method_class(enter_mode=True)
+    methodcls_success = get_test_method_class(enter_mode=None)
 
     # Act
     # Note: prioritize the failing first, so that the failing one will also be
@@ -110,7 +111,12 @@ def _arrange_for_test_activate(monkeypatch):
     mocks.call_processor = Mock(spec_set=CallProcessor)
 
     def fake_activate_method(method):
-        success = method.enter_mode()
+        try:
+            assert method.enter_mode() is None
+            success = True
+        except:
+            success = False
+
         return (
             MethodActivationResult(
                 method_name=method.name,
@@ -580,24 +586,38 @@ def test_stagename():
     assert StageName.REQUIREMENTS == "REQUIREMENTS"
 
 
-def test_wakepy_fake_success(monkeypatch):
+# These are the only "falsy" values for WAKEPY_FAKE_SUCCESS
+@pytest.mark.parametrize("val", ("0", "no", "NO", "False", "false", "FALSE"))
+def test_wakepy_fake_success_falsy_values(val, monkeypatch):
     method = WakepyFakeSuccess()
 
-    # These are the only "falsy" values for WAKEPY_FAKE_SUCCESS
-    for val in ("0", "no", "NO", "False", "false", "FALSE"):
-        with monkeypatch.context() as mp:
-            mp.setenv("WAKEPY_FAKE_SUCCESS", val)
-            val_from_env = os.environ.get("WAKEPY_FAKE_SUCCESS")
-            assert val_from_env == str(val)
-            assert method.enter_mode() is False
-    # Anything else is considered truthy
-    for val in ("1", "yes", "True", "anystring"):
-        with monkeypatch.context() as mp:
-            mp.setenv("WAKEPY_FAKE_SUCCESS", val)
-            val_from_env = os.environ.get("WAKEPY_FAKE_SUCCESS")
-            assert val_from_env == str(val)
-            assert method.enter_mode() is True
+    with wakepy_fake_value_set(monkeypatch, val), pytest.raises(
+        RuntimeError, match=f"WAKEPY_FAKE_SUCCESS set to falsy value: {val}"
+    ):
+        method.enter_mode()
 
+
+@pytest.mark.parametrize("val", ("1", "yes", "True", "anystring"))
+def test_wakepy_fake_success_truthy_values(val, monkeypatch):
+    method = WakepyFakeSuccess()
+
+    with wakepy_fake_value_set(monkeypatch, val):
+        assert method.enter_mode() is None
+
+
+def test_wakepy_fake_success_without_the_env_var_set(monkeypatch):
+    method = WakepyFakeSuccess()
     if "WAKEPY_FAKE_SUCCESS" in os.environ:
         monkeypatch.delenv("WAKEPY_FAKE_SUCCESS")
-    assert method.enter_mode() is False
+
+    with pytest.raises(RuntimeError, match=f"WAKEPY_FAKE_SUCCESS not set"):
+        method.enter_mode()
+
+
+@contextmanager
+def wakepy_fake_value_set(monkeypatch, val):
+    with monkeypatch.context() as mp:
+        mp.setenv("WAKEPY_FAKE_SUCCESS", val)
+        val_from_env = os.environ.get("WAKEPY_FAKE_SUCCESS")
+        assert val_from_env == str(val)
+        yield

--- a/tests/unit/test_core/test_activation/test_activation.py
+++ b/tests/unit/test_core/test_activation/test_activation.py
@@ -22,13 +22,13 @@ from testmethods import (
 from wakepy.core import MethodActivationResult
 from wakepy.core.activation import (
     StageName,
+    WakepyFakeSuccess,
     activate_method,
     activate_one_of_multiple,
     caniuse_fails,
     deactivate_method,
     get_platform_supported,
     try_enter_and_heartbeat,
-    WakepyFakeSuccess,
 )
 from wakepy.core.calls import CallProcessor
 from wakepy.core.heartbeat import Heartbeat

--- a/tests/unit/test_core/test_activation/test_activation.py
+++ b/tests/unit/test_core/test_activation/test_activation.py
@@ -27,8 +27,8 @@ from wakepy.core.activation import (
     caniuse_fails,
     deactivate_method,
     get_platform_supported,
-    should_fake_success,
     try_enter_and_heartbeat,
+    WakepyFakeSuccess,
 )
 from wakepy.core.calls import CallProcessor
 from wakepy.core.heartbeat import Heartbeat
@@ -580,22 +580,24 @@ def test_stagename():
     assert StageName.REQUIREMENTS == "REQUIREMENTS"
 
 
-def test_should_fake_success(monkeypatch):
+def test_wakepy_fake_success(monkeypatch):
+    method = WakepyFakeSuccess()
+
     # These are the only "falsy" values for WAKEPY_FAKE_SUCCESS
     for val in ("0", "no", "NO", "False", "false", "FALSE"):
         with monkeypatch.context() as mp:
             mp.setenv("WAKEPY_FAKE_SUCCESS", val)
             val_from_env = os.environ.get("WAKEPY_FAKE_SUCCESS")
             assert val_from_env == str(val)
-            assert should_fake_success() is False
+            assert method.enter_mode() is False
     # Anything else is considered truthy
     for val in ("1", "yes", "True", "anystring"):
         with monkeypatch.context() as mp:
             mp.setenv("WAKEPY_FAKE_SUCCESS", val)
             val_from_env = os.environ.get("WAKEPY_FAKE_SUCCESS")
             assert val_from_env == str(val)
-            assert should_fake_success() is True
+            assert method.enter_mode() is True
 
     if "WAKEPY_FAKE_SUCCESS" in os.environ:
         monkeypatch.delenv("WAKEPY_FAKE_SUCCESS")
-    assert should_fake_success() is False
+    assert method.enter_mode() is False

--- a/tests/unit/test_core/test_activation/test_activationresult.py
+++ b/tests/unit/test_core/test_activation/test_activationresult.py
@@ -2,7 +2,7 @@ import re
 import pytest
 
 from wakepy.core import ActivationResult, MethodActivationResult
-from wakepy.core.activation import StageName
+from wakepy.core.activation import StageName, WakepyFakeSuccess
 
 PLATFORM_SUPPORT_FAIL = MethodActivationResult(
     success=False,
@@ -24,6 +24,18 @@ UNUSED_RESULT = MethodActivationResult(
     success=None,
     method_name="some-unused-method",
 )
+
+WAKEPY_FAKE_NOTINUSE = MethodActivationResult(
+    success=False,
+    failure_stage=StageName.ACTIVATION,
+    method_name=WakepyFakeSuccess.name,
+)
+WAKEPY_FAKE_SUCCESS = MethodActivationResult(
+    success=True,
+    failure_stage=StageName.ACTIVATION,
+    method_name=WakepyFakeSuccess.name,
+)
+
 METHODACTIVATIONRESULTS_1 = [
     PLATFORM_SUPPORT_FAIL,
     REQUIREMENTS_FAIL,
@@ -64,14 +76,14 @@ METHODACTIVATIONRESULTS_3_FAIL = [
 
 
 def test_activation_result_list_methods():
-    ar = ActivationResult()
-    ar._results = [
-        PLATFORM_SUPPORT_FAIL,
-        REQUIREMENTS_FAIL,
-        SUCCESS_RESULT,
-        UNUSED_RESULT,
-    ]
-
+    ar = ActivationResult(
+        [
+            PLATFORM_SUPPORT_FAIL,
+            REQUIREMENTS_FAIL,
+            SUCCESS_RESULT,
+            UNUSED_RESULT,
+        ]
+    )
     # By default, the list_methods drops out failures occuring in the
     # platform stage
     assert ar.list_methods() == [
@@ -104,13 +116,14 @@ def test_activation_result_list_methods():
 
 
 def test_activation_result_query():
-    ar = ActivationResult()
-    ar._results = [
-        PLATFORM_SUPPORT_FAIL,
-        REQUIREMENTS_FAIL,
-        SUCCESS_RESULT,
-        UNUSED_RESULT,
-    ]
+    ar = ActivationResult(
+        [
+            PLATFORM_SUPPORT_FAIL,
+            REQUIREMENTS_FAIL,
+            SUCCESS_RESULT,
+            UNUSED_RESULT,
+        ]
+    )
 
     # When no arguments given, return everything
     assert ar.query() == [
@@ -140,21 +153,21 @@ def test_activation_result_query():
 
 
 @pytest.mark.parametrize(
-    "results, success_expected, real_success_expected, faking_success",
+    "results, success_expected, real_success_expected",
     [
-        (METHODACTIVATIONRESULTS_1, True, True, "0"),
-        (METHODACTIVATIONRESULTS_2, True, True, "0"),
-        (METHODACTIVATIONRESULTS_3_FAIL, False, False, "0"),
-        (METHODACTIVATIONRESULTS_3_FAIL, True, False, "1"),
+        (METHODACTIVATIONRESULTS_1, True, True),
+        (METHODACTIVATIONRESULTS_2, True, True),
+        (METHODACTIVATIONRESULTS_3_FAIL + [WAKEPY_FAKE_NOTINUSE], False, False),
+        (METHODACTIVATIONRESULTS_3_FAIL + [WAKEPY_FAKE_SUCCESS], True, False),
     ],
 )
 def test_activation_result_success(
-    results, success_expected, real_success_expected, faking_success
+    results,
+    success_expected,
+    real_success_expected,
 ):
-    with pytest.MonkeyPatch.context() as mp:
-        mp.setenv("WAKEPY_FAKE_SUCCESS", str(faking_success))
-        ar = ActivationResult()
-        ar._results = results
+    with pytest.MonkeyPatch.context():
+        ar = ActivationResult(results)
 
         assert ar.success == success_expected
         assert ar.real_success == real_success_expected

--- a/tests/unit/test_core/test_activation/test_activationresult.py
+++ b/tests/unit/test_core/test_activation/test_activationresult.py
@@ -1,4 +1,5 @@
 import re
+
 import pytest
 
 from wakepy.core import ActivationResult, MethodActivationResult
@@ -189,7 +190,9 @@ def test_active_method_with_multiple_success():
     with pytest.raises(
         ValueError,
         match=re.escape(
-            "The ActivationResult cannot have more than one active methods! Active methods: ['1st.successfull.method', '2nd-successful-method', 'last-successful-method']"
+            "The ActivationResult cannot have more than one active methods! Active "
+            "methods: ['1st.successfull.method', '2nd-successful-method', "
+            "'last-successful-method']"
         ),
     ):
         ar.active_method

--- a/tests/unit/test_core/test_mode.py
+++ b/tests/unit/test_core/test_mode.py
@@ -168,7 +168,11 @@ def _assert_context_manager_used_correctly(mocks):
     ]
 
 
-def test_modecontroller():
+def test_modecontroller(monkeypatch):
+    # Disable fake success here, because we want to use method_cls for the
+    # activation (and not WakepyFakeSuccess)
+    monkeypatch.setenv("WAKEPY_FAKE_SUCCESS", "0")
+
     method_cls = get_test_method_class(enter_mode=None, heartbeat=None, exit_mode=None)
     controller = ModeController(Mock(spec_set=CallProcessor))
 

--- a/tests/unit/test_modes.py
+++ b/tests/unit/test_modes.py
@@ -75,7 +75,7 @@ def test_keep_running_mode_creation(input_args, monkeypatch):
     assert mode._dbus_adapter_cls == MyDbusAdapter
 
 
-def test_keep_running(monkeypatch, fake_dbus_adapter):
+def test_keep_running_with_fake_success(monkeypatch, fake_dbus_adapter):
     """Simple smoke test for keep.running()"""
     monkeypatch.setenv("WAKEPY_FAKE_SUCCESS", "1")
     mode = keep.running(dbus_adapter=fake_dbus_adapter)
@@ -90,7 +90,7 @@ def test_keep_running(monkeypatch, fake_dbus_adapter):
     assert isinstance(m.activation_result, ActivationResult)
 
 
-def test_keep_running(monkeypatch, fake_dbus_adapter):
+def test_keep_running_without_fake_success(monkeypatch, fake_dbus_adapter):
     """Simple smoke test for keep.running()"""
     monkeypatch.setenv("WAKEPY_FAKE_SUCCESS", "0")
     # This we expect to fail as the only adapter is the fake_dbus_adapter

--- a/wakepy/core/activation.py
+++ b/wakepy/core/activation.py
@@ -232,6 +232,9 @@ def activate_one_of_multiple(
     Method which succeeds activation will be used, in order from highest
     priority to lowest priority.
 
+    The activation may be faked as to be successful by using the
+    WAKEPY_FAKE_SUCCESS environment variable.
+
     Parameters
     ----------
     methods:
@@ -253,6 +256,9 @@ def activate_one_of_multiple(
         return ActivationResult(), None, None
 
     prioritized_methods = get_prioritized_methods(methods, methods_priority)
+    # The fake method is always checked first (WAKEPY_FAKE_SUCCESS)
+    prioritized_methods.insert(0, WakepyFakeSuccess)
+
     results = []
 
     for methodcls in prioritized_methods:

--- a/wakepy/core/activation.py
+++ b/wakepy/core/activation.py
@@ -794,7 +794,11 @@ class WakepyFakeSuccess(Method):
     """
 
     name = "WAKEPY_FAKE_SUCCESS"
-    _env_var = name
+    environment_variable = name
+
+    # All other values are considered to be truthy. Comparison is case
+    # insensitive
+    falsy_values = ("0", "no", "false")
 
     def enter_mode(self) -> bool:
         """Function which says if fake success should be enabled
@@ -817,7 +821,7 @@ class WakepyFakeSuccess(Method):
         # import until here.
         import os
 
-        if self._env_var not in os.environ:
+        if self.environment_variable not in os.environ:
             return False
 
-        return os.environ[self._env_var].lower() in ("0", "no", "false")
+        return os.environ[self.environment_variable].lower() not in self.falsy_values

--- a/wakepy/core/activation.py
+++ b/wakepy/core/activation.py
@@ -771,29 +771,3 @@ def _rollback_with_exit(method):
             f"Entered {method.__class__.__name__} ({method.name}) but could not exit!"
             + f" Original error: {str(exc)}"
         ) from exc
-
-
-def should_fake_success() -> bool:
-    """Function which says if fake success should be enabled
-
-    Fake success is controlled via WAKEPY_FAKE_SUCCESS environment variable.
-    If that variable is set to a truthy value,fake success is activated.
-
-    Falsy values: '0', 'no', 'false' (case ignored)
-    Truthy values: everything else
-
-    Motivation:
-    -----------
-    When running on CI system, wakepy might fail to acquire an inhibitor lock
-    just because there is no Desktop Environment running. In these cases, it
-    might be useful to just tell with an environment variable that wakepy
-    should fake the successful inhibition anyway. Faking the success is done
-    after every other method is tried (and failed).
-    """
-    if "WAKEPY_FAKE_SUCCESS" not in os.environ:
-        return False
-
-    val_from_env = os.environ["WAKEPY_FAKE_SUCCESS"].lower()
-    if val_from_env in ("0", "no", "false"):
-        return False
-    return True

--- a/wakepy/core/activation.py
+++ b/wakepy/core/activation.py
@@ -820,7 +820,4 @@ class WakepyFakeSuccess(Method):
         if self._env_var not in os.environ:
             return False
 
-        val_from_env = os.environ[self._env_var].lower()
-        if val_from_env in ("0", "no", "false"):
-            return False
-        return True
+        return os.environ[self._env_var].lower() in ("0", "no", "false")

--- a/wakepy/core/activation.py
+++ b/wakepy/core/activation.py
@@ -101,7 +101,7 @@ class ActivationResult:
         may not faked with WAKEPY_FAKE_SUCCESS environment variable.
         """
         for res in self._results:
-            if res.success:
+            if res.success and res.method_name != WakepyFakeSuccess.name:
                 return True
         return False
 
@@ -111,9 +111,11 @@ class ActivationResult:
 
         Note that this may be faked with WAKEPY_FAKE_SUCCESS environment
         variable (for tests). See also: real_success.
-
         """
-        return self.real_success or should_fake_success()
+        for res in self._results:
+            if res.success:
+                return True
+        return False
 
     @property
     def failure(self) -> bool:
@@ -190,7 +192,12 @@ class ActivationResult:
         for res in self._results:
             if res.success not in success:
                 continue
-            if res.success is False and res.failure_stage not in fail_stages:
+            elif res.success is False and res.failure_stage not in fail_stages:
+                continue
+            elif res.success is False and res.method_name == WakepyFakeSuccess.name:
+                # The fake method is only listed if it was requested to be,
+                # used, and when it is not requested to be used, the
+                # res.success is False.
                 continue
             out.append(res)
 

--- a/wakepy/core/activation.py
+++ b/wakepy/core/activation.py
@@ -800,7 +800,9 @@ class WakepyFakeSuccess(Method):
     # insensitive
     falsy_values = ("0", "no", "false")
 
-    def enter_mode(self) -> bool:
+    supported_platforms = (CURRENT_PLATFORM,)
+
+    def enter_mode(self):
         """Function which says if fake success should be enabled
 
         Fake success is controlled via WAKEPY_FAKE_SUCCESS environment variable.
@@ -822,6 +824,10 @@ class WakepyFakeSuccess(Method):
         import os
 
         if self.environment_variable not in os.environ:
-            return False
+            raise RuntimeError(f"{self.environment_variable} not set.")
 
-        return os.environ[self.environment_variable].lower() not in self.falsy_values
+        val = os.environ[self.environment_variable]
+        if val.lower() in self.falsy_values:
+            raise RuntimeError(
+                f"{self.environment_variable} set to falsy value: {val}."
+            )

--- a/wakepy/core/activation.py
+++ b/wakepy/core/activation.py
@@ -93,14 +93,18 @@ class ActivationResult:
             The MethodActivationResults to be used to fill the ActivationResult
 
         """
-        self._results: list[MethodActivationResult] = results or []
+
+        # These are the retuls for each of the used wakepy.Methods, in the
+        # order the methods were tried (first = highest priority, last =
+        # lowest priority)
+        self._method_results: list[MethodActivationResult] = results or []
 
     @property
     def real_success(self) -> bool:
         """Tells is entering into a mode was successful. This
         may not faked with WAKEPY_FAKE_SUCCESS environment variable.
         """
-        for res in self._results:
+        for res in self._method_results:
             if res.success and res.method_name != WakepyFakeSuccess.name:
                 return True
         return False
@@ -112,7 +116,7 @@ class ActivationResult:
         Note that this may be faked with WAKEPY_FAKE_SUCCESS environment
         variable (for tests). See also: real_success.
         """
-        for res in self._results:
+        for res in self._method_results:
             if res.success:
                 return True
         return False
@@ -126,7 +130,7 @@ class ActivationResult:
     def active_method(self) -> str | None:
         """The name of the active (successful) method. If no methods are
         active, this is None."""
-        methods = [res.method_name for res in self._results if res.success]
+        methods = [res.method_name for res in self._method_results if res.success]
         if not methods:
             return None
         elif len(methods) == 1:
@@ -189,7 +193,7 @@ class ActivationResult:
             "PLATFORM_SUPPORT", "REQUIREMENTS" and "ACTIVATION".
         """
         out = []
-        for res in self._results:
+        for res in self._method_results:
             if res.success not in success:
                 continue
             elif res.success is False and res.failure_stage not in fail_stages:

--- a/wakepy/core/activation.py
+++ b/wakepy/core/activation.py
@@ -790,11 +790,11 @@ def _rollback_with_exit(method):
 
 
 class WakepyFakeSuccess(Method):
-    """This is a special fake method for any methods. It can be used in tests
-    for faking wakepy mode entry. This way all IO and real excutable, library
-    and dbus calls are prevented. To make this method active, set
-    WAKEPY_FAKE_SUCCESS environment variable to a truthy value (e.g. "1", or
-    "True").
+    """This is a special fake method to be used with any mode. It can be used
+    in tests for faking wakepy mode activation. This way all IO and real
+    executable, library and dbus calls are prevented. To use this method (and
+    skip using any other methods), set WAKEPY_FAKE_SUCCESS environment variable
+    to a truthy value (e.g. "1", or "True").
     """
 
     name = "WAKEPY_FAKE_SUCCESS"


### PR DESCRIPTION
Change how WAKEPY_FAKE_SUCCESS works

1) Remove the old should_fake_success() function
2) Add a new wakepy.Method: WakepyFakeSuccess, which is used if the
  WAKEPY_FAKE_SUCCESS environment variable is set to a truthy value.
3) Update ActivationResult for the change. The "WAKEPY_FAKE_SUCCESS"
  method is snown in the .list_methods() and .query() outputs if the
  WAKEPY_FAKE_SUCCESS was used, but not shown if it was not used. 