### PR TITLE
Issue 29: on_fail action for Mode activation

### DIFF
--- a/tests/unit/test_modes.py
+++ b/tests/unit/test_modes.py
@@ -2,9 +2,9 @@ import re
 
 import pytest
 
+from wakepy import ActivationError
 from wakepy.core import ActivationResult, DbusAdapter, Method, Mode, ModeName
 from wakepy.modes import keep
-from wakepy import ActivationError
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_modes.py
+++ b/tests/unit/test_modes.py
@@ -83,8 +83,9 @@ def test_keep_running_with_fake_success(monkeypatch, fake_dbus_adapter):
     assert isinstance(m.activation_result, ActivationResult)
 
 
-def test_keep_presenting(fake_dbus_adapter):
+def test_keep_presenting(monkeypatch, fake_dbus_adapter):
     """Simple smoke test for keep.presenting()"""
+    monkeypatch.setenv("WAKEPY_FAKE_SUCCESS", "1")
     with keep.presenting(dbus_adapter=fake_dbus_adapter) as m:
         assert isinstance(m, Mode)
-        assert isinstance(m.activation_result.success, bool)
+        assert m.activation_result.success is True

--- a/tests/unit/test_modes.py
+++ b/tests/unit/test_modes.py
@@ -120,6 +120,18 @@ class TestOnFail:
             with modefactory(methods=[], on_fail="error") as m:
                 self._assertions_for_activation_failure(m, expected_name)
 
+    def test_on_fail_callable(self, modefactory, expected_name):
+        called = False
+
+        def my_callable(result):
+            nonlocal called
+            called = True
+            assert isinstance(result, ActivationResult)
+
+        with modefactory(methods=[], on_fail=my_callable) as m:
+            assert called is True
+            self._assertions_for_activation_failure(m, expected_name)
+
     @staticmethod
     def _assertions_for_activation_failure(m: Mode, expected_name):
         assert m.active is False

--- a/tests/unit/test_modes.py
+++ b/tests/unit/test_modes.py
@@ -4,6 +4,7 @@ import pytest
 
 from wakepy.core import ActivationResult, DbusAdapter, Method, Mode, ModeName
 from wakepy.modes import keep
+from wakepy import ActivationError
 
 
 @pytest.mark.parametrize(
@@ -111,6 +112,12 @@ class TestOnFail:
         err_txt = f'Could not activate Mode "{expected_name}"!'
         with pytest.warns(UserWarning, match=re.escape(err_txt)):
             with modefactory(methods=[], on_fail="warn") as m:
+                self._assertions_for_activation_failure(m, expected_name)
+
+    def test_on_fail_error(self, modefactory, expected_name):
+        err_txt = f'Could not activate Mode "{expected_name}"!'
+        with pytest.raises(ActivationError, match=re.escape(err_txt)):
+            with modefactory(methods=[], on_fail="error") as m:
                 self._assertions_for_activation_failure(m, expected_name)
 
     @staticmethod

--- a/tests/unit/test_modes.py
+++ b/tests/unit/test_modes.py
@@ -89,3 +89,19 @@ def test_keep_presenting(monkeypatch, fake_dbus_adapter):
     with keep.presenting(dbus_adapter=fake_dbus_adapter) as m:
         assert isinstance(m, Mode)
         assert m.activation_result.success is True
+
+
+@pytest.mark.parametrize(
+    "modefactory, expected_name",
+    [
+        (keep.running, "keep.running"),
+        (keep.presenting, "keep.presenting"),
+    ],
+)
+def test_keep_x_failure_pass(modefactory, expected_name):
+    """Test failure handling for keep.presenting and keep.running."""
+    with modefactory(methods=[], on_fail="pass") as m:
+        assert m.active is False
+        assert isinstance(m, Mode)
+        assert m.name == expected_name
+        assert m.activation_result.modename == expected_name

--- a/tests/unit/test_modes.py
+++ b/tests/unit/test_modes.py
@@ -102,7 +102,8 @@ def test_keep_presenting(monkeypatch, fake_dbus_adapter):
     ],
 )
 class TestOnFail:
