### PR TITLE
Issue 158: Add Python 3.12 & 3.13-alpha.2 tests to GitHub actions

### DIFF
--- a/.github/workflows/tests-linux.yml
+++ b/.github/workflows/tests-linux.yml
@@ -19,7 +19,7 @@ jobs:
       PYTHON_VERSION: '3.10'
       PYTHON_EXECUTABLE: 'python3.10'
       PYTHON_TOX_ENVS: 'py310, check'
-    steps:
+    steps: &job-steps
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install python 
@@ -42,60 +42,17 @@ jobs:
       - name: Run tests with tox
         run: tox -e ${{ env.PYTHON_TOX_ENVS }} 
   test-linux-py37:
-    runs-on: ubuntu-20.04
+    # List of available versions: https://github.com/actions/python-versions/blob/main/versions-manifest.json
     env:
       PYTHON_VERSION: '3.7'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      # Install python 3.7
-      # Ubuntu 22.04 comes with Python 3.10.6 and Ubuntu 20.04 comes with 3.8.10
-      # Ubuntu 20.04 has 3.5, 3.6 and 3.7 as an option.
-      # List of available versions: https://github.com/actions/python-versions/blob/main/versions-manifest.json
-      - name: Install python 
-        uses: actions/setup-python@v4 
-        with:
-          python-version: ${{ env.PYTHON_VERSION }} 
-      - name: Show OS version
-        run: cat /etc/os-release
-      - run: printenv
-      - name: Check D-Bus
-        run: ps -ef | grep dbus | grep -v grep
-      - name: Show python version
-        run: python --version
-      - name: Show platform information
-        run: python -c "import platform; print(platform.platform())"
-      - name: install tox
-        run: |
-          python3.7 -m pip install -U pip wheel && \
-          python3.7 -m pip install tox~=4.6.0
-      - name: Run tests with tox
-        run: tox -e py37
+      PYTHON_EXECUTABLE: 'python3.7'
+      PYTHON_TOX_ENVS: 'py37'
+    steps: *job-steps
   test-linux-py312:
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      # Install python 3.12
-      # List of available versions: https://github.com/actions/python-versions/blob/main/versions-manifest.json
-      - name: Install python 
-        uses: actions/setup-python@v4 
-        with:
-          python-version: '3.12' 
-      - name: Show OS version
-        run: cat /etc/os-release
-      - run: printenv
-      - name: Check D-Bus
-        run: ps -ef | grep dbus | grep -v grep
-      - name: Show python version
-        run: python --version
-      - name: Show platform information
-        run: python -c "import platform; print(platform.platform())"
-      - name: install tox
-        run: |
-          python3.12 -m pip install -U pip wheel && \
-          python3.12 -m pip install tox~=4.6.0
-      - name: Run tests with tox
-        run: tox -e py312
+    env:
+      PYTHON_VERSION: '3.12'
+      PYTHON_EXECUTABLE: 'python3.12'
+      PYTHON_TOX_ENVS: 'py312'
+    steps: *job-steps
 
-    
+      

--- a/.github/workflows/tests-linux.yml
+++ b/.github/workflows/tests-linux.yml
@@ -16,8 +16,9 @@ jobs:
   test-linux-py310:
     runs-on: ubuntu-22.04
     env:
-      PYTHON_VERSION: '3.11'
-      PYTHON_EXECUTABLE: 'python3.11'
+      PYTHON_VERSION: '3.10'
+      PYTHON_TOX_ENVs: 'py310, check'
+      PYTHON_EXECUTABLE: 'python3.10'
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/tests-linux.yml
+++ b/.github/workflows/tests-linux.yml
@@ -1,7 +1,7 @@
 name: Run tests (Linux)
 
 # Manual start only. Trying the save some minutes :) 
-on:  
+'on':  
   [workflow_dispatch]
 
 # Cancel in-progress jobs/runs for the same workflow; if you push to same
@@ -49,7 +49,27 @@ jobs:
       PYTHON_EXECUTABLE: 'python3.7'
       PYTHON_TOX_ENVS: 'py37'
     steps: 
