### PR TITLE
Method registry: Allow multiple wakepy.Methods have same name if mode is different.

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -10,3 +10,24 @@ class TestDbusAdapter(DbusAdapter):
 @pytest.fixture(scope="session")
 def fake_dbus_adapter():
     return TestDbusAdapter
+
+
+class TestUtils:
+    """Any functions needed to be "imported" anywhere from any tests. Available
+    as a fixture called `testutils`.
+    """
+
+    @staticmethod
+    def empty_method_registry(monkeypatch):
+        # Make the method registry empty for duration of a test
+        monkeypatch.setattr("wakepy.core.registry._method_registry", dict())
+
+
+@pytest.fixture(scope="session")
+def testutils():
+    return TestUtils
+
+
+@pytest.fixture(scope="function", name="empty_method_registry")
+def empty_method_registry_fixture(monkeypatch):
+    TestUtils.empty_method_registry(monkeypatch)

--- a/tests/unit/test_core/conftest.py
+++ b/tests/unit/test_core/conftest.py
@@ -9,9 +9,8 @@ SECOND_MODE = "second_mode"
 
 
 @pytest.fixture(scope="function")
-def provide_methods_different_platforms(monkeypatch):
-    # empty method registry
-    monkeypatch.setattr("wakepy.core.method._method_registry", dict())
+def provide_methods_different_platforms(monkeypatch, testutils):
+    testutils.empty_method_registry(monkeypatch)
 
     class WindowsA(Method):
         name = "WinA"
@@ -47,9 +46,8 @@ def provide_methods_different_platforms(monkeypatch):
 
 
 @pytest.fixture(scope="function")
-def provide_methods_a_f(monkeypatch):
-    # empty method registry
-    monkeypatch.setattr("wakepy.core.method._method_registry", dict())
+def provide_methods_a_f(monkeypatch, testutils):
+    testutils.empty_method_registry(monkeypatch)
 
     class MethodA(Method):
         name = "A"

--- a/tests/unit/test_core/conftest.py
+++ b/tests/unit/test_core/conftest.py
@@ -8,35 +8,40 @@ FIRST_MODE = "first_mode"
 SECOND_MODE = "second_mode"
 
 
+class TestMethod(Method):
+    __test__ = False  # for pytest
+    mode = "_test"
+
+
 @pytest.fixture(scope="function")
 def provide_methods_different_platforms(monkeypatch, testutils):
     testutils.empty_method_registry(monkeypatch)
 
-    class WindowsA(Method):
+    class WindowsA(TestMethod):
         name = "WinA"
         supported_platforms = (PlatformName.WINDOWS,)
 
-    class WindowsB(Method):
+    class WindowsB(TestMethod):
         name = "WinB"
         supported_platforms = (PlatformName.WINDOWS,)
 
-    class WindowsC(Method):
+    class WindowsC(TestMethod):
         name = "WinC"
         supported_platforms = (PlatformName.WINDOWS,)
 
-    class LinuxA(Method):
+    class LinuxA(TestMethod):
         name = "LinuxA"
         supported_platforms = (PlatformName.LINUX,)
 
-    class LinuxB(Method):
+    class LinuxB(TestMethod):
         name = "LinuxB"
         supported_platforms = (PlatformName.LINUX,)
 
-    class LinuxC(Method):
+    class LinuxC(TestMethod):
         name = "LinuxC"
         supported_platforms = (PlatformName.LINUX,)
 
