### PR TITLE
better jeepney error text

### DIFF
--- a/wakepy/dbus_adapters/jeepney.py
+++ b/wakepy/dbus_adapters/jeepney.py
@@ -5,6 +5,10 @@ from jeepney.wrappers import unwrap_msg
 from wakepy.core import DbusAdapter, DbusMethodCall
 
 
+class DbusNotFoundError(RuntimeError):
+    ...
+
+
 class JeepneyDbusAdapter(DbusAdapter):
     """An implementation of DbusAdapter using jeepney. Can be used to process
     DbusMethodCalls (communication with Dbus services over a dbus-daemon)."""
@@ -25,7 +29,18 @@ class JeepneyDbusAdapter(DbusAdapter):
             signature=call.method.signature,
             body=call.args,
         )
-        connection = open_dbus_connection(bus=call.method.bus)
+        try:
+            connection = open_dbus_connection(bus=call.method.bus)
+        except KeyError as exc:
+            if "DBUS_SESSION_BUS_ADDRESS" in str(exc):
+                raise DbusNotFoundError(
+                    "The environment variable DBUS_SESSION_BUS_ADDRESS is not set! "
+                    "To use dbus-based methods with jeepney, a session (not system) "
+                    "bus (dbus-daemon process) must be running, and the address of the "
+                    "bus should be available at the DBUS_SESSION_BUS_ADDRESS environment "
+                    "variable. To check if you're running a session dbus-daemon, run "
+                    "`ps -x | grep dbus-daemon`"
+                ) from exc
         reply = connection.send_and_get_reply(msg, timeout=self.timeout)
         resp = unwrap_msg(reply)
         return resp

--- a/wakepy/dbus_adapters/jeepney.py
+++ b/wakepy/dbus_adapters/jeepney.py
@@ -37,9 +37,9 @@ class JeepneyDbusAdapter(DbusAdapter):
                     "The environment variable DBUS_SESSION_BUS_ADDRESS is not set! "
                     "To use dbus-based methods with jeepney, a session (not system) "
                     "bus (dbus-daemon process) must be running, and the address of the "
-                    "bus should be available at the DBUS_SESSION_BUS_ADDRESS environment "
-                    "variable. To check if you're running a session dbus-daemon, run "
-                    "`ps -x | grep dbus-daemon`"
+                    "bus should be available at the DBUS_SESSION_BUS_ADDRESS "
+                    "environment variable. To check if you're running a session "
+                    "dbus-daemon, run `ps -x | grep dbus-daemon`"
                 ) from exc
         reply = connection.send_and_get_reply(msg, timeout=self.timeout)
         resp = unwrap_msg(reply)


### PR DESCRIPTION
Make the jeepney (dbus) related error texts more understandable if DBUS_SESSION_BUS_ADDRESS is not set.

Error before:
```
ActivationError: Could not activate Mode "keep.running"!

Method usage results, in order (highest priority first):
[(FAIL @ACTIVATION, org.gnome.SessionManager, "KeyError('DBUS_SESSION_BUS_ADDRESS')"), (FAIL 
@PLATFORM_SUPPORT, caffeinate, ""), (FAIL @PLATFORM_SUPPORT, SetThreadExecutionState, "")]
```

Error now:

```
ActivationError: Could not activate Mode "keep.running"!

Method usage results, in order (highest priority first):
[(FAIL @ACTIVATION, org.gnome.SessionManager, "DbusNotFoundError("The environment variable 
DBUS_SESSION_BUS_ADDRESS is not set! To use dbus-based methods with jeepney, a session (not system) bus (dbus-
daemon process) must be running, and the address of the bus should be available at the DBUS_SESSION_BUS_ADDRESS 
environment variable. To check if you're running a session dbus-daemon, run `ps -x | grep dbus-daemon`")"), (FAIL 
@PLATFORM_SUPPORT, caffeinate, ""), (FAIL @PLATFORM_SUPPORT, SetThreadExecutionState, "")]
```