-    """Test failure handling for keep.presenting and keep.running."""
+    """Test failure handling for keep.presenting and keep.running. (the on_fail
+    parameter)"""
 
     def test_on_fail_pass(self, modefactory, expected_name):
         with modefactory(methods=[], on_fail="pass") as m:

--- a/wakepy/__init__.py
+++ b/wakepy/__init__.py
@@ -1,5 +1,6 @@
 # NOTE The methods sub-package is imported for registering all the methods.
 from . import methods as methods
+from .core import ActivationError as ActivationError
 from .core import DbusAdapter as DbusAdapter
 from .core import Method as Method
 from .core import Mode as Mode

--- a/wakepy/core/__init__.py
+++ b/wakepy/core/__init__.py
@@ -14,8 +14,8 @@ from .dbus import DbusAddress as DbusAddress
 from .dbus import DbusMethod as DbusMethod
 from .dbus import DbusMethodCall as DbusMethodCall
 from .method import Method as Method
-from .mode import Mode as Mode
 from .mode import ActivationError as ActivationError
+from .mode import Mode as Mode
 from .platform import CURRENT_PLATFORM as CURRENT_PLATFORM
 from .registry import get_method as get_method
 from .registry import get_methods as get_methods

--- a/wakepy/core/__init__.py
+++ b/wakepy/core/__init__.py
@@ -15,6 +15,7 @@ from .dbus import DbusMethod as DbusMethod
 from .dbus import DbusMethodCall as DbusMethodCall
 from .method import Method as Method
 from .mode import Mode as Mode
+from .mode import ActivationError as ActivationError
 from .platform import CURRENT_PLATFORM as CURRENT_PLATFORM
 from .registry import get_method as get_method
 from .registry import get_methods as get_methods

--- a/wakepy/core/mode.py
+++ b/wakepy/core/mode.py
@@ -229,14 +229,16 @@ def create_mode(
     modename: ModeName,
     methods: Optional[StrCollection] = None,
     omit: Optional[StrCollection] = None,
-    methods_priority: Optional[MethodsPriorityOrder] = None,
-    dbus_adapter: Type[DbusAdapter] | DbusAdapterTypeSeq | None = None,
+    **kwargs,
 ) -> Mode:
     """
     Creates and returns a Mode (a context manager).
 
     Parameters
     ----------
+    modename:
+        The name of the mode to create. Used for debugging, logging, warning
+        and error messaged. Could be basically any string.
     methods: list, tuple or set of str
         The names of Methods to select from the mode defined with `modename`;
         a "whitelist" filter. Means "use these and only these Methods". Any
@@ -247,10 +249,9 @@ def create_mode(
         a "blacklist" filter. Any Method in `omit` but not in the selected mode
         will be silently ignored. Cannot be used same time with `methods`.
         Optional.
-    methods_priority: list[str | set[str]]
-        The methods_priority parameter for Mode. Used to prioritize methods.
-    dbus_adapter:
-        Optional argument which can be used to define a custom DBus adapter.
+    **kwargs
+        Passed to Mode as initialization arguments.
+
 
     Returns
     -------
@@ -259,12 +260,7 @@ def create_mode(
     """
     methods_for_mode = get_methods_for_mode(modename)
     selected_methods = select_methods(methods_for_mode, use_only=methods, omit=omit)
-    return Mode(
-        name=modename,
-        methods=selected_methods,
-        methods_priority=methods_priority,
-        dbus_adapter=dbus_adapter,
-    )
+    return Mode(name=modename, methods=selected_methods, **kwargs)
 
 
 def handle_activation_fail(on_fail: OnFail, result: ActivationResult):