-      - *job-steps
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install python 
+        uses: actions/setup-python@v4 
+        with:
+          python-version: ${{ env.PYTHON_VERSION }} 
+      - name: Show OS version
+        run: cat /etc/os-release
+      - run: printenv
+      - name: Check D-Bus
+        run: ps -ef | grep dbus | grep -v grep
+      - name: Show python version
+        run: python --version
+      - name: Show platform information
+        run: python -c "import platform; print(platform.platform())"
+      - name: install tox
+        run: |
+          ${{ env.PYTHON_EXECUTABLE }} -m pip install -U pip wheel && \
+          ${{ env.PYTHON_EXECUTABLE }} -m pip install tox~=4.6.0
+      - name: Run tests with tox
+        run: tox -e ${{ env.PYTHON_TOX_ENVS }} 
   test-linux-py312:
     runs-on: ubuntu-22.04
     env:
@@ -57,6 +77,26 @@ jobs:
       PYTHON_EXECUTABLE: 'python3.12'
       PYTHON_TOX_ENVS: 'py312'
     steps: 
-      - *job-steps
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install python 
+        uses: actions/setup-python@v4 
+        with:
+          python-version: ${{ env.PYTHON_VERSION }} 
+      - name: Show OS version
+        run: cat /etc/os-release
+      - run: printenv
+      - name: Check D-Bus
+        run: ps -ef | grep dbus | grep -v grep
+      - name: Show python version
+        run: python --version
+      - name: Show platform information
+        run: python -c "import platform; print(platform.platform())"
+      - name: install tox
+        run: |
+          ${{ env.PYTHON_EXECUTABLE }} -m pip install -U pip wheel && \
+          ${{ env.PYTHON_EXECUTABLE }} -m pip install tox~=4.6.0
+      - name: Run tests with tox
+        run: tox -e ${{ env.PYTHON_TOX_ENVS }} 
 
       

--- a/.github/workflows/tests-linux.yml
+++ b/.github/workflows/tests-linux.yml
@@ -16,13 +16,14 @@ env:
   TOX_REQUIREMENT: 'tox~=4.6.0'
   
 jobs:  
-  test-linux-py310:
+  test-linux-py37:
+    # List of available versions: https://github.com/actions/python-versions/blob/main/versions-manifest.json
     runs-on: ubuntu-22.04
     env:
-      PYTHON_VERSION: '3.10'
-      PYTHON_EXECUTABLE: 'python3.10'
-      PYTHON_TOX_ENVS: 'py310,check'
-    steps:
+      PYTHON_VERSION: '3.7'
+      PYTHON_EXECUTABLE: 'python3.7'
+      PYTHON_TOX_ENVS: 'py37'
+    steps: 
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install python 
@@ -44,14 +45,13 @@ jobs:
           ${{ env.PYTHON_EXECUTABLE }} -m pip install ${{ env.TOX_REQUIREMENT }} 
       - name: Run tests with tox
         run: tox -e ${{ env.PYTHON_TOX_ENVS }} 
-  test-linux-py37:
-    # List of available versions: https://github.com/actions/python-versions/blob/main/versions-manifest.json
+  test-linux-py310:
     runs-on: ubuntu-22.04
     env:
-      PYTHON_VERSION: '3.7'
-      PYTHON_EXECUTABLE: 'python3.7'
-      PYTHON_TOX_ENVS: 'py37'
-    steps: 
+      PYTHON_VERSION: '3.10'
+      PYTHON_EXECUTABLE: 'python3.10'
+      PYTHON_TOX_ENVS: 'py310,check'
+    steps:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install python 

--- a/.github/workflows/tests-linux.yml
+++ b/.github/workflows/tests-linux.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       PYTHON_VERSION: '3.11'
+      PYTHON_EXECUTABLE: 'python3.11'
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -35,8 +36,8 @@ jobs:
         run: python -c "import platform; print(platform.platform())"
       - name: install tox
         run: |
