### PR TITLE
add org.freedesktop.Screensaver method

### DIFF
--- a/tests/unit/test_methods/test_freedesktop.py
+++ b/tests/unit/test_methods/test_freedesktop.py
@@ -1,0 +1,101 @@
+"""This module tests the Freedesktop.org specific methods. 
+
+These tests do *not* use IO / real or fake Dbus calls. Instead, a special dbus
+adapter is used which simply asserts the Call objects and returns what we
+would expect from a dbus service."""
+
+import re
+
+import pytest
+
+from wakepy.core.dbus import BusType, DbusAdapter, DbusAddress, DbusMethod
+from wakepy.methods.freedesktop import FreedesktopScreenSaverInhibit
+
+screen_saver = DbusAddress(
+    bus=BusType.SESSION,
+    service="org.freedesktop.ScreenSaver",
+    path="/org/freedesktop/ScreenSaver",
+    interface="org.freedesktop.ScreenSaver",
+)
+
+
+fake_cookie = 75848243423
+
+
+def test_screensaver_enter_mode():
+    # Arrange
+    method_inhibit = DbusMethod(
+        name="Inhibit",
+        signature="ss",
+        params=("application_name", "reason_for_inhibit"),
+        output_signature="u",
+        output_params=("cookie",),
+    ).of(screen_saver)
+
+    class TestAdapter(DbusAdapter):
+        def process(self, call):
+            assert call.method == method_inhibit
+            assert call.get_kwargs() == {
+                "application_name": "wakepy",
+                "reason_for_inhibit": "wakelock active",
+            }
+
+            return (fake_cookie,)
+
+    method = FreedesktopScreenSaverInhibit(dbus_adapter=TestAdapter())
+    assert method.inhibit_cookie is None
+
+    # Act
+    enter_retval = method.enter_mode()
+
+    # Assert
+    assert enter_retval is None
+    # Entering mode sets a inhibit_cookie to value returned by the DbusAdapter
+    assert method.inhibit_cookie == fake_cookie
+
+
+def test_screensaver_exit_mode():
+    # Arrange
+    method_uninhibit = DbusMethod(
+        name="Uninhibit",
+        signature="u",
+        params=("cookie",),
+    ).of(screen_saver)
+
+    class TestAdapter(DbusAdapter):
+        def process(self, call):
+            assert call.method == method_uninhibit
+            assert call.get_kwargs() == {"cookie": fake_cookie}
+
+    method = FreedesktopScreenSaverInhibit(dbus_adapter=TestAdapter())
+    method.inhibit_cookie = fake_cookie
+
+    # Act
+    exit_retval = method.exit_mode()
+
+    # Assert
+    assert exit_retval is None
+    # exiting mode unsets the inhibit_cookie
+    assert method.inhibit_cookie is None
+
+
+def test_screensaver_exit_before_enter():
+    method = FreedesktopScreenSaverInhibit(dbus_adapter=DbusAdapter())
+    assert method.inhibit_cookie is None
+    assert method.exit_mode() is None
+
+
+def test_with_dbus_adapter_which_returns_none():
+    class BadAdapterReturnNone(DbusAdapter):
+        def process(self, _):
+            return None
+
+    method = FreedesktopScreenSaverInhibit(dbus_adapter=BadAdapterReturnNone())
+
+    with pytest.raises(
+        RuntimeError,
+        match=re.escape(
+            "Could not get inhibit cookie from org.freedesktop.ScreenSaver"
+        ),
+    ):
+        assert method.enter_mode() is False

--- a/wakepy/methods/__init__.py
+++ b/wakepy/methods/__init__.py
@@ -26,5 +26,6 @@ Examples
 # is that the Methods are registered into the method registry only if the class
 # definition is executed (if the module containing the Method class definition
 # is imported)
+from . import freedesktop as freedesktop
 from . import gnome as gnome
 from . import windows as windows

--- a/wakepy/methods/freedesktop.py
+++ b/wakepy/methods/freedesktop.py
@@ -19,7 +19,7 @@ class FreedesktopScreenSaverInhibit(Method):
     https://people.freedesktop.org/~hadess/idle-inhibition-spec/re01.html
     """
 
-    name = "org.gnome.ScreenSaver"
+    name = "org.freedesktop.ScreenSaver"
     mode = ModeName.KEEP_PRESENTING
 
     screen_saver = DbusAddress(

--- a/wakepy/methods/freedesktop.py
+++ b/wakepy/methods/freedesktop.py
@@ -1,0 +1,78 @@
+"""The Freedesktop.org related methods"""
+
+from typing import Optional
+
+from wakepy.core import (
+    BusType,
+    DbusAddress,
+    DbusMethod,
+    DbusMethodCall,
+    Method,
+    ModeName,
+    PlatformName,
+)
+
+
+class FreedesktopScreenSaverInhibit(Method):
+    """Method using org.freedesktop.ScreenSaver D-Bus API
+
+    https://people.freedesktop.org/~hadess/idle-inhibition-spec/re01.html
+    """
+
+    name = "org.gnome.ScreenSaver"
+    mode = ModeName.KEEP_PRESENTING
+
+    screen_saver = DbusAddress(
+        bus=BusType.SESSION,
+        service="org.freedesktop.ScreenSaver",
+        path="/org/freedesktop/ScreenSaver",
+        interface="org.freedesktop.ScreenSaver",
+    )
+
+    method_inhibit = DbusMethod(
+        name="Inhibit",
+        signature="ss",
+        params=("application_name", "reason_for_inhibit"),
+        output_signature="u",
+        output_params=("cookie",),
+    ).of(screen_saver)
+
+    method_uninhibit = DbusMethod(
+        name="Uninhibit",
+        signature="u",
+        params=("cookie",),
+    ).of(screen_saver)
+
+    supported_platforms = (PlatformName.LINUX,)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.inhibit_cookie: Optional[int] = None
+
+    def enter_mode(self):
+        call = DbusMethodCall(
+            method=self.method_inhibit,
+            args=dict(
+                application_name="wakepy",
+                reason_for_inhibit="wakelock active",
+            ),
+        )
+
+        retval = self.process_dbus_call(call)
+        if retval is None:
+            raise RuntimeError(
+                "Could not get inhibit cookie from org.freedesktop.ScreenSaver"
+            )
+        self.inhibit_cookie = retval[0]
+
+    def exit_mode(self):
+        if self.inhibit_cookie is None:
+            # Nothing to exit from.
+            return
+
+        call = DbusMethodCall(
+            method=self.method_uninhibit,
+            args=dict(cookie=self.inhibit_cookie),
+        )
+        self.process_dbus_call(call)
+        self.inhibit_cookie = None


### PR DESCRIPTION
Implements a keep.running mode with https://people.freedesktop.org/~hadess/idle-inhibition-spec/re01.html

The org.freedesktop.Screensaver does not have option for inhibiting just suspend.

Closes: https://github.com/fohrloop/wakepy/issues/62