--- a/wakepy/core/mode.py
+++ b/wakepy/core/mode.py
@@ -11,12 +11,17 @@ from .registry import get_methods_for_mode
 
 if typing.TYPE_CHECKING:
     from types import TracebackType
-    from typing import Optional, Type
+    from typing import Optional, Type, Literal, Callable
 
     from .activation import MethodsPriorityOrder
     from .constants import ModeName
     from .dbus import DbusAdapter, DbusAdapterTypeSeq
     from .method import Method, StrCollection
+
+
+OnFail: Literal["error"] | Literal["warn"] | Literal["pass"] | Callable[
+    [ActivationResult], None
+]
 
 
 class ModeExit(Exception):

--- a/wakepy/core/mode.py
+++ b/wakepy/core/mode.py
@@ -169,6 +169,10 @@ class Mode(ABC):
             methods_priority=self.methods_priority,
         )
         self.active = self.activation_result.success
+
+        if not self.active:
+            handle_activation_fail(self.on_fail, self.activation_result)
+
         return self
 
     def __exit__(

--- a/wakepy/core/mode.py
+++ b/wakepy/core/mode.py
@@ -180,6 +180,7 @@ class Mode(ABC):
         self.activation_result = self.controller.activate(
             self.methods_classes,
             methods_priority=self.methods_priority,
+            modename=self.name,
         )
         self.active = self.activation_result.success
 

--- a/wakepy/core/mode.py
+++ b/wakepy/core/mode.py
@@ -19,10 +19,7 @@ if typing.TYPE_CHECKING:
     from .dbus import DbusAdapter, DbusAdapterTypeSeq
     from .method import Method, StrCollection
 
-
-OnFail: Literal["error"] | Literal["warn"] | Literal["pass"] | Callable[
-    [ActivationResult], None
-]
+    OnFail = Literal["error", "warn", "pass"] | Callable[[ActivationResult], None]
 
 
 class ActivationError(RuntimeError):

--- a/wakepy/core/mode.py
+++ b/wakepy/core/mode.py
@@ -128,7 +128,7 @@ class Mode(ABC):
         self,
         methods: list[Type[Method]],
         methods_priority: Optional[MethodsPriorityOrder] = None,
-        name: ModeName | str = "[unnamed mode]",
+        name: Optional[ModeName | str] = None,
         on_fail: OnFail = "error",
         dbus_adapter: Type[DbusAdapter] | DbusAdapterTypeSeq | None = None,
     ):
@@ -149,7 +149,7 @@ class Mode(ABC):
         name:
             Name of the Mode. Used for communication to user, logging and in
             error messages (can be "any string" which makes sense to you).
-            Defaults to "[unnamed mode]".
+            Optional.
         on_fail:
             Determines what to do in case mode activation fails. Valid options
             are: "error", "warn", "pass" and a callable. If the option is

--- a/wakepy/core/mode.py
+++ b/wakepy/core/mode.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import typing
 from abc import ABC
+import warnings
 
 from .activation import ActivationResult, activate_mode, deactivate_method
 from .dbus import get_dbus_adapter
@@ -257,3 +258,20 @@ def create_mode(
         methods_priority=methods_priority,
         dbus_adapter=dbus_adapter,
     )
+
+
+def handle_activation_fail(on_fail: OnFail, result: ActivationResult):
+    if on_fail == "pass":
+        return
+    elif on_fail == "warn" or on_fail == "error":
+        err_txt = "Could not activate mode"
+        if on_fail == "warn":
+            warnings.warn(err_txt)
+        else:
+            raise ActivationError(err_txt)
+    elif not callable(on_fail):
+        raise ValueError(
+            'on_fail must be one of "error", "warn", pass" or a callable which takes '
+            "single positional argument (ActivationResult)"
+        )
+    callable(result)