-          python3.10 -m pip install -U pip wheel && \
-          python3.10 -m pip install tox~=4.6.0
+          $PYTHON_EXECUTABLE -m pip install -U pip wheel && \
+          $PYTHON_EXECUTABLE -m pip install tox~=4.6.0
       - name: Run tests with tox
         run: tox -e py310,check
   test-linux-py37:

--- a/.github/workflows/tests-linux.yml
+++ b/.github/workflows/tests-linux.yml
@@ -11,6 +11,9 @@ concurrency:
   group: linux-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Common environment variables
+env:
+  TOX_REQUIREMENT: 'tox~=4.6.0'
   
 jobs:  
   test-linux-py310:
@@ -38,7 +41,7 @@ jobs:
       - name: install tox
         run: |
           ${{ env.PYTHON_EXECUTABLE }} -m pip install -U pip wheel && \
-          ${{ env.PYTHON_EXECUTABLE }} -m pip install tox~=4.6.0
+          ${{ env.PYTHON_EXECUTABLE }} -m pip install ${{ env.TOX_REQUIREMENT }} 
       - name: Run tests with tox
         run: tox -e ${{ env.PYTHON_TOX_ENVS }} 
   test-linux-py37:
@@ -67,7 +70,7 @@ jobs:
       - name: install tox
         run: |
           ${{ env.PYTHON_EXECUTABLE }} -m pip install -U pip wheel && \
-          ${{ env.PYTHON_EXECUTABLE }} -m pip install tox~=4.6.0
+          ${{ env.PYTHON_EXECUTABLE }} -m pip install ${{ env.TOX_REQUIREMENT }} 
       - name: Run tests with tox
         run: tox -e ${{ env.PYTHON_TOX_ENVS }} 
   test-linux-py312:
@@ -95,7 +98,7 @@ jobs:
       - name: install tox
         run: |
           ${{ env.PYTHON_EXECUTABLE }} -m pip install -U pip wheel && \
-          ${{ env.PYTHON_EXECUTABLE }} -m pip install tox~=4.6.0
+          ${{ env.PYTHON_EXECUTABLE }} -m pip install ${{ env.TOX_REQUIREMENT }} 
       - name: Run tests with tox
         run: tox -e ${{ env.PYTHON_TOX_ENVS }} 
 

--- a/.github/workflows/tests-linux.yml
+++ b/.github/workflows/tests-linux.yml
@@ -18,7 +18,7 @@ jobs:
     env:
       PYTHON_VERSION: '3.10'
       PYTHON_EXECUTABLE: 'python3.10'
-      PYTHON_TOX_ENVS: 'py310, check'
+      PYTHON_TOX_ENVS: 'py310,check'
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/tests-linux.yml
+++ b/.github/workflows/tests-linux.yml
@@ -37,7 +37,7 @@ jobs:
       - name: install tox
         run: |
           ${{ env.PYTHON_EXECUTABLE }} -m pip install -U pip wheel && \
-          $PYTHON_EXECUTABLE -m pip install tox~=4.6.0
+          ${{ env.PYTHON_EXECUTABLE }} -m pip install tox~=4.6.0
       - name: Run tests with tox
         run: tox -e py310,check
   test-linux-py37:

--- a/.github/workflows/tests-linux.yml
+++ b/.github/workflows/tests-linux.yml
@@ -43,16 +43,20 @@ jobs:
         run: tox -e ${{ env.PYTHON_TOX_ENVS }} 
   test-linux-py37:
     # List of available versions: https://github.com/actions/python-versions/blob/main/versions-manifest.json
+    runs-on: ubuntu-22.04
     env:
       PYTHON_VERSION: '3.7'
       PYTHON_EXECUTABLE: 'python3.7'
       PYTHON_TOX_ENVS: 'py37'
-    steps: *job-steps
+    steps: 
+      - *job-steps
   test-linux-py312:
+    runs-on: ubuntu-22.04
     env:
       PYTHON_VERSION: '3.12'
       PYTHON_EXECUTABLE: 'python3.12'
       PYTHON_TOX_ENVS: 'py312'
