### PR TITLE
Better error text when mode activation fails

### DIFF
--- a/tests/unit/test_core/test_activation/test_activationresult.py
+++ b/tests/unit/test_core/test_activation/test_activationresult.py
@@ -175,6 +175,21 @@ def test_activation_result_success(
         assert ar.failure == (not success_expected)
 
 
+def test_activationresult_get_error_text_success():
+    ar = ActivationResult(METHODACTIVATIONRESULTS_1)
+    # error text is empty string in case of success.
+    assert ar.get_error_text() == ""
+
+
+def test_activationresult_get_error_text_failure():
+    ar = ActivationResult(
+        [PLATFORM_SUPPORT_FAIL, REQUIREMENTS_FAIL], modename="SomeMode"
+    )
+    assert ar.get_error_text() == (
+        'Could not activate Mode "SomeMode"!\n\nMethod usage results, in order (highest priority first):\n[(FAIL @PLATFORM_SUPPORT, fail-platform, "Platform XYZ not supported!"), (FAIL @REQUIREMENTS, fail-requirements, "Missing requirement: Some SW v.1.2.3")]'
+    )
+
+
 def test_active_method():
     ar = ActivationResult(METHODACTIVATIONRESULTS_1)
     assert ar.active_method == "a-successful-method"

--- a/wakepy/core/activation.py
+++ b/wakepy/core/activation.py
@@ -223,6 +223,20 @@ class ActivationResult:
 
         return out
 
+    def get_error_text(self) -> str:
+        """Gets information about a failure as text. In case the mode
+        activation was successful, returns an empty string."""
+
+        if self.success:
+            return ""
+        debug_info = str(self.query())
+        modename = self.modename or "[unnamed mode]"
+
+        return (
+            f'Could not activate Mode "{modename}"!\n\nMethod usage results, in '
+            f"order (highest priority first):\n{debug_info}"
+        )
+
 
 @dataclass
 class MethodActivationResult:

--- a/wakepy/core/activation.py
+++ b/wakepy/core/activation.py
@@ -156,7 +156,11 @@ class ActivationResult:
     ) -> list[MethodActivationResult]:
         """Get a list of the methods present in the activation process, and
         their activation results. This is the higher-level interface. If you
-        want more control, use .query().
+        want more control, use .query(). The returned methods are in the order
+        as given in when initializing ActivationResult. If you did not create
+        the ActivationReult manually, the methods are in the priority order;
+        the highest priority methods (those which are/were tried first) are
+        listed first.
 
         Parameters
         ----------
@@ -187,7 +191,11 @@ class ActivationResult:
     ) -> list[MethodActivationResult]:
         """Get a list of the methods present in the activation process, and
         their activation results. This is the lower-level interface. If you
-        want easier access, use .list_methods().
+        want easier access, use .list_methods(). The methods are in the order
+        as given in when initializing ActivationResult. If you did not create
+        the ActivationReult manually, the methods are in the priority order;
+        the highest priority methods (those which are/were tried first) are
+        listed first.
 
         Parameters
         ----------

--- a/wakepy/core/mode.py
+++ b/wakepy/core/mode.py
@@ -266,17 +266,11 @@ def handle_activation_fail(on_fail: OnFail, result: ActivationResult):
     if on_fail == "pass":
         return
     elif on_fail == "warn" or on_fail == "error":
-        debug_info = str(result.query())
-        modename = result.modename or "[unnamed mode]"
-        err_txt = (
-            f'Could not activate Mode "{modename}"!\n\nMethod usage results, in '
-            f"order (highest priority first):\n{debug_info}"
-        )
         if on_fail == "warn":
-            warnings.warn(err_txt)
+            warnings.warn(result.get_error_text())
             return
         else:
-            raise ActivationError(err_txt)
+            raise ActivationError(result.get_error_text())
     elif not callable(on_fail):
         raise ValueError(
             'on_fail must be one of "error", "warn", pass" or a callable which takes '

--- a/wakepy/core/mode.py
+++ b/wakepy/core/mode.py
@@ -266,8 +266,12 @@ def handle_activation_fail(on_fail: OnFail, result: ActivationResult):
     if on_fail == "pass":
         return
     elif on_fail == "warn" or on_fail == "error":
+        debug_info = str(result.query())
         modename = result.modename or "[unnamed mode]"
-        err_txt = f'Could not activate Mode "{modename}"!'
+        err_txt = (
+            f'Could not activate Mode "{modename}"!\n\nMethod usage results, in '
+            f"order (highest priority first):\n{debug_info}"
+        )
         if on_fail == "warn":
             warnings.warn(err_txt)
             return


### PR DESCRIPTION
Previously, the error text for a failing mode activation was:

```
ActivationError: Could not activate Mode "keep.running"!
```

Now, it is (toy example):

```
ActivationError: Could not activate Mode "keep.running"!

Method usage results, in order (highest priority first):
[(FAIL @ACTIVATION, org.gnome.SessionManager, "Error in the enter_mode of GnomeSessionManagerNoSuspend (org.gnome.SessionManager)! Original error: division by zero"), (FAIL @PLATFORM_SUPPORT, caffeinate, ""), (FAIL @PLATFORM_SUPPORT, SetThreadExecutionState, "")]
```

In addition, the ActivationResult has now a .get_error_text() method which may be used to get the error text.