--- a/wakepy/core/mode.py
+++ b/wakepy/core/mode.py
@@ -273,6 +273,7 @@ def handle_activation_fail(on_fail: OnFail, result: ActivationResult):
         err_txt = f'Could not activate Mode "{modename}"!'
         if on_fail == "warn":
             warnings.warn(err_txt)
+            return
         else:
             raise ActivationError(err_txt)
     elif not callable(on_fail):
@@ -280,4 +281,4 @@ def handle_activation_fail(on_fail: OnFail, result: ActivationResult):
             'on_fail must be one of "error", "warn", pass" or a callable which takes '
             "single positional argument (ActivationResult)"
         )
-    callable(result)
+    on_fail(result)

--- a/wakepy/core/mode.py
+++ b/wakepy/core/mode.py
@@ -61,6 +61,7 @@ class ModeController:
         self,
         method_classes: list[Type[Method]],
         methods_priority: Optional[MethodsPriorityOrder] = None,
+        modename: Optional[str] = None,
     ) -> ActivationResult:
         """Activates the mode with one of the methods in the input method
         classes. The methods are used with descending priority; highest
@@ -70,6 +71,7 @@ class ModeController:
             methods=method_classes,
             methods_priority=methods_priority,
             dbus_adapter=self.dbus_adapter,
+            modename=modename,
         )
         self.active_method = active_method
         self.heartbeat = heartbeat

--- a/wakepy/core/mode.py
+++ b/wakepy/core/mode.py
@@ -126,9 +126,9 @@ class Mode(ABC):
 
     def __init__(
         self,
-        name: str,
         methods: list[Type[Method]],
         methods_priority: Optional[MethodsPriorityOrder] = None,
+        name: ModeName | str = "[unnamed mode]",
         on_fail: OnFail = "error",
         dbus_adapter: Type[DbusAdapter] | DbusAdapterTypeSeq | None = None,
     ):
@@ -139,9 +139,6 @@ class Mode(ABC):
 
         Parameters
         ----------
-        name:
-            Name of the Mode. Used for communication to user, logging and in
-            error messages (can be "any string" which makes sense to you).
         methods:
             The list of Methods to be used for activating this Mode.
         methods_priority: list[str | set[str]]
@@ -149,6 +146,10 @@ class Mode(ABC):
             ('*'). The asterisk means "all rest methods" and may occur only
             once in the priority order, and cannot be part of a set. All method
             names must be unique and must be part of the `methods`.
+        name:
+            Name of the Mode. Used for communication to user, logging and in
+            error messages (can be "any string" which makes sense to you).
+            Defaults to "[unnamed mode]".
         on_fail:
             Determines what to do in case mode activation fails. Valid options
             are: "error", "warn", "pass" and a callable. If the option is

--- a/wakepy/core/mode.py
+++ b/wakepy/core/mode.py
@@ -122,6 +122,7 @@ class Mode(ABC):
         self,
         methods: list[Type[Method]],
         methods_priority: Optional[MethodsPriorityOrder] = None,
+        on_fail: OnFail = "error",
         dbus_adapter: Type[DbusAdapter] | DbusAdapterTypeSeq | None = None,
     ):
         """Initialize a Mode using Methods.
@@ -138,6 +139,14 @@ class Mode(ABC):
             ('*'). The asterisk means "all rest methods" and may occur only
             once in the priority order, and cannot be part of a set. All method
             names must be unique and must be part of the `methods`.
