### PR TITLE
remove trailing spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
-# Changelog 
+# Changelog
 
 ## Not published
 ### Changed
 - Removed `set_keepawake` and `unset_keepawake functions` and the `keepawake` context manager. These were deprecated in 0.7.0 and are replaced with the new api: `keep.running` and `keep.presenting` context managers.
 - The `WAKEPY_FAKE_SUCCESS` check is done *before* any other Methods (previously, it would be checked if all other methods failed)
-- Added `on_fail` parameter for modes. 
-- If Mode activation fails, raise `wakepy.ActivationError` by default. Previously 
+- Added `on_fail` parameter for modes.
+- If Mode activation fails, raise `wakepy.ActivationError` by default. Previously
   there was no "on fail" action, but users needed to check the
-  `result.success` to make sure the activation was successful. 
+  `result.success` to make sure the activation was successful.
 - It is now possible to select the used wakepy.Methods with `methods` and
  `omit` and to change the priority order of methods with `methods_priority`.
 
@@ -18,22 +18,22 @@
 ## [0.7.1] (2023-06-11)
 ### Fixed
 - `keep.running` and `keep.presenting` return an object `m` with `success` value of `True`.
-   
+
 ## [0.7.0] (2023-06-11)
 ### Added
-- New API: `keep.running()` and `keep.presenting()` context managers. These are currently simple wrappers of the old methods but the internals will be re-written in a future version. 
+- New API: `keep.running()` and `keep.presenting()` context managers. These are currently simple wrappers of the old methods but the internals will be re-written in a future version.
 - The context managers now return the result of the action, `m`. Users may check with `m.success` if changing the mode was succesful.
 - Possibility to fake succesful change of mode with `WAKEPY_FAKE_SUCCESS` (for CI / tests).
 ### Fixed
 - No exceptions anymore on import-time. All exceptions should be handled now gracefully, and user is informed if switching to a `keep.running` or `keep.presenting` mode failed.
-  
+
 ### Deprecated
 - Old Python API:  The `keepawake()`, `set_keepawake` and `unset_keepwake`. These will be removed in a future version of wakepy. Use `keep.running()`or `keep.presenting()`, instead.
-- The `-s, --keep-screen-awake` option of the `wakepy` CLI command. Use `-p, --presentation ` option, instead. 
+- The `-s, --keep-screen-awake` option of the `wakepy` CLI command. Use `-p, --presentation ` option, instead.
 
 ## [0.6.0] (2023-02-27)
 ### Added
