### PR TITLE
Issue 61: Add Method for MacOS (caffeinate) using new API

### DIFF
--- a/tests/unit/test_methods/test_macos.py
+++ b/tests/unit/test_methods/test_macos.py
@@ -1,0 +1,46 @@
+from unittest.mock import patch, Mock, call
+
+import pytest
+
+from wakepy.methods import macos
+from subprocess import PIPE
+
+
+@pytest.mark.parametrize(
+    "method_cls, expected_command",
+    [
+        (macos.CaffeinateKeepRunning, ["caffeinate"]),
+        (macos.CaffeinateKeepPresenting, ["caffeinate", "-d"]),
+    ],
+)
+def test_enter_mode_success(method_cls, expected_command):
+    method = method_cls()
+
+    with patch("wakepy.methods.macos.Popen") as popenmock:
+        popenmock.return_value = Mock()
+        retval = method.enter_mode()
+
+    assert retval is None
+    assert expected_command == method.command.split()
+    popenmock.assert_called_with(expected_command, stdin=PIPE, stdout=PIPE)
+    # Entering the mode sets the ._process
+    assert method._process is popenmock.return_value
+
+
+@pytest.mark.parametrize(
+    "method_cls",
+    [macos.CaffeinateKeepRunning, macos.CaffeinateKeepPresenting],
+)
+def test_exit_mode_success(method_cls):
+    method = method_cls()
+
+    method._process = Mock()
+    retval = method.exit_mode()
+
+    assert retval is None
+    assert method._process.mock_calls == [call.terminate(), call.wait()]
+
+    # Case: Mode not entered
+    method = method_cls()
+    retval = method.exit_mode()
+    assert retval is None

--- a/wakepy/methods/__init__.py
+++ b/wakepy/methods/__init__.py
@@ -28,4 +28,5 @@ Examples
 # is imported)
 from . import freedesktop as freedesktop
 from . import gnome as gnome
+from . import macos as macos
 from . import windows as windows

--- a/wakepy/methods/macos.py
+++ b/wakepy/methods/macos.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import logging
+import typing
+from abc import ABC, abstractmethod
+from subprocess import PIPE, Popen
+
+from wakepy.core import Method, ModeName, PlatformName
+
+if typing.TYPE_CHECKING:
+    from typing import Optional
+
+
+class _MacCaffeinate(Method, ABC):
+    """This is a method which calls the `caffeinate` command.
+
+    Docs: https://ss64.com/osx/caffeinate.html
+    Also: https://web.archive.org/web/20140604153141/https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man8/caffeinate.8.html
+    """
+
+    supported_platforms = (PlatformName.MACOS, PlatformName.LINUX)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.logger = logging.getLogger(__name__)
+        self._process: Optional[Popen] = None
+
+    def enter_mode(self):
+        self.logger.debug('Running "%s"', self.command)
+        self._process = Popen(self.command.split(), stdin=PIPE, stdout=PIPE)
+
+    def exit_mode(self):
+        if self._process is None:
+            self.logger.debug("No need to terminate process (not started)")
+            return
+        self.logger.debug('Terminating process ("%s")', self.command)
+        self._process.terminate()
+        self._process.wait()
+
+    @property
+    @abstractmethod
+    def command(self) -> str:
+        ...
+
+
+class CaffeinateKeepRunning(_MacCaffeinate):
+    mode = ModeName.KEEP_RUNNING
+    command = "caffeinate"
+    name = "caffeinate"
+
+
+class CaffeinatePresenting(_MacCaffeinate):
+    mode = ModeName.KEEP_PRESENTING
+    # -d:  Create an assertion to prevent the display from sleeping.
+    command = "caffeinate -d"
+    name = "caffeinate"

--- a/wakepy/methods/macos.py
+++ b/wakepy/methods/macos.py
@@ -18,7 +18,7 @@ class _MacCaffeinate(Method, ABC):
     Also: https://web.archive.org/web/20140604153141/https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man8/caffeinate.8.html
     """
 
-    supported_platforms = (PlatformName.MACOS, PlatformName.LINUX)
+    supported_platforms = (PlatformName.MACOS,)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -49,7 +49,7 @@ class CaffeinateKeepRunning(_MacCaffeinate):
     name = "caffeinate"
 
 
-class CaffeinatePresenting(_MacCaffeinate):
+class CaffeinateKeepPresenting(_MacCaffeinate):
     mode = ModeName.KEEP_PRESENTING
     # -d:  Create an assertion to prevent the display from sleeping.
     command = "caffeinate -d"

--- a/wakepy/methods/macos.py
+++ b/wakepy/methods/macos.py
@@ -23,7 +23,7 @@ class _MacCaffeinate(Method, ABC):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.logger = logging.getLogger(__name__)
-        self._process: Optional[Popen] = None
+        self._process: Optional[Popen[bytes]] = None
 
     def enter_mode(self):
         self.logger.debug('Running "%s"', self.command)


### PR DESCRIPTION
Basically the same method as in previous versions of wakepy, but now as subclass of wakepy.Method.

Adds support for MacOS for wakepy 0.8.0 