+        on_fail:
+            Determines what to do in case mode activation fails. Valid options
+            are: "error", "warn", "pass" and a callable. If the option is
+            "error", raises wakepy.ActivationError. Is selected "warn", issues
+            warning. If "pass", does nothing. If `on_fail` is a callable, it
+            must take one positional argument: result, which is an instance of
+            ActivationResult. The ActivationResult contains more detailed
+            information about the activation process.
         dbus_adapter:
             For using a custom dbus-adapter. Optional.
         """
@@ -147,6 +156,7 @@ class Mode(ABC):
         self.controller: ModeController | None = None
         self.activation_result: ActivationResult | None = None
         self.active: bool = False
+        self.on_fail = on_fail
         self._dbus_adapter_cls = dbus_adapter
 
     def __enter__(self) -> Mode:

--- a/wakepy/core/mode.py
+++ b/wakepy/core/mode.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import typing
-from abc import ABC
 import warnings
+from abc import ABC
 
 from .activation import ActivationResult, activate_mode, deactivate_method
 from .dbus import get_dbus_adapter
@@ -12,7 +12,7 @@ from .registry import get_methods_for_mode
 
 if typing.TYPE_CHECKING:
     from types import TracebackType
-    from typing import Optional, Type, Literal, Callable
+    from typing import Callable, Literal, Optional, Type
 
     from .activation import MethodsPriorityOrder
     from .constants import ModeName

--- a/wakepy/core/mode.py
+++ b/wakepy/core/mode.py
@@ -24,6 +24,11 @@ OnFail: Literal["error"] | Literal["warn"] | Literal["pass"] | Callable[
 ]
 
 
+class ActivationError(RuntimeError):
+    """Raised if activation is not successful and on-fail action is to raise
+    Exception."""
+
+
 class ModeExit(Exception):
     """This can be used to exit from any wakepy mode with block. Just raise it
     within any with block which is a wakepy mode, and no code below it will

--- a/wakepy/core/mode.py
+++ b/wakepy/core/mode.py
@@ -269,7 +269,8 @@ def handle_activation_fail(on_fail: OnFail, result: ActivationResult):
     if on_fail == "pass":
         return
     elif on_fail == "warn" or on_fail == "error":
-        err_txt = "Could not activate mode"
+        modename = result.modename or "[unnamed mode]"
+        err_txt = f'Could not activate Mode "{modename}"!'
         if on_fail == "warn":
             warnings.warn(err_txt)
         else:

--- a/wakepy/core/mode.py
+++ b/wakepy/core/mode.py
@@ -126,6 +126,7 @@ class Mode(ABC):
 
     def __init__(
         self,
+        name: str,
         methods: list[Type[Method]],
         methods_priority: Optional[MethodsPriorityOrder] = None,
         on_fail: OnFail = "error",
@@ -138,6 +139,9 @@ class Mode(ABC):
 
         Parameters
         ----------
+        name:
+            Name of the Mode. Used for communication to user, logging and in
+            error messages (can be "any string" which makes sense to you).
         methods:
             The list of Methods to be used for activating this Mode.
         methods_priority: list[str | set[str]]
@@ -157,6 +161,7 @@ class Mode(ABC):
             For using a custom dbus-adapter. Optional.
         """
 
+        self.name = name
         self.methods_classes = methods
         self.methods_priority = methods_priority
         self.controller: ModeController | None = None
@@ -254,6 +259,7 @@ def create_mode(
     methods_for_mode = get_methods_for_mode(modename)
     selected_methods = select_methods(methods_for_mode, use_only=methods, omit=omit)
     return Mode(
+        name=modename,
         methods=selected_methods,
         methods_priority=methods_priority,
         dbus_adapter=dbus_adapter,

--- a/wakepy/core/mode.py
+++ b/wakepy/core/mode.py
@@ -174,10 +174,9 @@ class Mode(ABC):
         self._dbus_adapter_cls = dbus_adapter
 
     def __enter__(self) -> Mode:
-        if self.controller is None:
-            self.controller = self._controller_class(
-                dbus_adapter=get_dbus_adapter(self._dbus_adapter_cls)
-            )
+        self.controller = self.controller or self._controller_class(
+            dbus_adapter=get_dbus_adapter(self._dbus_adapter_cls)
+        )
         self.activation_result = self.controller.activate(
             self.methods_classes,
             methods_priority=self.methods_priority,

--- a/wakepy/modes/keep.py
+++ b/wakepy/modes/keep.py
@@ -11,13 +11,14 @@ if typing.TYPE_CHECKING:
     from ..core.activation import MethodsPriorityOrder
     from ..core.dbus import DbusAdapter, DbusAdapterTypeSeq
     from ..core.method import StrCollection
-    from ..core.mode import Mode
+    from ..core.mode import Mode, OnFail
 
 
 def running(
     methods: Optional[StrCollection] = None,
     omit: Optional[StrCollection] = None,
     methods_priority: Optional[MethodsPriorityOrder] = None,
+    on_fail: OnFail = "error",
     dbus_adapter: Type[DbusAdapter] | DbusAdapterTypeSeq | None = None,
 ) -> Mode:
     """Create a wakepy mode (a context manager) for keeping programs running.
@@ -41,9 +42,6 @@ def running(
 
     ```
     with keep.running() as k:
-        if k.failed:
-            # fall back or notify user
-
         # do something that takes a long time.
     ```
 
@@ -75,7 +73,14 @@ def running(
         and may occur only once in the priority order, and cannot be part of a
         set. If asterisk is not part of the `methods_priority`, it will be
         added as the last element automatically.
-
+    on_fail:
+        Determines what to do in case mode activation fails. Valid options are:
+        "error", "warn", "pass" and a callable. If the option is "error",
+        raises wakepy.ActivationError. Is selected "warn", issues warning. If
+        "pass", does nothing. If `on_fail` is a callable, it must take one
+        positional argument: result, which is an instance of ActivationResult.
+        The ActivationResult contains more detailed information about the
+        activation process.
     dbus_adapter:
         Optional argument which can be used to define a customer DBus adapter.
 
@@ -90,6 +95,7 @@ def running(
         omit=omit,
         methods=methods,
         methods_priority=methods_priority,
+        on_fail=on_fail,
         dbus_adapter=dbus_adapter,
     )
 
@@ -98,6 +104,7 @@ def presenting(
     methods: Optional[StrCollection] = None,
     omit: Optional[StrCollection] = None,
     methods_priority: Optional[MethodsPriorityOrder] = None,
+    on_fail: OnFail = "error",
     dbus_adapter: Type[DbusAdapter] | DbusAdapterTypeSeq | None = None,
 ) -> Mode:
     """Create a wakepy mode (a context manager) for keeping a system running
@@ -107,9 +114,6 @@ def presenting(
 
     ```
     with keep.presenting() as k:
-        if k.failed:
-            # fall back or notify user
-
         # do something that takes a long time.
     ```
 
@@ -141,9 +145,16 @@ def presenting(
         and may occur only once in the priority order, and cannot be part of a
         set. If asterisk is not part of the `methods_priority`, it will be
         added as the last element automatically.
+    on_fail:
+        Determines what to do in case mode activation fails. Valid options are:
+        "error", "warn", "pass" and a callable. If the option is "error",
+        raises wakepy.ActivationError. Is selected "warn", issues warning. If
+        "pass", does nothing. If `on_fail` is a callable, it must take one
+        positional argument: result, which is an instance of ActivationResult.
+        The ActivationResult contains more detailed information about the
+        activation process.
     dbus_adapter:
         Optional argument which can be used to define a customer DBus adapter.
-
 
     Returns
     -------
@@ -155,5 +166,6 @@ def presenting(
         methods=methods,
         omit=omit,
         methods_priority=methods_priority,
+        on_fail=on_fail,
         dbus_adapter=dbus_adapter,
     )


### PR DESCRIPTION
Closes: https://github.com/fohrloop/wakepy/issues/29

The modes now receive a `on_fail` argument:

```
with keep.running(on_fail="warn"):
    ...
```
 
The on fail can either a string or a callable.

"error" (raise wakepy.ActivationError) -- default
"warn" (warnings.warn)
"pass" (do nothing)
callable (custom callable, which takes single argument: ActivationResult)