### PR TITLE
Windows SetThreadExecutionState based Methods using new internal API [gh60]

### DIFF
--- a/tests/unit/test_methods/test_windows.py
+++ b/tests/unit/test_methods/test_windows.py
@@ -20,12 +20,10 @@ from wakepy.methods.windows import (
         (WindowsKeepRunning, ES_CONTINUOUS | ES_SYSTEM_REQUIRED),
     ],
 )
-def test_windows_setthreadexecutionstate_enter_mode(method_cls, expected_flag):
+def test_enter_mode_success(method_cls, expected_flag):
     method = method_cls()
 
-    with patch(
-        "wakepy.methods.windows.ctypes",
-    ) as ctypesmock:
+    with patch("wakepy.methods.windows.ctypes") as ctypesmock:
         retval = method.enter_mode()
 
     assert retval is None
@@ -36,13 +34,45 @@ def test_windows_setthreadexecutionstate_enter_mode(method_cls, expected_flag):
     "method_cls",
     [WindowsKeepPresenting, WindowsKeepRunning],
 )
-def test_windows_setthreadexecutionstate_exit_mode(method_cls):
+def test_exit_mode_success(method_cls):
     method = method_cls()
 
-    with patch(
-        "wakepy.methods.windows.ctypes",
-    ) as ctypesmock:
+    with patch("wakepy.methods.windows.ctypes") as ctypesmock:
         retval = method.exit_mode()
 
     assert retval is None
     ctypesmock.windll.kernel32.SetThreadExecutionState.assert_called_with(ES_CONTINUOUS)
+
+
+@pytest.mark.parametrize(
+    "method_cls",
+    [WindowsKeepPresenting, WindowsKeepRunning],
+)
+def test_enter_mode_with_exception(method_cls):
+    method = method_cls()
+
+    def raising_exc(_):
+        raise AttributeError("foo")
+
+    with patch("wakepy.methods.windows.ctypes") as ctypesmock:
+        ctypesmock.windll.kernel32.SetThreadExecutionState.side_effect = raising_exc
+
+        with pytest.raises(RuntimeError, match="Could not use kernel32.dll!"):
+            method.enter_mode()
+
+
+@pytest.mark.parametrize(
+    "method_cls",
+    [WindowsKeepPresenting, WindowsKeepRunning],
+)
+def test_exit_mode_with_exception(method_cls):
+    method = method_cls()
+
+    def raising_exc(_):
+        raise AttributeError("foo")
+
+    with patch("wakepy.methods.windows.ctypes") as ctypesmock:
+        ctypesmock.windll.kernel32.SetThreadExecutionState.side_effect = raising_exc
+
+        with pytest.raises(RuntimeError, match="Could not use kernel32.dll!"):
+            method.exit_mode()

--- a/tests/unit/test_methods/test_windows.py
+++ b/tests/unit/test_methods/test_windows.py
@@ -1,12 +1,13 @@
-import pytest
 from unittest.mock import patch
 
+import pytest
+
 from wakepy.methods.windows import (
+    ES_CONTINUOUS,
+    ES_DISPLAY_REQUIRED,
+    ES_SYSTEM_REQUIRED,
     WindowsKeepPresenting,
     WindowsKeepRunning,
-    ES_CONTINUOUS,
-    ES_SYSTEM_REQUIRED,
-    ES_DISPLAY_REQUIRED,
 )
 
 

--- a/tests/unit/test_methods/test_windows.py
+++ b/tests/unit/test_methods/test_windows.py
@@ -1,0 +1,48 @@
+import pytest
+from unittest.mock import patch
+
+from wakepy.methods.windows import (
+    WindowsKeepPresenting,
+    WindowsKeepRunning,
+    ES_CONTINUOUS,
+    ES_SYSTEM_REQUIRED,
+    ES_DISPLAY_REQUIRED,
+)
+
+
+@pytest.mark.parametrize(
+    "method_cls, expected_flag",
+    [
+        (
+            WindowsKeepPresenting,
+            ES_CONTINUOUS | ES_SYSTEM_REQUIRED | ES_DISPLAY_REQUIRED,
+        ),
+        (WindowsKeepRunning, ES_CONTINUOUS | ES_SYSTEM_REQUIRED),
+    ],
+)
+def test_windows_setthreadexecutionstate_enter_mode(method_cls, expected_flag):
+    method = method_cls()
+
+    with patch(
+        "wakepy.methods.windows.ctypes",
+    ) as ctypesmock:
+        retval = method.enter_mode()
+
+    assert retval is None
+    ctypesmock.windll.kernel32.SetThreadExecutionState.assert_called_with(expected_flag)
+
+
+@pytest.mark.parametrize(
+    "method_cls",
+    [WindowsKeepPresenting, WindowsKeepRunning],
+)
+def test_windows_setthreadexecutionstate_exit_mode(method_cls):
+    method = method_cls()
+
+    with patch(
+        "wakepy.methods.windows.ctypes",
+    ) as ctypesmock:
+        retval = method.exit_mode()
+
+    assert retval is None
+    ctypesmock.windll.kernel32.SetThreadExecutionState.assert_called_with(ES_CONTINUOUS)