-- Support for using wakepy without sudo on linux! There are now D-bus solutions (1) using  jeepney and (2) using dbus-python (libdbus). Thanks to [Stehlampe2020](https://github.com/Stehlampe2020) for the dbus-python based solution ([PR #22](https://github.com/np-8/wakepy/pull/22)) and [NicoWeio](https://github.com/NicoWeio) for raising  [Issue #17](https://github.com/np-8/wakepy/issues/17). 
+- Support for using wakepy without sudo on linux! There are now D-bus solutions (1) using  jeepney and (2) using dbus-python (libdbus). Thanks to [Stehlampe2020](https://github.com/Stehlampe2020) for the dbus-python based solution ([PR #22](https://github.com/np-8/wakepy/pull/22)) and [NicoWeio](https://github.com/NicoWeio) for raising  [Issue #17](https://github.com/np-8/wakepy/issues/17).
 ### Changed
 - Linux+systemd approach has sudo check. The program won't start without `SUDO_UID` environment variable set.
 
@@ -60,7 +60,7 @@
 
 
 ## [0.4.0] (2021-06-09)
-### Added 
+### Added
 - `keepawake` context manager. [[PR #6](https://github.com/np-8/wakepy/pull/6)]. Thanks to [HoustonFortney](https://github.com/HoustonFortney).
 
 ## [0.3.2] (2021-06-06)

--- a/DEV.md
+++ b/DEV.md
@@ -5,14 +5,14 @@ This document serves as documentation for the package developers.
 ## Branches and tags
 
 - **`dev`** branch: for development. All PRs should be against it.
-- **`latest-release`** branch: The latest wakepy release. This is used to select the where [wakepy.readthedocs.io](https://wakepy.readthedocs.io/) redirects to (the "latest" version). 
+- **`latest-release`** branch: The latest wakepy release. This is used to select the where [wakepy.readthedocs.io](https://wakepy.readthedocs.io/) redirects to (the "latest" version).
 - Use a local short-lived feature branch for development.
 - Release versions use [Semantic Versioning](https://semver.org/) and are marked with git tags (on the dev branch) with format `v[major].[minor].[patch]`; e.g. v1.2.0 or v2.2.0.
 
 ## Installing for development
 
-Requirements: 
-- At least of of the supported Python versions installed (see README.md and/or tox.ini). 
+Requirements:
+- At least of of the supported Python versions installed (see README.md and/or tox.ini).
 - pip >= 21.3 (for pyproject.toml support)
 
 Install in editable state with the `doc` and `dev` options:
@@ -20,11 +20,11 @@ Install in editable state with the `doc` and `dev` options:
 python -m pip install -e .[doc,dev]
 ```
 
-where `.` means the current directory (assuming cwd is at root of the repository). 
+where `.` means the current directory (assuming cwd is at root of the repository).
 
 ## Documentation
 
-- The documentation is done with Sphinx and the source code lives at 
+- The documentation is done with Sphinx and the source code lives at
  `./docs/source`.
 - **Building locally** (for debugging / testing docs), with autobuild:
 
@@ -37,12 +37,12 @@ The `-a` flag ensures that *all* files (not only edited files) will get rebuild.
 sphinx-build -b html docs/source/ docs/build
 ```
 - **Deploying**: Just push to github, and it will be automatically built by readthedocs. The settings can be adjusted [here](https://readthedocs.org/dashboard).
-- Versions selected for documentation are selected in the readthedocs UI. Select one version per `major.minor` version (latest of them) from the git tags. 
+- Versions selected for documentation are selected in the readthedocs UI. Select one version per `major.minor` version (latest of them) from the git tags.
 - The `latest` version (default versio) in readthedocs follows the `latest-release` branch automatically.
-  
 
 
-# Testing 
+
+# Testing
 
 - wakepy uses pytest for tests and tox for testing the library with multiple python versions.
 
@@ -58,16 +58,16 @@ python -m pytest
 - To run tests with coverage, use
 
 ```
-python -m pytest --cov-branch --cov wakepy && coverage html && python -m webbrowser -t htmlcov/index.html 
+python -m pytest --cov-branch --cov wakepy && coverage html && python -m webbrowser -t htmlcov/index.html
 ```
 
 ## Running tests with multiple environments
 
-- Requirement:  All the python versions mentioned in the envlist in tox.ini have to be installed and available for tox.  
+- Requirement:  All the python versions mentioned in the envlist in tox.ini have to be installed and available for tox.
 - To run the tests with multiple python versions, use tox:
 
 ```
-python -m tox 
+python -m tox
 ```
 
 - To start a debugger on error with a specific python version, select the tox environment with "-e <envname>" and add "-- --pdb" to start the python debugger on error. For example:
@@ -88,13 +88,13 @@ python -m pip wheel --no-deps .
 ```
 python -m twine  upload wakepy-<version>-py3-none-any.whl --repository wakepy
 ```
-- If made a new version, remember to update the `latest-release` branch so ReadTheDocs may update the documentation. 
+- If made a new version, remember to update the `latest-release` branch so ReadTheDocs may update the documentation.
 - Also, check that readthedocs has included all the correct versions (git tags)
 
 
 ## Setting up twine/pip for uploading to PyPI
 - This should be done once per system
-- (1) Get a PyPI token for the *project* from [pypi.org/manage/account/token/](https://pypi.org/manage/account/token/) 
+- (1) Get a PyPI token for the *project* from [pypi.org/manage/account/token/](https://pypi.org/manage/account/token/)
 - (2) Create a `$HOME/.pypirc` file with following contents:
 
 ```

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 <!-- start before docs link -->
 ![GitHub tag (latest by date)](https://img.shields.io/github/v/tag/fohrloop/wakepy)&nbsp;![PyPI](https://img.shields.io/pypi/v/wakepy)&nbsp;![PyPI - Downloads](https://img.shields.io/pypi/dm/wakepy)&nbsp;![GitHub](https://img.shields.io/github/license/fohrloop/wakepy)
 
-# ⏰😴 wakepy 
+# ⏰😴 wakepy
 
-Cross-platform wakelock / keep-awake / stay-awake written in Python. 
+Cross-platform wakelock / keep-awake / stay-awake written in Python.
 
 ## Supports
-- Python: 3.7 to 3.12 
-- OS: Windows, Linux and macOS 
+- Python: 3.7 to 3.12
+- OS: Windows, Linux and macOS
 
-## What it can do? 
+## What it can do?
 
 Wakepy has two main modes:
 1. **`keep.running`**: keep your tasks & CPU running even if you lock your session and turn screenlock on; This mode prevents your system from going to sleep automatically (*e.g.* for training machine learning models, video encoding, web scraping, ...)
@@ -22,10 +22,10 @@ Wakepy has two main modes:
 - [viskillz-blender](https://github.com/viskillz/viskillz-blender) — Generating assets of Mental Cutting Test exercises
 - [mpc-autofill](https://github.com/chilli-axe/mpc-autofill) — Automating MakePlayingCards' online ordering system
 - [lakeshorecryotronics/python-driver](https://github.com/lakeshorecryotronics/python-driver) — Lake Shore instruments python Driver
-- [UCSD-E4E/baboon-tracking](https://github.com/UCSD-E4E/baboon-tracking) — In pipelines of a Computer Vision project tracking baboons  
-- [davlee1972/upscale_video](https://github.com/davlee1972/upscale_video) — Upscaling video using AI 
+- [UCSD-E4E/baboon-tracking](https://github.com/UCSD-E4E/baboon-tracking) — In pipelines of a Computer Vision project tracking baboons
+- [davlee1972/upscale_video](https://github.com/davlee1972/upscale_video) — Upscaling video using AI
 - [minarca](https://github.com/ikus060/minarca) — Cross-platform data backup software
-## Documentation 
+## Documentation
 ### 👉 **[wakepy.readthedocs.io](http://wakepy.readthedocs.io)**
 <!-- start after docs link -->
 ## ⚖️👑 Key selling points
@@ -33,11 +33,11 @@ Wakepy has two main modes:
 - Simple command line interface and a python API
 - Permissive MIT licence
 - Low amount of python dependencies
-  - For using the D-Bus methods on Linux: [jeepney](https://jeepney.readthedocs.io/)  
+  - For using the D-Bus methods on Linux: [jeepney](https://jeepney.readthedocs.io/)
   - Otherwise: None
 
 
-## Deprecation timeline (wakepy 0.7.0+) 
+## Deprecation timeline (wakepy 0.7.0+)
 
 Since deprecations may affect many users, they are communicated well before and time is given for project maintainers for migration. Timeline:
 

--- a/docs/source/api-reference.md
+++ b/docs/source/api-reference.md
@@ -11,8 +11,8 @@ in wakepy.js! -->
 
 Wakepy Modes
 -------------
-.. autofunction:: wakepy.keep.running 
-.. autofunction:: wakepy.keep.presenting 
+.. autofunction:: wakepy.keep.running
+.. autofunction:: wakepy.keep.presenting
 
 Wakepy Core
 ------------

--- a/docs/source/cli-api.md
+++ b/docs/source/cli-api.md
@@ -3,10 +3,10 @@
 It is possibe to start wakepy from the command line either by running
 
 ```{code-block} text
-wakepy 
+wakepy
 ```
 
-or  
+or
 
 ```{code-block} text
 python -m wakepy

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -5,7 +5,7 @@
 
 Wakepy supports Windows, MacOS and Linux flavours which Desktop Environment that implements the `org.freedesktop.ScreenSaver` interface[^linux-support].
 
-[^linux-support]: The Linux support is under active development. Target is to support at least GNOME, KDE, Xfce, Cinnamon, LXQt and MATE Desktop Environments. 
+[^linux-support]: The Linux support is under active development. Target is to support at least GNOME, KDE, Xfce, Cinnamon, LXQt and MATE Desktop Environments.
 ## Installing
 
 To install wakepy from PyPI, run
@@ -50,8 +50,8 @@ with keep.presenting():
 ::::
 
 
-### Mode quick reference 
- 
+### Mode quick reference
+
 
 
 | Wakepy mode              | keep.running | keep.presenting |

--- a/docs/source/methods-reference.md
+++ b/docs/source/methods-reference.md
@@ -19,7 +19,7 @@ Methods are different ways of entering/keeping in a Mode. A Method may support o
 ### org.gnome.SessionManager
 - **Name**: `org.gnome.SessionManager`
 - **Introduced in**: wakepy 0.8.0
-- **How it works**: Uses the [Inhibit](https://lira.no-ip.org:8443/doc/gnome-session/dbus/gnome-session.html#org.gnome.SessionManager.Inhibit) method of [org.gnome.SessionManager](https://lira.no-ip.org:8443/doc/gnome-session/dbus/gnome-session.html#org.gnome.SessionManager) D-Bus service with flag 4 ("Inhibit suspending the session or computer") when activating and saves the returned cookie on the Method instance. Uses the [Uninhibit](https://lira.no-ip.org:8443/doc/gnome-session/dbus/gnome-session.html#org.gnome.SessionManager.Uninhibit) method of the org.gnome.SessionManager with the cookie when deactivating.  
+- **How it works**: Uses the [Inhibit](https://lira.no-ip.org:8443/doc/gnome-session/dbus/gnome-session.html#org.gnome.SessionManager.Inhibit) method of [org.gnome.SessionManager](https://lira.no-ip.org:8443/doc/gnome-session/dbus/gnome-session.html#org.gnome.SessionManager) D-Bus service with flag 4 ("Inhibit suspending the session or computer") when activating and saves the returned cookie on the Method instance. Uses the [Uninhibit](https://lira.no-ip.org:8443/doc/gnome-session/dbus/gnome-session.html#org.gnome.SessionManager.Uninhibit) method of the org.gnome.SessionManager with the cookie when deactivating.
 - **Multiprocess safe?**: Yes
 - **What if the process holding the lock dies?**: The lock is automatically removed.
 - **How to check it?**:  You may check the list of inhibitors using the [GetInhibitors](https://lira.no-ip.org:8443/doc/gnome-session/dbus/gnome-session.html#org.gnome.SessionManager.GetInhibitors) method, which gives you list of object paths like `["/org/gnome/SessionManager/Inhibitor20"]`. Then you can use the [GetAppId](https://lira.no-ip.org:8443/doc/gnome-session/dbus/gnome-session.html#org.gnome.SessionManager.Inhibitor.GetAppId), [GetFlags](https://lira.no-ip.org:8443/doc/gnome-session/dbus/gnome-session.html#org.gnome.SessionManager.Inhibitor.GetFlags) and [GetReason](https://lira.no-ip.org:8443/doc/gnome-session/dbus/gnome-session.html#org.gnome.SessionManager.Inhibitor.GetReason) methods on the [org.gnome.SessionManager.Inhibitor](https://lira.no-ip.org:8443/doc/gnome-session/dbus/gnome-session.html#org.gnome.SessionManager.Inhibitor) interface of the listed objects on the org.gnome.SessionManager service to translate that into something meaningful. A good tool for this is [D-Spy](https://apps.gnome.org/Dspy/). Alternatively, you could monitor your inhibit call with [`dbus-monitor`](https://dbus.freedesktop.org/doc/dbus-monitor.1.html).
@@ -55,7 +55,7 @@ There are two ways how a Windows system might automatically set a screen lock
 1. When resuming from sleep, if "Require sign-in when PC wakes up from sleep" -setting is set.
 2. When Screen Saver idle timeout is reached *and it has set to have password protection in the Lock Screen Setting or that is enforced by a Group Policy*.
 
-if you want to check if your system will sleep automatically when using this method, you may either check the  `ScreenSaverIsSecure`, `ScreenSaveActive` and `ScreenSaveTimeout` from  "HKCU:\Control Panel\Desktop" and "HKCU:\Software\Policies\Microsoft\Windows\Control Panel\Desktop", or use the following python snippet: 
+if you want to check if your system will sleep automatically when using this method, you may either check the  `ScreenSaverIsSecure`, `ScreenSaveActive` and `ScreenSaveTimeout` from  "HKCU:\Control Panel\Desktop" and "HKCU:\Software\Policies\Microsoft\Windows\Control Panel\Desktop", or use the following python snippet:
 
 ```{code-block} python
 import ctypes
@@ -87,7 +87,7 @@ print('SPI_GETSCREENSAVETIMEOUT', retval.value)
 - **Introduced in**: wakepy 0.3.0
 - **How it works**: It calls the `caffeinate` command. See docs at [ss64.com](https://ss64.com/mac/caffeinate.html) or at archives from [developer.apple.com](https://web.archive.org/web/20140604153141/https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man8/caffeinate.8.html)
 - **Multiprocess safe?**: Yes
-- **What if the process holding the lock dies?**: The lock is automatically removed. 
+- **What if the process holding the lock dies?**: The lock is automatically removed.
 - **How to check it?**: You should be able to see a process with a command `/bin/bash caffeinate` or similar associated with it using a task manager.
 - **Requirements**: Mac OS X 10.8 Mountain Lion (July 2012) or newer.
 
@@ -110,11 +110,11 @@ print('SPI_GETSCREENSAVETIMEOUT', retval.value)
 ### org.freedesktop.ScreenSaver
 - **Name**: `org.freedesktop.ScreenSaver`
 - **Introduced in**: wakepy 0.6.0
-- **How it works**: Uses the Inhibit method of [org.freedesktop.ScreenSaver](https://people.freedesktop.org/~hadess/idle-inhibition-spec/re01.html) D-Bus service when activating and saves the returned cookie on the Method instance. Uses the org.freedesktop.ScreenSaver.UnInhibit method with the cookie when deactivating. The org.freedesktop.ScreenSaver can only be used to prevent idle; that is why there is no "keep.running" mode counterpart.  
+- **How it works**: Uses the Inhibit method of [org.freedesktop.ScreenSaver](https://people.freedesktop.org/~hadess/idle-inhibition-spec/re01.html) D-Bus service when activating and saves the returned cookie on the Method instance. Uses the org.freedesktop.ScreenSaver.UnInhibit method with the cookie when deactivating. The org.freedesktop.ScreenSaver can only be used to prevent idle; that is why there is no "keep.running" mode counterpart.
 - **Multiprocess safe?**: Yes
 - **What if the process holding the lock dies?**: The lock is automatically removed.
 - **How to check it?**:  The org.freedesktop.ScreenSaver does not expose a method for listing the inhibitors, but you could monitor your inhibit call with [`dbus-monitor`](https://dbus.freedesktop.org/doc/dbus-monitor.1.html).
-- **Requirements**: D-Bus, and a [freedesktop.org compliant desktop environment](https://www.freedesktop.org/wiki/Desktops/), which should implement the org.freedesktop.ScreenSaver.Inhibit method. 
+- **Requirements**: D-Bus, and a [freedesktop.org compliant desktop environment](https://www.freedesktop.org/wiki/Desktops/), which should implement the org.freedesktop.ScreenSaver.Inhibit method.
 - **Tested on**:  Ubuntu 22.04 with GNOME 42.9 ([PR #171](https://github.com/fohrloop/wakepy/pull/171) by [fohrloop](https://github.com/fohrloop/)).
 
 (keep-presenting-windows-stes)=
@@ -140,7 +140,7 @@ print('SPI_GETSCREENSAVETIMEOUT', retval.value)
 - **Introduced in**: wakepy 0.3.0
 - **How it works**: It calls the `caffeinate` command with `-d` flag ("Create an assertion to prevent the display from sleeping."). See docs at [ss64.com](https://ss64.com/mac/caffeinate.html) or at archives from [developer.apple.com](https://web.archive.org/web/20140604153141/https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man8/caffeinate.8.html)
 - **Multiprocess safe?**: Yes
-- **What if the process holding the lock dies?**: The lock is automatically removed. 
+- **What if the process holding the lock dies?**: The lock is automatically removed.
 - **How to check it?**: You should be able to see a process with a command `/bin/bash caffeinate -d` or similar associated with it using a task manager.
 - **Requirements**: Mac OS X 10.8 Mountain Lion (July 2012) or newer.
 

--- a/docs/source/migration.md
+++ b/docs/source/migration.md
@@ -1,7 +1,7 @@
 # Migration Guide
 ## Migration Guide: 0.7.0
 
-- When migrating from wakepy <=0.6.0 to >=0.7.0 
+- When migrating from wakepy <=0.6.0 to >=0.7.0
 -  `set_keepawake` and `unset_keepawake` and `keepawake`: Replace with `keep.running` or `keep.presenting`, whichever makes sense in the application.
 
 ### Python API
@@ -13,7 +13,7 @@ with keepawake():
   do_something()
 ```
 
-or 
+or
 
 ```{code-block} python
 from wakepy import set_keepawake, unset_keepawake

--- a/docs/source/modes.md
+++ b/docs/source/modes.md
@@ -2,7 +2,7 @@
 
 
 
-The available modes are 
+The available modes are
 | Wakepy mode                              | What it does                                        |
 | ---------------------------------------- | --------------------------------------------------- |
 | [keep.running](#keep-running-mode)       | Automatic sleep is prevented                        |
@@ -15,7 +15,7 @@ The wakepy modes are implemented as context managers of type `wakepy.Mode`. When
 - `m.active`: True, if entering mode was successful. Can be [faked in CI](./tests-and-ci.md#wakepy_fake_success).
 - `m.activation_result`: An ActivationResult instance which gives more detailed information about the activation process.
 
-````{tip} 
+````{tip}
 You may want to inform user about failure in activating a mode. For example:
 
 ```{code-block} python
@@ -67,7 +67,7 @@ manual reversal.
 
 While `keep.presenting` mode is activated, the system may not automatically go to sleep (or
 suspend) meaning that programs will continue running and can use CPU. In addition to
-that, automatic start of screensaver & screenlock are prevented, meaning that you can 
+that, automatic start of screensaver & screenlock are prevented, meaning that you can
 show content in the `keep.presenting` mode.
 
 
@@ -95,6 +95,6 @@ manual reversal.
 
 
 ## General questions
-**What if the process holding the lock dies?**: The lock is automatically removed. 
+**What if the process holding the lock dies?**: The lock is automatically removed.
 
 **How to use wakepy in tests / CI**: One problem with tests and/or CI systems is that many times the environment is different, and preventing system going to sleep works differently there. To fake a successful inhibit lock in tests, you may set an environment variable: `WAKEPY_FAKE_SUCCESS` to `yes`.

--- a/docs/source/test-manually.md
+++ b/docs/source/test-manually.md
@@ -7,8 +7,8 @@ All wakepy Modes rely somehow on external software, library or dbus service. Thi
 ```{admonition} Notes for manual testing
 :class: warning
 ###### Before testing
-- Close browser tabs which might prevent your system from going to sleep (e.g.  YouTube) 
-- Close applications which might prevent your system from going to sleep (e.g. video players apps) 
+- Close browser tabs which might prevent your system from going to sleep (e.g.  YouTube)
+- Close applications which might prevent your system from going to sleep (e.g. video players apps)
 
 ###### When ending the test
 - Avoid pressing the power button as it might force the computer to sleep.
@@ -53,7 +53,7 @@ Dec 25 12:29:16 | elapsed 0:00:41.484495 | delta: 2.00023s
 Dec 25 12:29:18 | elapsed 0:00:43.484847 | delta: 2.000352s
 Dec 25 12:29:20 | elapsed 0:00:45.485045 | delta: 2.000198s
 ```
- 
+
 In the above example, the delta (time between two prints) was 2 seconds, until 16 seconds elapsed. After that, CPU was sleeping for 19 seconds.
 
 ## Entering in wakepy modes for tests
@@ -67,7 +67,7 @@ Either on CLI
 wakepy
 ```
 
-or in python 
+or in python
 
 
 ```{code-block} python
@@ -87,7 +87,7 @@ Either on CLI
 wakepy -p
 ```
 
-or in python 
+or in python
 
 
 ```{code-block} python
@@ -142,9 +142,9 @@ Follow the [same steps as in with keep.running](#gnome-keep-running-manual-test)
 (windows-keep-running-manual-test)=
 ### keep.running (Windows)
 
-Change your current settings from windows menu -> "Edit Power Plan". Change "Turn off the display" and "Put the computer to sleep"  both to 1 minute. -> Save Changes. 
+Change your current settings from windows menu -> "Edit Power Plan". Change "Turn off the display" and "Put the computer to sleep"  both to 1 minute. -> Save Changes.
 
-Then, run the [wakepy test script](#code-wakepy-test-script) on one terminal window, and enter in the [keep.running](#enter-keep-running-script)  or in the in another. After you're done, reset the Power Plan values to what they were. 
+Then, run the [wakepy test script](#code-wakepy-test-script) on one terminal window, and enter in the [keep.running](#enter-keep-running-script)  or in the in another. After you're done, reset the Power Plan values to what they were.
 
 
 ```{admonition} About Windows idle timers

--- a/docs/source/tests-and-ci.md
+++ b/docs/source/tests-and-ci.md
@@ -3,14 +3,14 @@
 If you're using wakepy in Continuous Integration tests, note that typically CI is running on a system where there is no Desktop Environment available. In addition, the available services and executables might be different from the services and executables you have on your machine. For this reason, even if wakepy is able to activate a mode on your machine, it might not be able to do so in CI tests.
 
 ## WAKEPY_FAKE_SUCCESS
-To force wakepy to fake a successful mode activation, you may set an environment variable `WAKEPY_FAKE_SUCCESS` to a *truthy value* like `1`. This makes wakepy to use a fake method to always guarantee a successful mode change. This works with any modes. The WAKEPY_FAKE_SUCCESS Method is tried *before* any other possible Methods, which guarantees that there will be no IO (except for the env var check), and no calling of any executables or 3rd party services when WAKEPY_FAKE_SUCCESS is used. 
+To force wakepy to fake a successful mode activation, you may set an environment variable `WAKEPY_FAKE_SUCCESS` to a *truthy value* like `1`. This makes wakepy to use a fake method to always guarantee a successful mode change. This works with any modes. The WAKEPY_FAKE_SUCCESS Method is tried *before* any other possible Methods, which guarantees that there will be no IO (except for the env var check), and no calling of any executables or 3rd party services when WAKEPY_FAKE_SUCCESS is used.
 
 In tox, this would be:
 
 ```{code-block} ini
 [testenv]
 # ... other settings
-setenv = 
+setenv =
     WAKEPY_FAKE_SUCCESS = "yes"
 ```
 
@@ -23,13 +23,13 @@ Only `0`, `no` and `false` are considered as falsy values (case ignored). Any ot
 
 ## DBUS_SESSION_BUS_ADDRESS
 
-On Linux, wakepy uses D-Bus methods to inhibit screensaver or power management. Therefore, you need to have `DBUS_SESSION_BUS_ADDRESS` set to the session D-Bus address. This is usually automatically set, but test runners might drop out set environment variables. 
+On Linux, wakepy uses D-Bus methods to inhibit screensaver or power management. Therefore, you need to have `DBUS_SESSION_BUS_ADDRESS` set to the session D-Bus address. This is usually automatically set, but test runners might drop out set environment variables.
 
 To pass the `DBUS_SESSION_BUS_ADDRESS` with tox, one would use:
 
 ```{code-block} ini
 [testenv]
 # ... other settings
-passenv = 
+passenv =
     DBUS_SESSION_BUS_ADDRESS
 ```

--- a/docs/source/wakepy-mode-lifecycle.md
+++ b/docs/source/wakepy-mode-lifecycle.md
@@ -11,13 +11,13 @@ with keep.running():
     USER_CODE
 ```
 
-Before we talk about the Mode lifecycle, let's introduce the different states a Mode can have. There are five different states related to any wakepy Mode lifecycle. Out of them, *three* are states of the Mode class: 
+Before we talk about the Mode lifecycle, let's introduce the different states a Mode can have. There are five different states related to any wakepy Mode lifecycle. Out of them, *three* are states of the Mode class:
 - ***Inactive***: The initial state of Modes. Also the state after deactivation.
 - ***Active***: Where USER_CODE is meant to be run in.
 - ***Activation Failed***: Possible state if activation fails.
 
 The two other — *Activation Started* and *Deactivation Started* — are intermediate states in the Mode activation and deactivation processes. The five states are shown in the wakepy.Mode State Diagram in {numref}`state-diagram`.
-    
+
 :::{figure-md} state-diagram
 ![wakepy mode state diagram](./img/mode-state-diagram.svg){width=500px}
 
@@ -34,16 +34,16 @@ from wakepy import keep
 
 # Returns an instance of Mode
 mode = keep.running()
-# Inactive 
+# Inactive
 
 with mode:
-    # Active 
+    # Active
     USER_CODE
     # Still Active
-    
+
 # Inactive
 ```
-The above comments assume "the happy path" (the mode activation succeeds). Then, we compare the code with the actions in the [Activity Diagram](#mode-activity-diagram). 
+The above comments assume "the happy path" (the mode activation succeeds). Then, we compare the code with the actions in the [Activity Diagram](#mode-activity-diagram).
 
 ### Mode Activity Diagram
 
@@ -60,7 +60,7 @@ The wakepy.Mode Activity Diagram in {numref}`fig-mode-activity-diagram` shows th
 
 ## Creating a Mode instance
 
-This corresponds to the action "Create Mode" in {numref}`fig-mode-activity-diagram`. When you create an instance of the wakepy Mode class with 
+This corresponds to the action "Create Mode" in {numref}`fig-mode-activity-diagram`. When you create an instance of the wakepy Mode class with
 
 
 ```{code-block} python
@@ -71,7 +71,7 @@ from wakepy import keep
 
 # Returns an instance of Mode
 mode = keep.running()
-# Inactive 
+# Inactive
 
 ```
 
@@ -88,14 +88,14 @@ In order to set your system into a Mode, you need to activate it ("Activate Mode
 mode = keep.running()
 
 with mode:
-    # Active 
+    # Active
     USER_CODE
 ```
 
 This will put the Mode into *Active* or *Activation Failed* state through the intermediate *Activation Started* state. If the code is set to *Activation Failed* state, the *Action on Fail* occurs (See: {numref}`fig-mode-activity-diagram`). This action may be an exception or a warning.
 
 (activating-a-mode-note)=
-````{note} 
+````{note}
 **Using mode.activate directly**:
 
 It is also possible to call `mode.activate()` directly, but using the `with` statement is highly recommended as it makes sure that deactivation is done even if there are exceptions within the `USER_CODE`. The above `with mode:...` is roughly equal to
@@ -131,12 +131,12 @@ This process happens in the `activate_mode` function and it returns an `Activati
 The {numref}`fig-activate-with-a-method` presents the activity diagram for the "Activate with a Method" action from the {numref}`fig-activate-mode-activity-diagram`. This is what wakepy does with the Method:
 
 
-1. Checks platform support against the list in the `Method.supported_plaforms`. 
+1. Checks platform support against the list in the `Method.supported_plaforms`.
 2. Checks requirements using `Method.caniuse()`. Some Methods could require a certain version of some specific Desktop Environment, a version of a 3rd party software, or some DBus service running. During this step, if some 3rd party SW has known bugs on certain versions, the Method may be dismissed.
 3. Tries to activate the Mode using the `Method.enter_mode()`, if defined
 4. Tries to start the heartbeat using the `Method.heartbeat()`, if defined
 5. Starts the Heartbeat, if the `Method.heartbeat()` exists. This will run in a separate thread.
-  
+
 If the first two steps do not fail, at least one of `Method.enter_mode()` and `Method.caniuse()` is defined and they do not raise Exceptions, the Mode activation is successful. This process happens in the `activate_method` function and it returns an `MethodActivationResult` object, and a `Heartbeat` instance (if used and activation was successful).
 :::{figure-md} fig-activate-with-a-method
 ![activity diagram for the "Activate Mode" action](./img/activate-mode-using-method-activity-diagram.svg){width=430px}
@@ -158,10 +158,10 @@ The "Deactivate Mode" activity in {numref}`fig-mode-activity-diagram` occurs aut
 :lineno-start: 7
 
 with mode:
-    # Active 
+    # Active
     USER_CODE
     # Still Active
-    
+
 # Inactive
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     {name = "Niko Föhr", email = "fohrloop@gmail.com"},
 ]
 dependencies = [
-    # For using the D-Bus based methods 
+    # For using the D-Bus based methods
     "jeepney >= 0.7.1;sys_platform=='linux'"
 ]
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,4 +1,4 @@
-"""The DBus adapters are tested against real DBus service(s). This module 
+"""The DBus adapters are tested against real DBus service(s). This module
 provides the services as fixtures. The services run in separate threads.
 """
 

--- a/tests/unit/test_methods/test_freedesktop.py
+++ b/tests/unit/test_methods/test_freedesktop.py
@@ -1,4 +1,4 @@
-"""This module tests the Freedesktop.org specific methods. 
+"""This module tests the Freedesktop.org specific methods.
 
 These tests do *not* use IO / real or fake Dbus calls. Instead, a special dbus
 adapter is used which simply asserts the Call objects and returns what we

--- a/tests/unit/test_methods/test_gnome.py
+++ b/tests/unit/test_methods/test_gnome.py
@@ -1,4 +1,4 @@
-"""This module tests the GNOME specific methods. 
+"""This module tests the GNOME specific methods.
 
 These tests do *not* use IO / real or fake Dbus calls. Instead, a special dbus
 adapter is used which simply asserts the Call objects and returns what we

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = 
+envlist =
     py37
     py310
     py312
@@ -8,9 +8,9 @@ minversion = 4.6.0
 
 [testenv]
 description = run the tests with pytest
-passenv = 
+passenv =
     DBUS_SESSION_BUS_ADDRESS
-setenv = 
+setenv =
     WAKEPY_FAKE_SUCCESS = "yes"
 deps =
     time-machine
@@ -18,7 +18,7 @@ deps =
     jeepney >= 0.7.1;sys_platform=='linux'
 commands =
     {envpython} -m pytest {tty:--color=yes} {posargs}
-allowlist_externals = 
+allowlist_externals =
     echo
 
 [testenv:check]
@@ -29,7 +29,7 @@ deps =
     isort==5.12.0
     mypy==1.3.0
 skip_install = true
-commands = 
+commands =
     python -m isort ./wakepy --check --diff
     python -m black ./wakepy --check
     python -m ruff ./wakepy

--- a/wakepy/__main__.py
+++ b/wakepy/__main__.py
@@ -26,9 +26,9 @@ if typing.TYPE_CHECKING:
 
     from wakepy import ActivationResult
 
-WAKEPY_TEXT_TEMPLATE = r"""                  _                       
-                 | |                      
- __      __ __ _ | | __ ___  _ __   _   _ 
+WAKEPY_TEXT_TEMPLATE = r"""                  _
+                 | |
+ __      __ __ _ | | __ ___  _ __   _   _
  \ \ /\ / // _` || |/ // _ \| '_ \ | | | |
   \ V  V /| (_| ||   <|  __/| |_) || |_| |
    \_/\_/  \__,_||_|\_\\___|| .__/  \__, |
@@ -37,7 +37,7 @@ WAKEPY_TEXT_TEMPLATE = r"""                  _
 
 WAKEPY_TICKBOXES_TEMPLATE = """
  [{no_auto_suspend}] System will continue running programs
- [{presentation_mode}] Presentation mode is on 
+ [{presentation_mode}] Presentation mode is on
 """
 
 

--- a/wakepy/core/activation.py
+++ b/wakepy/core/activation.py
@@ -4,7 +4,7 @@ deactivation of Modes (using Methods).
 Most important functions
 ------------------------
 activate_method(method:Method) -> MethodActivationResult
-    Activate a mode using a single Method 
+    Activate a mode using a single Method
 get_prioritized_methods
     Prioritize of collection of Methods
 

--- a/wakepy/core/dbus.py
+++ b/wakepy/core/dbus.py
@@ -1,10 +1,10 @@
 """This module is contains classes and functions related to D-Bus, which is
-a message bus for communication between processes operating systems like 
-Linux and DSD. 
+a message bus for communication between processes operating systems like
+Linux and DSD.
 
 When creating a subclass of wakepy.Method, which uses D-Bus methods, one needs
 to create DbusMethodCall, and use the Method.process_dbus_call to get the
-response. 
+response.
 
 Wakepy is not tied to any specific D-Bus implementation. If you want to use a
 non-standard way to communicate with D-Bus, you need to subclass DbusAdapter.
@@ -59,7 +59,7 @@ class DbusAddress(NamedTuple):
     bus: Optional[Union[str, BusType]] = BusType.SESSION
     """The type of message bus used. Should be "SESSION" or "SYSTEM".
     Each running dbus-daemon process provides a new message bus.
-    If omitted, session bus is assumed.   
+    If omitted, session bus is assumed.
     """
 
 
@@ -73,14 +73,14 @@ class DbusMethod(NamedTuple):
 
     name: str
     """name of the method, without the interface part. For example if creating
-    method for  "org.spam.Manager.SomeMethod", the method name is "SomeMethod". 
+    method for  "org.spam.Manager.SomeMethod", the method name is "SomeMethod".
     """
 
     signature: str | None
     """The signature for the method input parameters.
 
     The types are: (Conventional name, ASCII type-code, meaning)::
-    
+
         BYTE	y (121)	Unsigned 8-bit integer
         BOOLEAN	b (98)	Boolean value: 0 is false, 1 is true
         INT16	n (110)	Signed 16-bit integer
@@ -94,7 +94,7 @@ class DbusMethod(NamedTuple):
                         out-of-band array of file descriptors, transferred via some
                         platform-specific mechanism
         STRING  s (115) String
-    
+
     Ref: `dbus-specification <https://dbus.freedesktop.org/doc/dbus-specification.html>`_
     """
     params: Optional[tuple[str, ...]] = None
@@ -105,7 +105,7 @@ class DbusMethod(NamedTuple):
 
     output_signature: str | None = None
     """The signature for the method output / return values. See the docs for
-    signature. 
+    signature.
     """
 
     output_params: Optional[tuple[str, ...]] = None
@@ -142,7 +142,7 @@ class DbusMethod(NamedTuple):
     bus: Optional[Union[str, BusType]] = BusType.SESSION
     """The type of message bus used. Should be "SESSION" or "SYSTEM".
     Each running dbus-daemon process provides a new message bus.
-    If omitted, session bus is assumed.   
+    If omitted, session bus is assumed.
     """
 
     def of(

--- a/wakepy/methods/__init__.py
+++ b/wakepy/methods/__init__.py
@@ -19,7 +19,7 @@ Examples
     or "least widespread" software.
 (3) If a method needs systemd and D-Bus, it is listed under systemd, as D-Bus
     is more widespread than systemd, and you may have D-Bus without systemd
-    but not vice versa. 
+    but not vice versa.
 """
 
 # NOTE: All modules containing wakepy.Methods must be imported here! The reason


### PR DESCRIPTION
Ran a script to remove trailing spaces:

```
find ./* -type f -not -path "./venv/*" -not -path "./docs/build/*" -not -path *.pyc -exec sed -i 's/[[:space:]]*$//' {} \;
```