### PR TITLE
Issue 157: Fix D-Bus adapter tests in GitHub Actions

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -26,8 +26,11 @@ def private_bus():
 
     $ ps -x | grep dbus-daemon | grep -v grep | grep dbus-daemon
 
-    It is listed as `PrivateSessionBus._start_cmd`  (e.g. "dbus-daemon
-    --session --print-address")
+    It is listed as something like
+
+        11150 pts/0    S      0:00 dbus-daemon --session --print-address
+
+    (includes the _start_cmd which is defined below)
     """
 
     _start_cmd = "dbus-daemon --session --print-address"

--- a/tests/integration/dbus_service.py
+++ b/tests/integration/dbus_service.py
@@ -188,6 +188,9 @@ def start_dbus_service(
     assert queue_.get(timeout=2) == "ready"
     logger.info(f"Initialization of {service_cls.addr.service} ready")
 
+    import time
+
+    time.sleep(60)
     yield
 
     should_stop = True

--- a/tests/integration/dbus_service.py
+++ b/tests/integration/dbus_service.py
@@ -188,9 +188,6 @@ def start_dbus_service(
     assert queue_.get(timeout=2) == "ready"
     logger.info(f"Initialization of {service_cls.addr.service} ready")
 
-    import time
-
-    time.sleep(60)
     yield
 
     should_stop = True

--- a/tests/integration/dbus_service.py
+++ b/tests/integration/dbus_service.py
@@ -146,8 +146,17 @@ class DbusService:
         """
 
 
-def start_dbus_service(service_cls: Type[DbusService]):
-    """Start a Dbus Service in a separate thread."""
+def start_dbus_service(
+    service_cls: Type[DbusService], bus_address: Optional[str] = None
+):
+    """Start a Dbus Service in a separate thread.
+
+    Parameters
+    ----------
+    bus_address:
+        If given, should be an address of a bus from dbus-daemon
+        --print-address. If not given, uses the service_cls.addr.bus.
+    """
 
     queue_ = queue.Queue()
     should_stop = False
@@ -157,7 +166,7 @@ def start_dbus_service(service_cls: Type[DbusService]):
     ):
         logger.info(f"Launching dbus service: {service.addr.service}")
 
-        service_ = service(service.addr.bus, queue_, stop=should_stop)
+        service_ = service(bus_address or service.addr.bus, queue_, stop=should_stop)
         service_.start(
             server_name=service.addr.service,
             object_path=service.addr.path,

--- a/tests/integration/test_dbus_adapters.py
+++ b/tests/integration/test_dbus_adapters.py
@@ -84,11 +84,11 @@ def test_jeepney_dbus_adapter_nonexisting_method(calculator_service_addr):
 
 
 @pytest.mark.usefixtures("dbus_calculator_service")
-def test_jeepney_dbus_adapter_wrong_service_definition():
+def test_jeepney_dbus_adapter_wrong_service_definition(private_bus: str):
     adapter = JeepneyDbusAdapter()
 
     wrong_service_addr = DbusAddress(
-        bus=BusType.SESSION,
+        bus=private_bus,
         service="org.github.wakepy.WrongService",
         path="/org/github/wakepy/TestCalculatorService",
         interface="org.github.wakepy.TestCalculatorService",


### PR DESCRIPTION
Initiates a private session bus and uses that for the integration tests.

Few reasons for this:
- In GitHub Actions, Ubuntu 22.04.3 the session bus is there, but the
  address is not available in DBUS_SESSION_BUS_ADDRESS. That is a bit
  problematic. 
- One option could have been to create a private bus and set
  os.environ['DBUS_SESSION_BUS_ADDRESS'] to that bus, but there might be
  other strategies python dbus libraries other than jeepney use for
  getting the session dbus address, so making also the DbusMethodCalls
  to expect service in the private bus (not the default "SESSION" bus),
  is a bit more robust.
- Another option would have been to try to dig out the session bus
  address from the running dbus-daemon process in the Ubuntu 22.04.03
  instance, and set DBUS_SESSION_BUS_ADDRESS to that, but that would be
  perhaps a bit more involved task. In addition, not all GitHub Actions
  instances have the dbus-daemon running as session bus (for example,
  the Ubuntu 20.04), so we would had to create a new bus anyway with
  dbus-daemon.