--- a/tests/unit/test_modes.py
+++ b/tests/unit/test_modes.py
@@ -83,22 +83,6 @@ def test_keep_running_with_fake_success(monkeypatch, fake_dbus_adapter):
     assert isinstance(m.activation_result, ActivationResult)
 
 
-def test_keep_running_without_fake_success(monkeypatch, fake_dbus_adapter):
-    """Simple smoke test for keep.running()"""
-    monkeypatch.setenv("WAKEPY_FAKE_SUCCESS", "0")
-    # This we expect to fail as the only adapter is the fake_dbus_adapter
-    mode = keep.running(dbus_adapter=fake_dbus_adapter)
-    assert mode.active is False
-
-    with mode as m:
-        assert mode is m
-        assert m.active is False
-        assert m.activation_result.success is False
-
-    assert m.active is False
-    assert isinstance(m.activation_result, ActivationResult)
-
-
 def test_keep_presenting(fake_dbus_adapter):
     """Simple smoke test for keep.presenting()"""
     with keep.presenting(dbus_adapter=fake_dbus_adapter) as m:

--- a/wakepy/methods/__init__.py
+++ b/wakepy/methods/__init__.py
@@ -27,3 +27,4 @@ Examples
 # definition is executed (if the module containing the Method class definition
 # is imported)
 from . import gnome as gnome
+from . import windows as windows

--- a/wakepy/methods/windows.py
+++ b/wakepy/methods/windows.py
@@ -39,12 +39,18 @@ class WindowsSetThreadExecutionState(Method):
     supported_platforms = (PlatformName.WINDOWS,)
 
     def enter_mode(self):
-        # Sets the flags until ES_CONTINUOUS is called or until the thread
+        # Sets the flags until Flags.RELEASE is used or until the thread
         # which called this dies.
-        ctypes.windll.kernel32.SetThreadExecutionState(self.flags.value)
+        self._call_set_thread_execution_state(self.flags.value)
 
     def exit_mode(self):
-        ctypes.windll.kernel32.SetThreadExecutionState(Flags.RELEASE.value)
+        self._call_set_thread_execution_state(Flags.RELEASE.value)
+
+    def _call_set_thread_execution_state(self, flags: int):
+        try:
+            ctypes.windll.kernel32.SetThreadExecutionState(flags)
+        except AttributeError as exc:
+            raise RuntimeError("Could not use kernel32.dll!") from exc
 
 
 class WindowsKeepRunning(WindowsSetThreadExecutionState):

--- a/wakepy/methods/windows.py
+++ b/wakepy/methods/windows.py
@@ -1,11 +1,7 @@
 import ctypes
 import enum
 
-from wakepy.core import (
-    Method,
-    ModeName,
-    PlatformName,
-)
+from wakepy.core import Method, ModeName, PlatformName
 
 # Different flags for WindowsSetThreadExecutionState
 # See: https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-setthreadexecutionstate

--- a/wakepy/methods/windows.py
+++ b/wakepy/methods/windows.py
@@ -1,0 +1,59 @@
+import ctypes
+
+from wakepy.core import (
+    Method,
+    ModeName,
+    PlatformName,
+)
+
+# Different flags for WindowsSetThreadExecutionState
+#
+# "Informs the system that the state being set should remain in effect until the
+# next call that uses ES_CONTINUOUS and one of the other state flags is
+# cleared."[1]
+ES_CONTINUOUS = 0x80000000
+# "Forces the system to be in the working state by resetting the system idle
+# timer."[1] Keeps CPU awake, but does not prevent screen lock
+ES_SYSTEM_REQUIRED = 0x00000001
+# "Forces the display to be on by resetting the display idle timer."[1]
+# Prevents automatic screen lock.
+ES_DISPLAY_REQUIRED = 0x00000002
+
+
+class WindowsSetThreadExecutionState(Method):
+    """This is a method which calls the SetThreadExecutionState function from
+    the kernel32.dll. The SetThreadExecutionState informs "the system that it
+    is in use, thereby preventing the system from entering sleep or turning off
+    the display while the application is running"[1] (depending on the used
+    flags)."""
+
+    name = "SetThreadExecutionState"
+
+    # The docs say that supports Windows XP and above (client) or Windows
+    # Server 2003 and above (server)
+    supported_platforms = (PlatformName.WINDOWS,)
+
+    def enter_mode(self):
+        # Sets the flags until ES_CONTINUOUS is called or until the thread
+        # which called this dies.
+        ctypes.windll.kernel32.SetThreadExecutionState(self.flags)
+
+    def exit_mode(self):
+        ctypes.windll.kernel32.SetThreadExecutionState(ES_CONTINUOUS)
+
+
+class WindowsKeepRunning(WindowsSetThreadExecutionState):
+    mode = ModeName.KEEP_RUNNING
+    flags = ES_CONTINUOUS | ES_SYSTEM_REQUIRED
+
+
+class WindowsKeepPresenting(WindowsSetThreadExecutionState):
+    mode = ModeName.KEEP_PRESENTING
+    flags = ES_CONTINUOUS | ES_SYSTEM_REQUIRED | ES_DISPLAY_REQUIRED
+
+
+"""
+References
+-----------
+[1] https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-setthreadexecutionstate
+"""