-    class MultiPlatformA(Method):
+    class MultiPlatformA(TestMethod):
         name = "multiA"
         supported_platforms = (
             PlatformName.LINUX,
@@ -49,25 +54,25 @@ def provide_methods_different_platforms(monkeypatch, testutils):
 def provide_methods_a_f(monkeypatch, testutils):
     testutils.empty_method_registry(monkeypatch)
 
-    class MethodA(Method):
+    class MethodA(TestMethod):
         name = "A"
         mode = SECOND_MODE
 
-    class MethodB(Method):
+    class MethodB(TestMethod):
         name = "B"
         mode = FIRST_MODE
 
-    class MethodC(Method):
+    class MethodC(TestMethod):
         name = "C"
 
-    class MethodD(Method):
+    class MethodD(TestMethod):
         name = "D"
         mode = FIRST_MODE
 
-    class MethodE(Method):
+    class MethodE(TestMethod):
         name = "E"
         mode = FIRST_MODE
 
-    class MethodF(Method):
+    class MethodF(TestMethod):
         name = "F"
         mode = SECOND_MODE

--- a/tests/unit/test_core/test_activation/test_activation.py
+++ b/tests/unit/test_core/test_activation/test_activation.py
@@ -20,7 +20,7 @@ from testmethods import (
     iterate_test_methods,
 )
 
-from wakepy.core import DbusAdapter, MethodActivationResult
+from wakepy.core import DbusAdapter, MethodActivationResult, get_methods
 from wakepy.core.activation import (
     StageName,
     WakepyFakeSuccess,
@@ -32,7 +32,7 @@ from wakepy.core.activation import (
     try_enter_and_heartbeat,
 )
 from wakepy.core.heartbeat import Heartbeat
-from wakepy.core.method import Method, MethodError, PlatformName, get_methods
+from wakepy.core.method import Method, MethodError, PlatformName
 
 
 def test_activate_without_methods(monkeypatch):

--- a/tests/unit/test_core/test_activation/test_prioritization.py
+++ b/tests/unit/test_core/test_activation/test_prioritization.py
@@ -8,7 +8,8 @@ from wakepy.core.activation import (
     get_prioritized_methods_groups,
     sort_methods_by_priority,
 )
-from wakepy.core.method import PlatformName, get_methods
+from wakepy.core.method import PlatformName
+from wakepy.core.registry import get_methods
 
 
 @pytest.mark.usefixtures("provide_methods_a_f")

--- a/tests/unit/test_core/test_method.py
+++ b/tests/unit/test_core/test_method.py
@@ -6,13 +6,18 @@ from wakepy.core.method import Method, select_methods
 from wakepy.core.registry import MethodRegistryError, get_method, get_methods
 
 
+class TestMethod(Method):
+    __test__ = False  # for pytest
+    mode = "_test"
+
+
 def test_overridden_methods_autodiscovery():
     """The enter_mode, heartbeat and exit_mode methods by default do nothing
     (on the Method base class). In subclasses, these are usually overriden.
     Check that detecting the overridden methods works correctly
     """
 
-    class WithEnterAndExit(Method):
+    class WithEnterAndExit(TestMethod):
         def enter_mode(self):
             return
 
@@ -25,7 +30,7 @@ def test_overridden_methods_autodiscovery():
     assert method1.has_exit
     assert not method1.has_heartbeat
 
-    class WithJustHeartBeat(Method):
+    class WithJustHeartBeat(TestMethod):
         def heartbeat(self):
             return
 
@@ -35,7 +40,7 @@ def test_overridden_methods_autodiscovery():
     assert not method2.has_exit
     assert method2.has_heartbeat
 
-    class WithEnterExitAndHeartBeat(Method):
+    class WithEnterExitAndHeartBeat(TestMethod):
         def heartbeat(self):
             return
 
@@ -71,7 +76,7 @@ def test_overridden_methods_autodiscovery():
 
 
 def test_method_has_x_is_not_writeable():
-    class MethodWithEnter(Method):
+    class MethodWithEnter(TestMethod):
         def enter_mode(self):
             return
 
@@ -95,7 +100,7 @@ def test_method_has_x_is_not_writeable():
 def test_not_possible_to_define_two_methods_with_same_name(testutils, monkeypatch):
     somename = "Some name"
 
-    class SomeMethod(Method):
+    class SomeMethod(TestMethod):
         name = somename
 
     # It is not possible to define two methods if same name
@@ -103,14 +108,14 @@ def test_not_possible_to_define_two_methods_with_same_name(testutils, monkeypatc
         MethodRegistryError, match=re.escape('Duplicate Method name "Some name"')
     ):
 
-        class SomeMethod(Method):  # noqa:F811
+        class SomeMethod(TestMethod):  # noqa:F811
             name = somename
 
     testutils.empty_method_registry(monkeypatch)
 
     # Now as the registry is empty it is possible to define method with
     # the same name again
-    class SomeMethod(Method):  # noqa:F811
+    class SomeMethod(TestMethod):  # noqa:F811
         name = somename
 
 

--- a/tests/unit/test_core/test_registry.py
+++ b/tests/unit/test_core/test_registry.py
@@ -1,0 +1,95 @@
+import re
+
+import pytest
+
+from wakepy.core import Method
+from wakepy.core.registry import (
+    get_method,
+    get_methods,
+    get_methods_for_mode,
+    method_names_to_classes,
+    register_method,
+)
+
+
+@pytest.mark.usefixtures("empty_method_registry")
+def test_get_method_which_is_not_yet_defined(monkeypatch):
+    # The method registry is empty so there is no Methods with the name
+    with pytest.raises(
+        KeyError, match=re.escape('No Method with name "Some name" found!')
+    ):
+        get_method("Some name")
+
+
+@pytest.mark.usefixtures("empty_method_registry")
+def test_get_method_working_example(monkeypatch):
+    somename = "Some name"
+
+    # Create a method
+    class SomeMethod(Method):
+        name = somename
+
+    # Check that we can retrieve the method
+    method_class = get_method(somename)
+    assert method_class is SomeMethod
+
+
+@pytest.mark.usefixtures("provide_methods_a_f")
+def test_method_names_to_classes():
+    (A, B, C) = get_methods(["A", "B", "C"])
+
+    # Asking for a list, getting a list
+    assert method_names_to_classes(["A", "B"]) == [A, B]
+    # The order of returned items matches the order of input params
+    assert method_names_to_classes(["C", "B", "A"]) == [C, B, A]
+    assert method_names_to_classes(["B", "A", "C"]) == [B, A, C]
+
+    # Asking a tuple, getting a tuple
+    assert method_names_to_classes(("A", "B")) == (A, B)
+    assert method_names_to_classes(("C", "B", "A")) == (C, B, A)
+
+    # Asking a set, getting a set
+    assert method_names_to_classes({"A", "B"}) == {A, B}
+    assert method_names_to_classes({"C", "B"}) == {C, B}
+
+    # Asking None, getting None
+    assert method_names_to_classes(None) is None
+
+    # Asking something that does not exists will raise KeyError
+    with pytest.raises(KeyError, match=re.escape('No Method with name "foo" found!')):
+        method_names_to_classes(["A", "foo"])
+
+    # Using unsupported type raises TypeError
+    with pytest.raises(TypeError):
+        method_names_to_classes(4123)
+
+
+@pytest.mark.usefixtures("provide_methods_a_f")
+def test_get_methods_for_mode():
+    methods = get_methods(["A", "B", "C", "D", "E", "F"])
+    (MethodA, MethodB, _, MethodD, MethodE, MethodF) = methods
+
+    assert get_methods_for_mode("first_mode") == [
+        MethodB,
+        MethodD,
+        MethodE,
+    ]
+    assert get_methods_for_mode("second_mode") == [
+        MethodA,
+        MethodF,
+    ]
+
+
+@pytest.mark.usefixtures("empty_method_registry")
+def test_register_method(monkeypatch):
+    class MethodA(Method):
+        name = "A"
+
+    assert get_method("A") is MethodA
+
+    # It is possible to register the same method many times without issues.
+    register_method(MethodA)
+    register_method(MethodA)
+    register_method(MethodA)
+
+    assert get_method("A") is MethodA

--- a/tests/unit/test_core/test_registry.py
+++ b/tests/unit/test_core/test_registry.py
@@ -83,6 +83,7 @@ def test_get_methods_for_mode():
 
 @pytest.mark.usefixtures("empty_method_registry")
 def test_register_method():
+    # Note that defining a subclass automatically registers a method.
     class MethodA(Method):
         name = "A"
 
@@ -91,6 +92,23 @@ def test_register_method():
     # It is possible to register the same method many times without issues.
     register_method(MethodA)
     register_method(MethodA)
-    register_method(MethodA)
 
     assert get_method("A") is MethodA
+
+    class MethodA2(Method):
+        name = "A"
+        mode = "somemode"
+
+    #  We can get both of the methods from the register
+    assert get_method("A") is MethodA
+    assert get_method("A", mode=None) is MethodA
+    assert get_method("A", mode="somemode") is MethodA2
+
+    # We can get the method from register after registering it.
+    class MethodA3(Method):
+        name = "A"
+        mode = "yet_another_mode"
+
+    assert get_method("A", mode=None) is MethodA
+    assert get_method("A", mode="somemode") is MethodA2
+    assert get_method("A", mode="yet_another_mode") is MethodA3

--- a/tests/unit/test_core/test_registry.py
+++ b/tests/unit/test_core/test_registry.py
@@ -2,18 +2,12 @@ import re
 
 import pytest
 
-from wakepy.core import Method
-from wakepy.core.registry import (
-    get_method,
-    get_methods,
-    get_methods_for_mode,
-    method_names_to_classes,
-    register_method,
-)
+from wakepy.core import Method, get_method, get_methods_for_mode, get_methods
+from wakepy.core.registry import register_method
 
 
 @pytest.mark.usefixtures("empty_method_registry")
-def test_get_method_which_is_not_yet_defined(monkeypatch):
+def test_get_method_which_is_not_yet_defined():
     # The method registry is empty so there is no Methods with the name
     with pytest.raises(
         KeyError, match=re.escape('No Method with name "Some name" found!')
@@ -22,7 +16,7 @@ def test_get_method_which_is_not_yet_defined(monkeypatch):
 
 
 @pytest.mark.usefixtures("empty_method_registry")
-def test_get_method_working_example(monkeypatch):
+def test_get_method_working_example():
     somename = "Some name"
 
     # Create a method
@@ -34,40 +28,47 @@ def test_get_method_working_example(monkeypatch):
     assert method_class is SomeMethod
 
 
-@pytest.mark.usefixtures("provide_methods_a_f")
-def test_method_names_to_classes():
-    (A, B, C) = get_methods(["A", "B", "C"])
+def test_get_methods(testutils, monkeypatch):
+    testutils.empty_method_registry(monkeypatch)
+
+    class A(Method):
+        name = "A"
+
+    class B(Method):
+        name = "B"
+
+    class C(Method):
+        name = "C"
 
     # Asking for a list, getting a list
-    assert method_names_to_classes(["A", "B"]) == [A, B]
+    assert get_methods(["A", "B"]) == [A, B]
     # The order of returned items matches the order of input params
-    assert method_names_to_classes(["C", "B", "A"]) == [C, B, A]
-    assert method_names_to_classes(["B", "A", "C"]) == [B, A, C]
+    assert get_methods(["C", "B", "A"]) == [C, B, A]
+    assert get_methods(["B", "A", "C"]) == [B, A, C]
 
     # Asking a tuple, getting a tuple
-    assert method_names_to_classes(("A", "B")) == (A, B)
-    assert method_names_to_classes(("C", "B", "A")) == (C, B, A)
+    assert get_methods(("A", "B")) == (A, B)
+    assert get_methods(("C", "B", "A")) == (C, B, A)
 
     # Asking a set, getting a set
-    assert method_names_to_classes({"A", "B"}) == {A, B}
-    assert method_names_to_classes({"C", "B"}) == {C, B}
+    assert get_methods({"A", "B"}) == {A, B}
+    assert get_methods({"C", "B"}) == {C, B}
 
     # Asking None, getting None
-    assert method_names_to_classes(None) is None
+    assert get_methods(None) is None
 
     # Asking something that does not exists will raise KeyError
     with pytest.raises(KeyError, match=re.escape('No Method with name "foo" found!')):
-        method_names_to_classes(["A", "foo"])
+        get_methods(["A", "foo"])
 
     # Using unsupported type raises TypeError
     with pytest.raises(TypeError):
-        method_names_to_classes(4123)
+        get_methods(4123)
 
 
 @pytest.mark.usefixtures("provide_methods_a_f")
 def test_get_methods_for_mode():
-    methods = get_methods(["A", "B", "C", "D", "E", "F"])
-    (MethodA, MethodB, _, MethodD, MethodE, MethodF) = methods
+    MethodA, MethodB, MethodD, MethodE, MethodF = get_methods(["A", "B", "D", "E", "F"])
 
     assert get_methods_for_mode("first_mode") == [
         MethodB,
@@ -81,7 +82,7 @@ def test_get_methods_for_mode():
 
 
 @pytest.mark.usefixtures("empty_method_registry")
-def test_register_method(monkeypatch):
+def test_register_method():
     class MethodA(Method):
         name = "A"
 

--- a/tests/unit/test_core/test_registry.py
+++ b/tests/unit/test_core/test_registry.py
@@ -18,6 +18,11 @@ def test_get_method_which_is_not_yet_defined():
         ValueError, match=re.escape('No Method with name "Some name" found!')
     ):
         get_method("Some name")
+    with pytest.raises(
+        ValueError, match=re.escape('No Method with name "Some name" found!')
+    ):
+        # for test coverage, test this branch, too.
+        get_method("Some name", mode="foo")
 
 
 @pytest.mark.usefixtures("empty_method_registry")

--- a/tests/unit/test_core/testmethods.py
+++ b/tests/unit/test_core/testmethods.py
@@ -80,7 +80,11 @@ def get_test_method_class(
 
     def _create_class():
         clsname = get_new_classname()
-        clskwargs = {"supported_platforms": supported_platforms, "name": clsname}
+        clskwargs = {
+            "supported_platforms": supported_platforms,
+            "name": clsname,
+            "mode": "_tests",
+        }
         clsmethods = dict()
         clsmethods["caniuse"] = _create_function(caniuse)
         clsmethods["enter_mode"] = _create_function(enter_mode)

--- a/tests/unit/test_modes.py
+++ b/tests/unit/test_modes.py
@@ -4,25 +4,6 @@ from wakepy.core import ActivationResult, DbusAdapter, Method, Mode, ModeName
 from wakepy.modes import keep
 
 
-def create_methods(monkeypatch, name_prefix: str, modename: ModeName):
-    # empty method registry
-    monkeypatch.setattr("wakepy.core.method._method_registry", dict())
-
-    class MethodA(Method):
-        name = f"{name_prefix}A"
-        mode = modename
-
-    class MethodB(Method):
-        name = f"{name_prefix}B"
-        mode = modename
-
-    class MethodC(Method):
-        name = f"{name_prefix}C"
-        mode = modename
-
-    return MethodA, MethodB, MethodC
-
-
 @pytest.mark.parametrize(
     "input_args",
     [
@@ -38,16 +19,28 @@ def create_methods(monkeypatch, name_prefix: str, modename: ModeName):
         ),
     ],
 )
-def test_keep_running_mode_creation(input_args, monkeypatch):
+def test_keep_running_mode_creation(input_args, monkeypatch, testutils):
     """Simple test for keep.running and keep.presenting. Tests that all input
     arguments for the functions are passed to the Mode.__init__
     """
+
+    testutils.empty_method_registry(monkeypatch)
+
     name_prefix = input_args["name_prefix"]
     function_under_test = input_args["function_under_test"]
+    modename = input_args["modename"]
 
-    MethodA, MethodB, MethodC = create_methods(
-        monkeypatch, name_prefix=name_prefix, modename=input_args["modename"]
-    )
+    class MethodA(Method):
+        name = f"{name_prefix}A"
+        mode = modename
+
+    class MethodB(Method):
+        name = f"{name_prefix}B"
+        mode = modename
+
+    class MethodC(Method):
+        name = f"{name_prefix}C"
+        mode = modename
 
     mode = function_under_test()
     # All the methods for the mode are selected automatically

--- a/wakepy/core/__init__.py
+++ b/wakepy/core/__init__.py
@@ -16,4 +16,7 @@ from .dbus import DbusMethodCall as DbusMethodCall
 from .method import Method as Method
 from .mode import Mode as Mode
 from .platform import CURRENT_PLATFORM as CURRENT_PLATFORM
+from .registry import get_method as get_method
+from .registry import get_methods as get_methods
+from .registry import get_methods_for_mode as get_methods_for_mode
 from .strenum import StrEnum as StrEnum

--- a/wakepy/core/activation.py
+++ b/wakepy/core/activation.py
@@ -798,6 +798,8 @@ class WakepyFakeSuccess(Method):
     """
 
     name = "WAKEPY_FAKE_SUCCESS"
+    mode = "_fake"
+
     environment_variable = name
 
     # All other values are considered to be truthy. Comparison is case

--- a/wakepy/core/method.py
+++ b/wakepy/core/method.py
@@ -80,7 +80,8 @@ class Method(ABC, metaclass=MethodMeta):
     but also the hybrid option is possible.
     """
 
-    mode: ModeName | None = None
+    mode: ModeName | str
+
     """The mode for the method. Each method may be connected to single mode.
     Use None for methods which do not implement any mode."""
 

--- a/wakepy/core/method.py
+++ b/wakepy/core/method.py
@@ -10,17 +10,6 @@ General functions
 select_methods
     Select Methods from a collection based on a white- or blacklist.
 
-Functions for getting Methods
------------------------------
-get_method
-    Get a single method by name
-get_methods
-    Get multiple methods be name
-method_names_to_classes
-    Convert multiple method names to Method classes
-get_methods_for_mode
-    Get Methods based on a Mode name
-
 """
 
 from __future__ import annotations

--- a/wakepy/core/method.py
+++ b/wakepy/core/method.py
@@ -30,6 +30,7 @@ from abc import ABC, ABCMeta
 from typing import Any, List, Optional, Set, Tuple, Type, TypeVar, Union
 
 from .constants import ModeName, PlatformName
+from .registry import register_method
 from .strenum import StrEnum, auto
 
 if typing.TYPE_CHECKING:
@@ -271,71 +272,6 @@ class Method(ABC, metaclass=MethodMeta):
         return f"<wakepy Method: {self.__class__.__name__} at {hex(id(self))}>"
 
 
-_method_registry: dict[str, MethodCls] = dict()
-"""A name -> Method class mapping. Updated automatically; when python loads
-a module with a subclass of Method, the Method class is added to this registry.
-"""
-
-
-def get_method(method_name: str) -> MethodCls:
-    """Get a Method class based on its name."""
-    if method_name not in _method_registry:
-        raise KeyError(
-            f'No Method with name "{method_name}" found!'
-            " Check that the name is correctly spelled and that the module containing"
-            " the class is being imported."
-        )
-    return _method_registry[method_name]
-
-
-def get_methods(method_names: List[str]) -> List[MethodCls]:
-    """Get Method classes based on their names."""
-    return [get_method(name) for name in method_names]
-
-
-def method_names_to_classes(
-    names: Collection[str] | None = None,
-) -> Collection[MethodCls] | None:
-    """Convert a collection (list, tuple or set) of method names to a
-    collection of method classes"""
-    if names is None:
-        return None
-
-    if isinstance(names, list):
-        return [get_method(name) for name in names]
-    elif isinstance(names, tuple):
-        return tuple(get_method(name) for name in names)
-    elif isinstance(names, set):
-        return set(get_method(name) for name in names)
-
-    raise TypeError("`names` must be a list, tuple or set")
-
-
-def get_methods_for_mode(
-    modename: ModeName,
-) -> List[MethodCls]:
-    """Get the Method classes belonging to a Mode; Methods with
-    Method.mode = `modename`.
-
-    Parameters
-    ----------
-    modename: str | ModeName
-        The name of the Mode from which to select the Methods.
-
-    Returns
-    -------
-    methods: list[MethodCls]
-        The Method classes for the Mode.
-    """
-    methods = []
-    for method_cls in _method_registry.values():
-        if method_cls.mode != modename:
-            continue
-        methods.append(method_cls)
-
-    return methods
-
-
 def select_methods(
     methods: MethodClsCollection,
     omit: Optional[StrCollection] = None,
@@ -387,22 +323,3 @@ def select_methods(
     else:  # pragma: no cover
         raise ValueError("Invalid `omit` and/or `use_only`!")
     return selected_methods
-
-
-def register_method(cls: Type[Method]):
-    """Registers a subclass of Method to the method registry"""
-
-    if cls.name is None:
-        # Methods without a name will not be registered
-        return
-
-    if cls.name in _method_registry:
-        if _method_registry[cls.name] is not cls:
-            raise MethodDefinitionError(
-                f'Duplicate Method name "{cls.name}": {cls.__qualname__} '
-                f"(already registered to {_method_registry[cls.name].__qualname__})"
-            )
-        else:
-            return
-
-    _method_registry[cls.name] = cls

--- a/wakepy/core/mode.py
+++ b/wakepy/core/mode.py
@@ -6,7 +6,8 @@ from abc import ABC
 from .activation import ActivationResult, activate_mode, deactivate_method
 from .dbus import get_dbus_adapter
 from .heartbeat import Heartbeat
-from .method import get_methods_for_mode, select_methods
+from .method import select_methods
+from .registry import get_methods_for_mode
 
 if typing.TYPE_CHECKING:
     from types import TracebackType

--- a/wakepy/core/registry.py
+++ b/wakepy/core/registry.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import typing
+from typing import List, Set, Tuple, Type, TypeVar, Union
+
+from .constants import ModeName
+
+if typing.TYPE_CHECKING:
+    from wakepy.core.method import Method, MethodCls
+
+T = TypeVar("T")
+Collection = Union[List[T], Tuple[T, ...], Set[T]]
+
+_method_registry: dict[str, MethodCls] = dict()
+"""A name -> Method class mapping. Updated automatically; when python loads
+a module with a subclass of Method, the Method class is added to this registry.
+"""
+
+
+class MethodRegistryError(RuntimeError):
+    """Any error which is related to the method registry"""
+
+
+def register_method(cls: Type[Method]):
+    """Registers a subclass of Method to the method registry"""
+
+    if cls.name is None:
+        # Methods without a name will not be registered
+        return
+
+    if cls.name in _method_registry:
+        if _method_registry[cls.name] is not cls:
+            raise MethodRegistryError(
+                f'Duplicate Method name "{cls.name}": {cls.__qualname__} '
+                f"(already registered to {_method_registry[cls.name].__qualname__})"
+            )
+        else:
+            return
+
+    _method_registry[cls.name] = cls
+
+
+def get_method(method_name: str) -> MethodCls:
+    """Get a Method class based on its name."""
+    if method_name not in _method_registry:
+        raise KeyError(
+            f'No Method with name "{method_name}" found!'
+            " Check that the name is correctly spelled and that the module containing"
+            " the class is being imported."
+        )
+    return _method_registry[method_name]
+
+
+def get_methods(method_names: List[str]) -> List[MethodCls]:
+    """Get Method classes based on their names."""
+    return [get_method(name) for name in method_names]
+
+
+def method_names_to_classes(
+    names: Collection[str] | None = None,
+) -> Collection[MethodCls] | None:
+    """Convert a collection (list, tuple or set) of method names to a
+    collection of method classes"""
+    if names is None:
+        return None
+
+    if isinstance(names, list):
+        return [get_method(name) for name in names]
+    elif isinstance(names, tuple):
+        return tuple(get_method(name) for name in names)
+    elif isinstance(names, set):
+        return set(get_method(name) for name in names)
+
+    raise TypeError("`names` must be a list, tuple or set")
+
+
+def get_methods_for_mode(
+    modename: ModeName,
+) -> List[MethodCls]:
+    """Get the Method classes belonging to a Mode; Methods with
+    Method.mode = `modename`.
+
+    Parameters
+    ----------
+    modename: str | ModeName
+        The name of the Mode from which to select the Methods.
+
+    Returns
+    -------
+    methods: list[MethodCls]
+        The Method classes for the Mode.
+    """
+    methods = []
+    for method_cls in _method_registry.values():
+        if method_cls.mode != modename:
+            continue
+        methods.append(method_cls)
+
+    return methods

--- a/wakepy/core/registry.py
+++ b/wakepy/core/registry.py
@@ -1,3 +1,19 @@
+"""This module constains registry of wakepy.Methods. All the subclasses of
+wakepy.Method are automatically added to this registry. The registry can be
+accessed with the functions listed below.
+
+Functions for getting Methods
+-----------------------------
+get_method
+    Get a single method by name
+get_methods
+    Get multiple methods be name
+method_names_to_classes
+    Convert multiple method names to Method classes
+get_methods_for_mode
+    Get Methods based on a Mode name
+"""
+
 from __future__ import annotations
 
 import typing

--- a/wakepy/core/registry.py
+++ b/wakepy/core/registry.py
@@ -133,7 +133,7 @@ def get_methods(
 
     Parameters
     ----------
-    names: array-like of str
+    names: list, tuple or set of str
         The names of the wakepy.Methods to get. The methods must be registered
         which means that the modules containing the subclass definitions must
         have been imported.

--- a/wakepy/core/registry.py
+++ b/wakepy/core/registry.py
@@ -122,14 +122,14 @@ def get_methods(
 
 
 def get_methods_for_mode(
-    modename: ModeName,
+    mode: ModeName | str,
 ) -> List[MethodCls]:
     """Get the Method classes belonging to a Mode; Methods with
-    Method.mode = `modename`.
+    Method.mode = `mode`.
 
     Parameters
     ----------
-    modename: str | ModeName
+    mode: str | ModeName
         The name of the Mode from which to select the Methods.
 
     Returns
@@ -137,4 +137,4 @@ def get_methods_for_mode(
     methods: list[MethodCls]
         The Method classes for the Mode.
     """
-    return [m for m in _method_registry.get(modename, dict()).values()]
+    return [m for m in _method_registry.get(mode, dict()).values()]

--- a/wakepy/core/registry.py
+++ b/wakepy/core/registry.py
@@ -137,10 +137,4 @@ def get_methods_for_mode(
     methods: list[MethodCls]
         The Method classes for the Mode.
     """
-    methods = []
-    for method_cls in _method_registry.values():
-        if method_cls.mode != modename:
-            continue
-        methods.append(method_cls)
-
-    return methods
+    return [m for m in _method_registry.get(modename, dict()).values()]

--- a/wakepy/core/registry.py
+++ b/wakepy/core/registry.py
@@ -67,16 +67,12 @@ def get_method(method_name: str) -> MethodCls:
     return _method_registry[method_name]
 
 
-def get_methods(method_names: List[str]) -> List[MethodCls]:
-    """Get Method classes based on their names."""
-    return [get_method(name) for name in method_names]
-
-
-def method_names_to_classes(
+def get_methods(
     names: Collection[str] | None = None,
 ) -> Collection[MethodCls] | None:
-    """Convert a collection (list, tuple or set) of method names to a
-    collection of method classes"""
+    """Get a collection (list, tuple or set) of Method classes based on their
+    names."""
+
     if names is None:
         return None
 


### PR DESCRIPTION
* Create a separate wakepy.code.registry module for everything related
  to the Method registry.
* The Methods registry now saves the methods in dictionaries, which are
  in a dictionary of modes
* Now it is possible to have multiple wakepy.Methods with same name. The
  consequence is that now querying for Methods usually needs the mode
  name, too.
* Make Method.mode mandatory (string). There should be no Methods
  without a Mode associated. If there is, that is most likely a mistake.
* Merge method_names_to_classes with get_methods. Now there is only
  get_methods. 
* Add some test utilities, like empty_method_registry fixture, which may
  be used to empty the method registry before a test is run.