-    steps: *job-steps
+    steps: 
+      - *job-steps
 
       

--- a/.github/workflows/tests-linux.yml
+++ b/.github/workflows/tests-linux.yml
@@ -42,7 +42,7 @@ jobs:
   test-linux-py37:
     runs-on: ubuntu-20.04
     env:
-      PYTHON_VERSION: '3.11'
+      PYTHON_VERSION: '3.7'
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/tests-linux.yml
+++ b/.github/workflows/tests-linux.yml
@@ -15,13 +15,15 @@ concurrency:
 jobs:  
   test-linux-py310:
     runs-on: ubuntu-22.04
+    env:
+      PYTHON_VERSION: '3.10'
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install python 
         uses: actions/setup-python@v4 
         with:
-          python-version: '3.10' 
+          python-version: ${{ env.PYTHON_VERSION }} 
       - name: Show OS version
         run: cat /etc/os-release
       - run: printenv

--- a/.github/workflows/tests-linux.yml
+++ b/.github/workflows/tests-linux.yml
@@ -17,8 +17,8 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       PYTHON_VERSION: '3.10'
-      PYTHON_TOX_ENVs: 'py310, check'
       PYTHON_EXECUTABLE: 'python3.10'
+      PYTHON_TOX_ENVS: 'py310, check'
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -40,7 +40,7 @@ jobs:
           ${{ env.PYTHON_EXECUTABLE }} -m pip install -U pip wheel && \
           ${{ env.PYTHON_EXECUTABLE }} -m pip install tox~=4.6.0
       - name: Run tests with tox
-        run: tox -e py310,check
+        run: tox -e ${{ env.PYTHON_TOX_ENVS }} 
   test-linux-py37:
     runs-on: ubuntu-20.04
     env:

--- a/.github/workflows/tests-linux.yml
+++ b/.github/workflows/tests-linux.yml
@@ -65,5 +65,31 @@ jobs:
           python3.7 -m pip install tox~=4.6.0
       - name: Run tests with tox
         run: tox -e py37
+  test-linux-py312:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      # Install python 3.12
+      # List of available versions: https://github.com/actions/python-versions/blob/main/versions-manifest.json
+      - name: Install python 
+        uses: actions/setup-python@v4 
+        with:
+          python-version: '3.12' 
+      - name: Show OS version
+        run: cat /etc/os-release
+      - run: printenv
+      - name: Check D-Bus
+        run: ps -ef | grep dbus | grep -v grep
+      - name: Show python version
+        run: python --version
+      - name: Show platform information
+        run: python -c "import platform; print(platform.platform())"
+      - name: install tox
+        run: |
+          python3.12 -m pip install -U pip wheel && \
+          python3.12 -m pip install tox~=4.6.0
+      - name: Run tests with tox
+        run: tox -e py312
 
     

--- a/.github/workflows/tests-linux.yml
+++ b/.github/workflows/tests-linux.yml
@@ -101,5 +101,33 @@ jobs:
           ${{ env.PYTHON_EXECUTABLE }} -m pip install ${{ env.TOX_REQUIREMENT }} 
       - name: Run tests with tox
         run: tox -e ${{ env.PYTHON_TOX_ENVS }} 
+  test-linux-py313:
+    runs-on: ubuntu-22.04
+    env:
+      PYTHON_VERSION: '3.13'
+      PYTHON_EXECUTABLE: 'python3.13'
+      PYTHON_TOX_ENVS: 'py313'
+    steps: 
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install python 
+        uses: actions/setup-python@v4 
+        with:
+          python-version: ${{ env.PYTHON_VERSION }} 
+      - name: Show OS version
+        run: cat /etc/os-release
+      - run: printenv
+      - name: Check D-Bus
+        run: ps -ef | grep dbus | grep -v grep
+      - name: Show python version
+        run: python --version
+      - name: Show platform information
+        run: python -c "import platform; print(platform.platform())"
+      - name: install tox
+        run: |
+          ${{ env.PYTHON_EXECUTABLE }} -m pip install -U pip wheel && \
+          ${{ env.PYTHON_EXECUTABLE }} -m pip install ${{ env.TOX_REQUIREMENT }} 
+      - name: Run tests with tox
+        run: tox -e ${{ env.PYTHON_TOX_ENVS }} 
 
       