--- a/wakepy/methods/windows.py
+++ b/wakepy/methods/windows.py
@@ -1,6 +1,7 @@
 import ctypes
 import enum
 from abc import ABC, abstractmethod
+
 from wakepy.core import Method, ModeName, PlatformName
 
 # Different flags for WindowsSetThreadExecutionState

--- a/wakepy/methods/windows.py
+++ b/wakepy/methods/windows.py
@@ -8,16 +8,9 @@ from wakepy.core import (
 )
 
 # Different flags for WindowsSetThreadExecutionState
-#
-# "Informs the system that the state being set should remain in effect until the
-# next call that uses ES_CONTINUOUS and one of the other state flags is
-# cleared."[1]
+# See: https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-setthreadexecutionstate
 ES_CONTINUOUS = 0x80000000
-# "Forces the system to be in the working state by resetting the system idle
-# timer."[1] Keeps CPU awake, but does not prevent screen lock
 ES_SYSTEM_REQUIRED = 0x00000001
-# "Forces the display to be on by resetting the display idle timer."[1]
-# Prevents automatic screen lock.
 ES_DISPLAY_REQUIRED = 0x00000002
 
 
@@ -29,9 +22,9 @@ class Flags(enum.IntFlag):
 
 class WindowsSetThreadExecutionState(Method):
     """This is a method which calls the SetThreadExecutionState function from
-    the kernel32.dll. The SetThreadExecutionState informs "the system that it
-    is in use, thereby preventing the system from entering sleep or turning off
-    the display while the application is running"[1] (depending on the used
+    the kernel32.dll. The SetThreadExecutionState informs the system that it
+    is in use preventing the system from entering sleep or turning off
+    the display while the application is running" (depending on the used
     flags)."""
 
     # The docs say that supports Windows XP and above (client) or Windows
@@ -63,10 +56,3 @@ class WindowsKeepPresenting(WindowsSetThreadExecutionState):
     mode = ModeName.KEEP_PRESENTING
     flags = Flags.KEEP_PRESENTING
     name = "SetThreadExecutionState"
-
-
-"""
-References
------------
-[1] https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-setthreadexecutionstate
-"""

--- a/wakepy/methods/windows.py
+++ b/wakepy/methods/windows.py
@@ -1,6 +1,6 @@
 import ctypes
 import enum
-
+from abc import ABC, abstractmethod
 from wakepy.core import Method, ModeName, PlatformName
 
 # Different flags for WindowsSetThreadExecutionState
@@ -16,7 +16,7 @@ class Flags(enum.IntFlag):
     RELEASE = ES_CONTINUOUS
 
 
-class WindowsSetThreadExecutionState(Method):
+class WindowsSetThreadExecutionState(Method, ABC):
     """This is a method which calls the SetThreadExecutionState function from
     the kernel32.dll. The SetThreadExecutionState informs the system that it
     is in use preventing the system from entering sleep or turning off
@@ -37,9 +37,14 @@ class WindowsSetThreadExecutionState(Method):
 
     def _call_set_thread_execution_state(self, flags: int):
         try:
-            ctypes.windll.kernel32.SetThreadExecutionState(flags)
+            ctypes.windll.kernel32.SetThreadExecutionState(flags)  # type:ignore
         except AttributeError as exc:
             raise RuntimeError("Could not use kernel32.dll!") from exc
+
+    @property
+    @abstractmethod
+    def flags(self) -> Flags:
+        ...
 
 
 class WindowsKeepRunning(WindowsSetThreadExecutionState):


### PR DESCRIPTION
Implements the SetThreadExecutionState based keep.running and keep.presenting modes on Windows by subclassing wakepy.Method.

Closes #60