--- a/.github/workflows/tests-linux.yml
+++ b/.github/workflows/tests-linux.yml
@@ -19,7 +19,7 @@ jobs:
       PYTHON_VERSION: '3.10'
       PYTHON_EXECUTABLE: 'python3.10'
       PYTHON_TOX_ENVS: 'py310, check'
-    steps: &job-steps
+    steps:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install python 

--- a/.github/workflows/tests-linux.yml
+++ b/.github/workflows/tests-linux.yml
@@ -101,10 +101,10 @@ jobs:
           ${{ env.PYTHON_EXECUTABLE }} -m pip install ${{ env.TOX_REQUIREMENT }} 
       - name: Run tests with tox
         run: tox -e ${{ env.PYTHON_TOX_ENVS }} 
-  test-linux-py313:
+  test-linux-py313-alpha:
     runs-on: ubuntu-22.04
     env:
-      PYTHON_VERSION: '3.13'
+      PYTHON_VERSION: '3.13.0-alpha.2'
       PYTHON_EXECUTABLE: 'python3.13'
       PYTHON_TOX_ENVS: 'py313'
     steps: 

--- a/.github/workflows/tests-linux.yml
+++ b/.github/workflows/tests-linux.yml
@@ -11,7 +11,7 @@ concurrency:
   group: linux-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-
+  
 jobs:  
   test-linux-py310:
     runs-on: ubuntu-22.04
@@ -41,6 +41,8 @@ jobs:
         run: tox -e py310,check
   test-linux-py37:
     runs-on: ubuntu-20.04
+    env:
+      PYTHON_VERSION: '3.11'
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -51,7 +53,7 @@ jobs:
       - name: Install python 
         uses: actions/setup-python@v4 
         with:
-          python-version: '3.7' 
+          python-version: ${{ env.PYTHON_VERSION }} 
       - name: Show OS version
         run: cat /etc/os-release
       - run: printenv

--- a/.github/workflows/tests-linux.yml
+++ b/.github/workflows/tests-linux.yml
@@ -16,7 +16,7 @@ jobs:
   test-linux-py310:
     runs-on: ubuntu-22.04
     env:
-      PYTHON_VERSION: '3.10'
+      PYTHON_VERSION: '3.11'
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/tests-linux.yml
+++ b/.github/workflows/tests-linux.yml
@@ -17,9 +17,9 @@ env:
   
 jobs:  
   test-linux-py37:
-    # List of available versions: https://github.com/actions/python-versions/blob/main/versions-manifest.json
     runs-on: ubuntu-22.04
     env:
+      # List of available versions: https://github.com/actions/python-versions/blob/main/versions-manifest.json
       PYTHON_VERSION: '3.7'
       PYTHON_EXECUTABLE: 'python3.7'
       PYTHON_TOX_ENVS: 'py37'

--- a/.github/workflows/tests-linux.yml
+++ b/.github/workflows/tests-linux.yml
@@ -36,7 +36,7 @@ jobs:
         run: python -c "import platform; print(platform.platform())"
       - name: install tox
         run: |
-          $PYTHON_EXECUTABLE -m pip install -U pip wheel && \
+          ${{ env.PYTHON_EXECUTABLE }} -m pip install -U pip wheel && \
           $PYTHON_EXECUTABLE -m pip install tox~=4.6.0
       - name: Run tests with tox
         run: tox -e py310,check


### PR DESCRIPTION
Closes: https://github.com/fohrloop/wakepy/issues/158

* Start using environment variables in the GitHub Actions .yml file
* Test also Python 3.12 & Python 3.12-alpha.2 (latest available version). Previously, tested on Python 3.7 and Python 3.10. (linux)
* Tried to make yaml file tidier. Unfortunately, YAML anchors are not supported (see: https://github.com/actions/runner/issues/1182)