### PR TITLE
Dbus -> DBus

### DIFF
--- a/docs/source/api-reference.md
+++ b/docs/source/api-reference.md
@@ -7,7 +7,7 @@ in wakepy.js! -->
 
     wakepy.keep.running
     wakepy.keep.presenting
-    wakepy.DbusAdapter
+    wakepy.DBusAdapter
 
 Wakepy Modes
 -------------
@@ -25,19 +25,19 @@ Wakepy Core
 
 DBus Adapter
 -------------
-Dbus adapters are an advanced concept of wakepy. They would be used in such a case where wants to use other D-Bus python library than the default (which is `jeepney <https://jeepney.readthedocs.io/>`_).
+DBus adapters are an advanced concept of wakepy. They would be used in such a case where wants to use other D-Bus python library than the default (which is `jeepney <https://jeepney.readthedocs.io/>`_).
 
-.. autoclass:: wakepy.DbusAdapter
+.. autoclass:: wakepy.DBusAdapter
     :members:
 
-.. autoclass:: wakepy.core.DbusMethodCall
+.. autoclass:: wakepy.core.DBusMethodCall
     :members:
 
-.. autoclass:: wakepy.core.DbusMethod
+.. autoclass:: wakepy.core.DBusMethod
     :members:
     :exclude-members: count, index
 
-.. autoclass:: wakepy.dbus_adapters.jeepney.JeepneyDbusAdapter
+.. autoclass:: wakepy.dbus_adapters.jeepney.JeepneyDBusAdapter
     :members:
 
 ```

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -9,12 +9,12 @@ import sys
 import pytest
 
 if sys.platform.lower().startswith("linux"):
-    from dbus_service import DbusService, start_dbus_service
+    from dbus_service import DBusService, start_dbus_service
 else:
-    DbusService = None
+    DBusService = None
     start_dbus_service = None
 
-from wakepy.core import DbusAddress, DbusMethod
+from wakepy.core import DBusAddress, DBusMethod
 
 logger = logging.getLogger(__name__)
 
@@ -53,8 +53,8 @@ def private_bus():
 
 
 @pytest.fixture(scope="session")
-def string_operation_service_addr(private_bus: str) -> DbusAddress:
-    return DbusAddress(
+def string_operation_service_addr(private_bus: str) -> DBusAddress:
+    return DBusAddress(
         bus=private_bus,
         service="org.github.wakepy.TestStringOperationService",
         path="/org/github/wakepy/TestStringOperationService",
@@ -63,8 +63,8 @@ def string_operation_service_addr(private_bus: str) -> DbusAddress:
 
 
 @pytest.fixture(scope="session")
-def calculator_service_addr(private_bus: str) -> DbusAddress:
-    return DbusAddress(
+def calculator_service_addr(private_bus: str) -> DBusAddress:
+    return DBusAddress(
         bus=private_bus,
         service="org.github.wakepy.TestCalculatorService",
         path="/org/github/wakepy/TestCalculatorService",
@@ -73,8 +73,8 @@ def calculator_service_addr(private_bus: str) -> DbusAddress:
 
 
 @pytest.fixture(scope="session")
-def numberadd_method(calculator_service_addr: DbusAddress) -> DbusMethod:
-    return DbusMethod(
+def numberadd_method(calculator_service_addr: DBusAddress) -> DBusMethod:
+    return DBusMethod(
         name="SimpleNumberAdd",
         signature="uu",
         params=("first_number", "second_number"),
@@ -84,8 +84,8 @@ def numberadd_method(calculator_service_addr: DbusAddress) -> DbusMethod:
 
 
 @pytest.fixture(scope="session")
-def numbermultiply_method(calculator_service_addr: DbusAddress) -> DbusMethod:
-    return DbusMethod(
+def numbermultiply_method(calculator_service_addr: DBusAddress) -> DBusMethod:
+    return DBusMethod(
         name="SimpleNumberMultiply",
         signature="ii",
         params=("first_number", "second_number"),
@@ -95,8 +95,8 @@ def numbermultiply_method(calculator_service_addr: DbusAddress) -> DbusMethod:
 
 
 @pytest.fixture(scope="session")
-def string_shorten_method(string_operation_service_addr: DbusAddress) -> DbusMethod:
-    return DbusMethod(
+def string_shorten_method(string_operation_service_addr: DBusAddress) -> DBusMethod:
+    return DBusMethod(
         name="ShortenToNChars",
         signature="su",
         params=("the_string", "max_chars"),
@@ -107,15 +107,15 @@ def string_shorten_method(string_operation_service_addr: DbusAddress) -> DbusMet
 
 @pytest.fixture(scope="session")
 def dbus_calculator_service(
-    calculator_service_addr: DbusAddress,
-    numberadd_method: DbusMethod,
-    numbermultiply_method: DbusMethod,
+    calculator_service_addr: DBusAddress,
+    numberadd_method: DBusMethod,
+    numbermultiply_method: DBusMethod,
     private_bus: str,
 ):
-    """Provides a Dbus service called org.github.wakepy.TestCalculatorService
+    """Provides a DBus service called org.github.wakepy.TestCalculatorService
     in the session bus"""
 
-    class TestCalculatorService(DbusService):
+    class TestCalculatorService(DBusService):
         addr = calculator_service_addr
 
         def handle_method(self, method: str, args):
@@ -131,14 +131,14 @@ def dbus_calculator_service(
 
 @pytest.fixture(scope="session")
 def dbus_string_operation_service(
-    string_operation_service_addr: DbusAddress,
-    string_shorten_method: DbusMethod,
+    string_operation_service_addr: DBusAddress,
+    string_shorten_method: DBusMethod,
     private_bus: str,
 ):
-    """Provides a Dbus service called org.github.wakepy.TestStringOperationService
+    """Provides a DBus service called org.github.wakepy.TestStringOperationService
     in the session bus"""
 
-    class TestStringOperationService(DbusService):
+    class TestStringOperationService(DBusService):
         addr = string_operation_service_addr
 
         def handle_method(self, method: str, args):

--- a/tests/integration/dbus_service.py
+++ b/tests/integration/dbus_service.py
@@ -10,7 +10,7 @@ from jeepney import HeaderFields, MessageType, new_error, new_method_return
 from jeepney.bus_messages import message_bus
 from jeepney.io.blocking import open_dbus_connection
 
-from wakepy.core import DbusAddress
+from wakepy.core import DBusAddress
 
 logger = logging.getLogger(__name__)
 
@@ -18,11 +18,11 @@ logger = logging.getLogger(__name__)
 DBUS_REQUEST_NAME_REPLY_PRIMARY_OWNER = 1
 
 
-class DbusService:
-    """A class for defining Dbus services, which can be made available in a
+class DBusService:
+    """A class for defining DBus services, which can be made available in a
     bus. To define a dbus service, create a subclass and provide
 
-    (1) addr: DbusAddress
+    (1) addr: DBusAddress
         Where the dbus service is located at.
     (2) handle_method
         A function which handles dbus method calls. Use if statements for
@@ -34,12 +34,12 @@ class DbusService:
         The address of the message bus
     bus_name: None | str
         If None, there is no service running. If not None, will be the well-
-        known bus name this service has reserved. A DbusService can only have
+        known bus name this service has reserved. A DBusService can only have
         one well-known bus name at a time. For example:
         "org.gnome.SessionManager"
     """
 
-    addr: DbusAddress
+    addr: DBusAddress
 
     def __init__(self, bus_address: str, queue_: queue.Queue, stop: Callable):
         """
@@ -147,9 +147,9 @@ class DbusService:
 
 
 def start_dbus_service(
-    service_cls: Type[DbusService], bus_address: Optional[str] = None
+    service_cls: Type[DBusService], bus_address: Optional[str] = None
 ):
-    """Start a Dbus Service in a separate thread.
+    """Start a DBus Service in a separate thread.
 
     Parameters
     ----------
@@ -162,7 +162,7 @@ def start_dbus_service(
     should_stop = False
 
     def start_service(
-        service: Type[DbusService], queue_: queue.Queue, should_stop: Callable
+        service: Type[DBusService], queue_: queue.Queue, should_stop: Callable
     ):
         logger.info(f"Launching dbus service: {service.addr.service}")
 

--- a/tests/integration/test_dbus_adapters.py
+++ b/tests/integration/test_dbus_adapters.py
@@ -13,40 +13,40 @@ if not sys.platform.lower().startswith("linux"):
 import jeepney
 import pytest
 
-from wakepy.core import DbusAddress, DbusMethod, DbusMethodCall
-from wakepy.dbus_adapters.jeepney import JeepneyDbusAdapter
+from wakepy.core import DBusAddress, DBusMethod, DBusMethodCall
+from wakepy.dbus_adapters.jeepney import JeepneyDBusAdapter
 
 
 @pytest.mark.usefixtures("dbus_calculator_service")
 def test_jeepney_dbus_adapter_numberadd(numberadd_method):
-    adapter = JeepneyDbusAdapter()
-    call = DbusMethodCall(numberadd_method, (2, 3))
+    adapter = JeepneyDBusAdapter()
+    call = DBusMethodCall(numberadd_method, (2, 3))
     assert adapter.process(call) == (5,)
 
 
 @pytest.mark.usefixtures("dbus_calculator_service")
 def test_jeepney_dbus_adapter_number_multiply(numbermultiply_method):
-    adapter = JeepneyDbusAdapter()
-    call = DbusMethodCall(numbermultiply_method, (-5, 3))
+    adapter = JeepneyDBusAdapter()
+    call = DBusMethodCall(numbermultiply_method, (-5, 3))
     assert adapter.process(call) == (-15,)
 
 
 @pytest.mark.usefixtures("dbus_calculator_service")
 def test_jeepney_dbus_adapter_wrong_arguments(numbermultiply_method):
-    adapter = JeepneyDbusAdapter()
+    adapter = JeepneyDBusAdapter()
     with pytest.raises(struct.error, match="required argument is not an intege"):
         # Bad input arg type
-        adapter.process(DbusMethodCall(numbermultiply_method, (-5, "foo")))
+        adapter.process(DBusMethodCall(numbermultiply_method, (-5, "foo")))
     with pytest.raises(
         ValueError, match=re.escape("Expected args to have 2 items! (has: 3)")
     ):
         # Too many input args
-        adapter.process(DbusMethodCall(numbermultiply_method, (-5, 3, 3)))
+        adapter.process(DBusMethodCall(numbermultiply_method, (-5, 3, 3)))
 
 
 @pytest.mark.usefixtures("dbus_calculator_service")
 def test_jeepney_dbus_adapter_wrong_signature(calculator_service_addr):
-    wrong_method = DbusMethod(
+    wrong_method = DBusMethod(
         name="SimpleNumberMultiply",
         signature="is",  # this is wrong: should be "ii"
         params=("first_number", "second_number"),
@@ -54,46 +54,46 @@ def test_jeepney_dbus_adapter_wrong_signature(calculator_service_addr):
         output_params=("result",),
     ).of(calculator_service_addr)
 
-    adapter = JeepneyDbusAdapter()
+    adapter = JeepneyDBusAdapter()
     with pytest.raises(
         jeepney.wrappers.DBusErrorResponse,
         match="org.github.wakepy.TestCalculatorService.Error.OtherError",
     ):
-        # The args are correct for the DbusMethod, but the DbusMethod is not
+        # The args are correct for the DBusMethod, but the DBusMethod is not
         # correct for the service (signature is wrong)
-        adapter.process(DbusMethodCall(wrong_method, (-5, "sdaasd")))
+        adapter.process(DBusMethodCall(wrong_method, (-5, "sdaasd")))
 
 
 @pytest.mark.usefixtures("dbus_calculator_service")
 def test_jeepney_dbus_adapter_nonexisting_method(calculator_service_addr):
-    non_existing_method = DbusMethod(
+    non_existing_method = DBusMethod(
         name="ThisDoesNotExist",
         signature="ii",
         params=("first_number", "second_number"),
         output_signature="i",
         output_params=("result",),
     ).of(calculator_service_addr)
-    adapter = JeepneyDbusAdapter()
+    adapter = JeepneyDBusAdapter()
 
     with pytest.raises(
         jeepney.wrappers.DBusErrorResponse,
         match="org.github.wakepy.TestCalculatorService.Error.NoMethod",
     ):
         # No such method: ThisDoesNotExist
-        adapter.process(DbusMethodCall(non_existing_method, (-5, 2)))
+        adapter.process(DBusMethodCall(non_existing_method, (-5, 2)))
 
 
 @pytest.mark.usefixtures("dbus_calculator_service")
 def test_jeepney_dbus_adapter_wrong_service_definition(private_bus: str):
-    adapter = JeepneyDbusAdapter()
+    adapter = JeepneyDBusAdapter()
 
-    wrong_service_addr = DbusAddress(
+    wrong_service_addr = DBusAddress(
         bus=private_bus,
         service="org.github.wakepy.WrongService",
         path="/org/github/wakepy/TestCalculatorService",
         interface="org.github.wakepy.TestCalculatorService",
     )
-    wrong_method = DbusMethod(
+    wrong_method = DBusMethod(
         name="SimpleNumberMultiply",
         signature="ii",
         params=("first_number", "second_number"),
@@ -101,7 +101,7 @@ def test_jeepney_dbus_adapter_wrong_service_definition(private_bus: str):
         output_params=("result",),
     ).of(wrong_service_addr)
 
-    # The args are correct for the DbusMethod, but the DbusMethod is not
+    # The args are correct for the DBusMethod, but the DBusMethod is not
     # correct for the service (signature is wrong)
     with pytest.raises(
         jeepney.wrappers.DBusErrorResponse,
@@ -110,13 +110,13 @@ def test_jeepney_dbus_adapter_wrong_service_definition(private_bus: str):
             "files"
         ),
     ):
-        adapter.process(DbusMethodCall(wrong_method, (-5, 2)))
+        adapter.process(DBusMethodCall(wrong_method, (-5, 2)))
 
 
 @pytest.mark.usefixtures("dbus_string_operation_service")
 def test_jeepney_dbus_adapter_string_shorten(string_shorten_method):
     # The service shortens a string to a given number of characters and tells
     # how many characters were dropped out.
-    adapter = JeepneyDbusAdapter()
-    call = DbusMethodCall(string_shorten_method, ("cat pinky", 3))
+    adapter = JeepneyDBusAdapter()
+    call = DBusMethodCall(string_shorten_method, ("cat pinky", 3))
     assert adapter.process(call) == ("cat", 6)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,15 +1,15 @@
 import pytest
 
-from wakepy import DbusAdapter
+from wakepy import DBusAdapter
 
 
-class TestDbusAdapter(DbusAdapter):
+class TestDBusAdapter(DBusAdapter):
     """A fake dbus adapter used in tests"""
 
 
 @pytest.fixture(scope="session")
 def fake_dbus_adapter():
-    return TestDbusAdapter
+    return TestDBusAdapter
 
 
 class TestUtils:

--- a/tests/unit/test_core/test_activation/test_activation.py
+++ b/tests/unit/test_core/test_activation/test_activation.py
@@ -20,7 +20,7 @@ from testmethods import (
     iterate_test_methods,
 )
 
-from wakepy.core import DbusAdapter, MethodActivationResult, get_methods
+from wakepy.core import DBusAdapter, MethodActivationResult, get_methods
 from wakepy.core.activation import (
     StageName,
     WakepyFakeSuccess,
@@ -107,7 +107,7 @@ def _arrange_for_test_activate(monkeypatch):
 
     mocks = Mock()
     mocks.heartbeat = Mock(spec_set=Heartbeat)
-    mocks.dbus_adapter = Mock(spec_set=DbusAdapter)
+    mocks.dbus_adapter = Mock(spec_set=DBusAdapter)
 
     def fake_activate_method(method):
         try:

--- a/tests/unit/test_core/test_calls.py
+++ b/tests/unit/test_core/test_calls.py
@@ -2,144 +2,144 @@ import re
 
 import pytest
 
-from wakepy.core import DbusAddress, DbusMethod, DbusMethodCall
+from wakepy.core import DBusAddress, DBusMethod, DBusMethodCall
 
 
 @pytest.fixture
 def service():
-    return DbusAddress(path="/foo", service="wakepy.foo", interface="/foo")
+    return DBusAddress(path="/foo", service="wakepy.foo", interface="/foo")
 
 
 @pytest.fixture
 def method(service):
-    return DbusMethod(
+    return DBusMethod(
         name="test-method", signature="isi", params=("first", "second", "third")
     ).of(service)
 
 
 @pytest.fixture
 def method_without_params(service):
-    service = DbusAddress(path="/foo", service="wakepy.foo", interface="/foo")
-    return DbusMethod(
+    service = DBusAddress(path="/foo", service="wakepy.foo", interface="/foo")
+    return DBusMethod(
         name="test-method",
         signature="isi",
     ).of(service)
 
 
-def test_dbusmethod_args_none(method: DbusMethod):
-    call = DbusMethodCall(method, args=None)
+def test_dbusmethod_args_none(method: DBusMethod):
+    call = DBusMethodCall(method, args=None)
     assert call.args == tuple()
 
 
-def test_dbusmethod_args_missing(method: DbusMethod):
-    call = DbusMethodCall(method)
+def test_dbusmethod_args_missing(method: DBusMethod):
+    call = DBusMethodCall(method)
     assert call.args == tuple()
 
 
-def test_dbusmethod_args_tuple(method: DbusMethod):
+def test_dbusmethod_args_tuple(method: DBusMethod):
     args = (1, "2", 3)
-    call = DbusMethodCall(method, args=args)
+    call = DBusMethodCall(method, args=args)
     assert call.args == args
 
 
-def test_dbusmethod_args_tuple_too_long(method: DbusMethod):
+def test_dbusmethod_args_tuple_too_long(method: DBusMethod):
     args = (1, "2", 3, 4)
     with pytest.raises(
         ValueError,
         match=re.escape("Expected args to have 3 items! (has: 4)"),
     ):
-        DbusMethodCall(method, args=args)
+        DBusMethodCall(method, args=args)
 
 
-def test_dbusmethod_args_tuple_too_short(method: DbusMethod):
+def test_dbusmethod_args_tuple_too_short(method: DBusMethod):
     args = (1, "2")
     with pytest.raises(
         ValueError,
         match=re.escape("Expected args to have 3 items! (has: 2)"),
     ):
-        DbusMethodCall(method, args=args)
+        DBusMethodCall(method, args=args)
 
 
-def test_dbusmethod_args_list(method: DbusMethod):
+def test_dbusmethod_args_list(method: DBusMethod):
     args = [1, "2", 3]
-    call = DbusMethodCall(method, args=args)
+    call = DBusMethodCall(method, args=args)
     assert call.args == (1, "2", 3)
 
 
 def test_dbusmethod_args_dict_method_without_params(
-    method_without_params: DbusMethod,
+    method_without_params: DBusMethod,
 ):
     args = dict(first=1, second="2", third=3)
     with pytest.raises(
         ValueError,
         match=re.escape(
             "args cannot be a dictionary if method does not have the params defined! "
-            "Either add params to the DbusMethod 'test-method' or give args as a tuple "
+            "Either add params to the DBusMethod 'test-method' or give args as a tuple "
             "or a list."
         ),
     ):
-        DbusMethodCall(method_without_params, args=args)
+        DBusMethodCall(method_without_params, args=args)
 
 
-def test_dbusmethod_args_dict_too_many_keys(method: DbusMethod):
+def test_dbusmethod_args_dict_too_many_keys(method: DBusMethod):
     args = dict(first=1, second="2", third=3, fourth=4)
 
     with pytest.raises(
         ValueError,
         match=re.escape("Expected args to have 3 items! (has: 4)"),
     ):
-        DbusMethodCall(method, args=args)
+        DBusMethodCall(method, args=args)
 
 
-def test_dbusmethod_args_dict_too_few_keys(method: DbusMethod):
+def test_dbusmethod_args_dict_too_few_keys(method: DBusMethod):
     args = dict(first=1, second="2")
 
     with pytest.raises(
         ValueError,
         match=re.escape("Expected args to have 3 items! (has: 2)"),
     ):
-        DbusMethodCall(method, args=args)
+        DBusMethodCall(method, args=args)
 
 
-def test_dbusmethod_args_dict_wrong_keys(method: DbusMethod):
+def test_dbusmethod_args_dict_wrong_keys(method: DBusMethod):
     args = dict(first=1, second="2", fifth="2")
 
     with pytest.raises(
         ValueError,
         match=re.escape(
-            "The keys in `args` do not match the keys in the DbusMethod params! "
+            "The keys in `args` do not match the keys in the DBusMethod params! "
             "Expected: ('first', 'second', 'third'). Got: ('first', 'second', 'fifth')"
         ),
     ):
-        DbusMethodCall(method, args=args)
+        DBusMethodCall(method, args=args)
 
 
-def test_dbusmethod_args_dict(method: DbusMethod):
+def test_dbusmethod_args_dict(method: DBusMethod):
     args = dict(first=1, second="2", third=3)
-    call = DbusMethodCall(method, args=args)
+    call = DBusMethodCall(method, args=args)
     assert call.args == (1, "2", 3)
 
 
-def test_dbusmethod_args_dict_different_order(method: DbusMethod):
+def test_dbusmethod_args_dict_different_order(method: DBusMethod):
     args = dict(third=3, first=1, second="2")
-    call = DbusMethodCall(method, args=args)
+    call = DBusMethodCall(method, args=args)
     assert call.args == (1, "2", 3)
 
 
-def test_dbusmethod_get_kwargs(method: DbusMethod):
+def test_dbusmethod_get_kwargs(method: DBusMethod):
     args = (1, "2", 3)
-    call = DbusMethodCall(method, args=args)
+    call = DBusMethodCall(method, args=args)
     assert call.get_kwargs() == dict(first=1, second="2", third=3)
 
 
-def test_dbusmethod_get_kwargs_noparams(method_without_params: DbusMethod):
+def test_dbusmethod_get_kwargs_noparams(method_without_params: DBusMethod):
     args = (1, "2", 3)
-    call = DbusMethodCall(method_without_params, args=args)
+    call = DBusMethodCall(method_without_params, args=args)
     # Not possible to convert to args to dict as the params are not named.
     assert call.get_kwargs() is None
 
 
-def test_dbusmethod_string_representation(method: DbusMethod):
+def test_dbusmethod_string_representation(method: DBusMethod):
     args = (1, "2", 3)
-    call = DbusMethodCall(method, args=args)
+    call = DBusMethodCall(method, args=args)
     assert call.__repr__() == "<wakepy.foo (1, '2', 3) | bus: SESSION>"

--- a/tests/unit/test_core/test_dbus.py
+++ b/tests/unit/test_core/test_dbus.py
@@ -1,8 +1,8 @@
 import pytest
 
-from wakepy.core.dbus import BusType, DbusAddress, DbusMethod, DbusMethodCall
+from wakepy.core.dbus import BusType, DBusAddress, DBusMethod, DBusMethodCall
 
-session_manager = DbusAddress(
+session_manager = DBusAddress(
     bus=BusType.SESSION,
     service="org.gnome.SessionManager",
     path="/org/gnome/SessionManager",
@@ -12,7 +12,7 @@ session_manager = DbusAddress(
 
 @pytest.fixture
 def method_inhibit():
-    return DbusMethod(
+    return DBusMethod(
         name="Inhibit",
         signature="susu",
         params=("app_id", "toplevel_xid", "reason", "flags"),
@@ -31,7 +31,7 @@ def test_dbus_method_to_call(method_inhibit, args_for_inhibit):
 
     call = method_inhibit.to_call(args_for_inhibit)
 
-    assert isinstance(call, DbusMethodCall)
+    assert isinstance(call, DBusMethodCall)
     assert call.args == args_for_inhibit
     assert call.method == method_inhibit
 
@@ -39,6 +39,6 @@ def test_dbus_method_to_call(method_inhibit, args_for_inhibit):
 def test_dbus_method_to_call_not_fully_defined_method(method_inhibit, args_for_inhibit):
     # The method is not fully defined as it is not tied to any address.
     with pytest.raises(
-        ValueError, match="DbusMethodCall requires completely defined DBusMethod"
+        ValueError, match="DBusMethodCall requires completely defined DBusMethod"
     ):
         method_inhibit.to_call(args_for_inhibit)

--- a/tests/unit/test_core/test_mode.py
+++ b/tests/unit/test_core/test_mode.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, call
 import pytest
 from testmethods import get_test_method_class
 
-from wakepy.core.dbus import DbusAdapter
+from wakepy.core.dbus import DBusAdapter
 from wakepy.core.heartbeat import Heartbeat
 from wakepy.core.mode import ActivationResult, Mode, ModeController, ModeExit
 
@@ -12,8 +12,8 @@ def mocks_for_test_mode():
     # Setup test
     mocks = Mock()
 
-    mocks.dbus_adapter_cls = Mock(spec_set=type(DbusAdapter))
-    mocks.dbus_adapter_cls.return_value = Mock(spec_set=DbusAdapter)
+    mocks.dbus_adapter_cls = Mock(spec_set=type(DBusAdapter))
+    mocks.dbus_adapter_cls.return_value = Mock(spec_set=DBusAdapter)
 
     mocks.mode_controller_cls = Mock()
     mocks.mode_controller_cls.return_value = Mock(spec_set=ModeController)
@@ -194,7 +194,7 @@ def test_modecontroller(monkeypatch):
     monkeypatch.setenv("WAKEPY_FAKE_SUCCESS", "0")
 
     method_cls = get_test_method_class(enter_mode=None, heartbeat=None, exit_mode=None)
-    controller = ModeController(Mock(spec_set=DbusAdapter))
+    controller = ModeController(Mock(spec_set=DBusAdapter))
 
     # When controller was created, it has not active method or heartbeat
     assert controller.active_method is None

--- a/tests/unit/test_methods/__init__.py
+++ b/tests/unit/test_methods/__init__.py
@@ -8,5 +8,5 @@ Tests include:
 
 Tests Exclude:
 * IO of any kind & calling 3rd party executables
-* Usage of Dbus services, even fake ones
+* Usage of DBus services, even fake ones
 """

--- a/tests/unit/test_methods/test_freedesktop.py
+++ b/tests/unit/test_methods/test_freedesktop.py
@@ -1,6 +1,6 @@
 """This module tests the Freedesktop.org specific methods.
 
-These tests do *not* use IO / real or fake Dbus calls. Instead, a special dbus
+These tests do *not* use IO / real or fake DBus calls. Instead, a special dbus
 adapter is used which simply asserts the Call objects and returns what we
 would expect from a dbus service."""
 
@@ -8,10 +8,10 @@ import re
 
 import pytest
 
-from wakepy.core.dbus import BusType, DbusAdapter, DbusAddress, DbusMethod
+from wakepy.core.dbus import BusType, DBusAdapter, DBusAddress, DBusMethod
 from wakepy.methods.freedesktop import FreedesktopScreenSaverInhibit
 
-screen_saver = DbusAddress(
+screen_saver = DBusAddress(
     bus=BusType.SESSION,
     service="org.freedesktop.ScreenSaver",
     path="/org/freedesktop/ScreenSaver",
@@ -24,7 +24,7 @@ fake_cookie = 75848243423
 
 def test_screensaver_enter_mode():
     # Arrange
-    method_inhibit = DbusMethod(
+    method_inhibit = DBusMethod(
         name="Inhibit",
         signature="ss",
         params=("application_name", "reason_for_inhibit"),
@@ -32,7 +32,7 @@ def test_screensaver_enter_mode():
         output_params=("cookie",),
     ).of(screen_saver)
 
-    class TestAdapter(DbusAdapter):
+    class TestAdapter(DBusAdapter):
         def process(self, call):
             assert call.method == method_inhibit
             assert call.get_kwargs() == {
@@ -50,19 +50,19 @@ def test_screensaver_enter_mode():
 
     # Assert
     assert enter_retval is None
-    # Entering mode sets a inhibit_cookie to value returned by the DbusAdapter
+    # Entering mode sets a inhibit_cookie to value returned by the DBusAdapter
     assert method.inhibit_cookie == fake_cookie
 
 
 def test_screensaver_exit_mode():
     # Arrange
-    method_uninhibit = DbusMethod(
+    method_uninhibit = DBusMethod(
         name="UnInhibit",
         signature="u",
         params=("cookie",),
     ).of(screen_saver)
 
-    class TestAdapter(DbusAdapter):
+    class TestAdapter(DBusAdapter):
         def process(self, call):
             assert call.method == method_uninhibit
             assert call.get_kwargs() == {"cookie": fake_cookie}
@@ -80,13 +80,13 @@ def test_screensaver_exit_mode():
 
 
 def test_screensaver_exit_before_enter():
-    method = FreedesktopScreenSaverInhibit(dbus_adapter=DbusAdapter())
+    method = FreedesktopScreenSaverInhibit(dbus_adapter=DBusAdapter())
     assert method.inhibit_cookie is None
     assert method.exit_mode() is None
 
 
 def test_with_dbus_adapter_which_returns_none():
-    class BadAdapterReturnNone(DbusAdapter):
+    class BadAdapterReturnNone(DBusAdapter):
         def process(self, _):
             return None
 

--- a/tests/unit/test_methods/test_gnome.py
+++ b/tests/unit/test_methods/test_gnome.py
@@ -1,6 +1,6 @@
 """This module tests the GNOME specific methods.
 
-These tests do *not* use IO / real or fake Dbus calls. Instead, a special dbus
+These tests do *not* use IO / real or fake DBus calls. Instead, a special dbus
 adapter is used which simply asserts the Call objects and returns what we
 would expect from a dbus service."""
 
@@ -8,14 +8,14 @@ import re
 
 import pytest
 
-from wakepy.core.dbus import BusType, DbusAdapter, DbusAddress, DbusMethod
+from wakepy.core.dbus import BusType, DBusAdapter, DBusAddress, DBusMethod
 from wakepy.methods.gnome import (
     GnomeFlag,
     GnomeSessionManagerNoIdle,
     GnomeSessionManagerNoSuspend,
 )
 
-session_manager = DbusAddress(
+session_manager = DBusAddress(
     bus=BusType.SESSION,
     service="org.gnome.SessionManager",
     path="/org/gnome/SessionManager",
@@ -35,7 +35,7 @@ fake_cookie = 75848243423
 )
 def test_gnome_enter_mode(method_cls, flag):
     # Arrange
-    method_inhibit = DbusMethod(
+    method_inhibit = DBusMethod(
         name="Inhibit",
         signature="susu",
         params=("app_id", "toplevel_xid", "reason", "flags"),
@@ -43,7 +43,7 @@ def test_gnome_enter_mode(method_cls, flag):
         output_params=("inhibit_cookie",),
     ).of(session_manager)
 
-    class TestAdapter(DbusAdapter):
+    class TestAdapter(DBusAdapter):
         def process(self, call):
             assert call.method == method_inhibit
             assert call.get_kwargs() == {
@@ -63,7 +63,7 @@ def test_gnome_enter_mode(method_cls, flag):
 
     # Assert
     assert enter_retval is None
-    # Entering mode sets a inhibit_cookie to value returned by the DbusAdapter
+    # Entering mode sets a inhibit_cookie to value returned by the DBusAdapter
     assert method.inhibit_cookie == fake_cookie
 
 
@@ -73,13 +73,13 @@ def test_gnome_enter_mode(method_cls, flag):
 )
 def test_gnome_exit_mode(method_cls):
     # Arrange
-    method_uninhibit = DbusMethod(
+    method_uninhibit = DBusMethod(
         name="Uninhibit",
         signature="u",
         params=("inhibit_cookie",),
     ).of(session_manager)
 
-    class TestAdapter(DbusAdapter):
+    class TestAdapter(DBusAdapter):
         def process(self, call):
             assert call.method == method_uninhibit
             assert call.get_kwargs() == {"inhibit_cookie": fake_cookie}
@@ -101,7 +101,7 @@ def test_gnome_exit_mode(method_cls):
     [GnomeSessionManagerNoSuspend, GnomeSessionManagerNoIdle],
 )
 def test_gnome_exit_before_enter(method_cls):
-    method = method_cls(dbus_adapter=DbusAdapter())
+    method = method_cls(dbus_adapter=DBusAdapter())
     assert method.inhibit_cookie is None
     assert method.exit_mode() is None
 
@@ -111,7 +111,7 @@ def test_gnome_exit_before_enter(method_cls):
     [GnomeSessionManagerNoSuspend, GnomeSessionManagerNoIdle],
 )
 def test_with_dbus_adapter_which_returns_none(method_cls):
-    class BadAdapterReturnNone(DbusAdapter):
+    class BadAdapterReturnNone(DBusAdapter):
         def process(self, _):
             return None
 

--- a/tests/unit/test_modes.py
+++ b/tests/unit/test_modes.py
@@ -3,7 +3,7 @@ import re
 import pytest
 
 from wakepy import ActivationError
-from wakepy.core import ActivationResult, DbusAdapter, Method, Mode, ModeName
+from wakepy.core import ActivationResult, DBusAdapter, Method, Mode, ModeName
 from wakepy.modes import keep
 
 
@@ -64,11 +64,11 @@ def test_keep_running_mode_creation(input_args, monkeypatch, testutils):
     assert set(mode.method_classes) == {MethodB, MethodA, MethodC}
 
     # Case: Test "dbus_adapter" parameter
-    class MyDbusAdapter(DbusAdapter):
+    class MyDBusAdapter(DBusAdapter):
         ...
 
-    mode = function_under_test(dbus_adapter=MyDbusAdapter)
-    assert mode._dbus_adapter_cls == MyDbusAdapter
+    mode = function_under_test(dbus_adapter=MyDBusAdapter)
+    assert mode._dbus_adapter_cls == MyDBusAdapter
 
 
 def test_keep_running_with_fake_success(monkeypatch, fake_dbus_adapter):

--- a/wakepy/__init__.py
+++ b/wakepy/__init__.py
@@ -2,7 +2,7 @@
 from . import methods as methods
 from .core import ActivationError as ActivationError
 from .core import ActivationResult as ActivationResult
-from .core import DbusAdapter as DbusAdapter
+from .core import DBusAdapter as DBusAdapter
 from .core import Method as Method
 from .core import Mode as Mode
 from .core import ModeExit as ModeExit

--- a/wakepy/core/__init__.py
+++ b/wakepy/core/__init__.py
@@ -9,10 +9,10 @@ from .activation import MethodActivationResult as MethodActivationResult
 from .constants import BusType as BusType
 from .constants import ModeName as ModeName
 from .constants import PlatformName as PlatformName
-from .dbus import DbusAdapter as DbusAdapter
-from .dbus import DbusAddress as DbusAddress
-from .dbus import DbusMethod as DbusMethod
-from .dbus import DbusMethodCall as DbusMethodCall
+from .dbus import DBusAdapter as DBusAdapter
+from .dbus import DBusAddress as DBusAddress
+from .dbus import DBusMethod as DBusMethod
+from .dbus import DBusMethodCall as DBusMethodCall
 from .method import Method as Method
 from .mode import ActivationError as ActivationError
 from .mode import Mode as Mode

--- a/wakepy/core/activation.py
+++ b/wakepy/core/activation.py
@@ -25,7 +25,7 @@ from dataclasses import dataclass
 from typing import List, Set, Union
 
 from .constants import PlatformName
-from .dbus import DbusAdapter
+from .dbus import DBusAdapter
 from .heartbeat import Heartbeat
 from .method import Method, MethodError, MethodOutcome
 from .platform import CURRENT_PLATFORM
@@ -266,7 +266,7 @@ class MethodActivationResult:
 
 def activate_mode(
     methods: list[Type[Method]],
-    dbus_adapter: Optional[DbusAdapter] = None,
+    dbus_adapter: Optional[DBusAdapter] = None,
     methods_priority: Optional[MethodsPriorityOrder] = None,
     modename: Optional[str] = None,
 ) -> Tuple[ActivationResult, Optional[Method], Optional[Heartbeat]]:
@@ -282,7 +282,7 @@ def activate_mode(
     methods:
         The list of Methods to be used for activating this Mode.
     dbus_adapter:
-        Can be used to define a custom DBus adapter for processing Dbus calls
+        Can be used to define a custom DBus adapter for processing DBus calls
         in the .caniuse(), .enter_mode(), .heartbeat() and .exit_mode() of the
         Method. Optional.
     methods_priority: list[str | set[str]]

--- a/wakepy/core/method.py
+++ b/wakepy/core/method.py
@@ -23,7 +23,7 @@ from .registry import register_method
 from .strenum import StrEnum, auto
 
 if typing.TYPE_CHECKING:
-    from wakepy.core import DbusAdapter, DbusMethodCall
+    from wakepy.core import DBusAdapter, DBusMethodCall
 
 MethodCls = Type["Method"]
 T = TypeVar("T")
@@ -108,7 +108,7 @@ class Method(ABC, metaclass=MethodMeta):
     _has_exit: bool
     _has_heartbeat: bool
 
-    def __init__(self, dbus_adapter: Optional[DbusAdapter] = None):
+    def __init__(self, dbus_adapter: Optional[DBusAdapter] = None):
         # The dbus-adapter may be used to process dbus calls. This is relevant
         # only on methods using D-Bus.
         self._dbus_adapter = dbus_adapter
@@ -151,7 +151,7 @@ class Method(ABC, metaclass=MethodMeta):
 
         # Examples
         # --------
-        # - Test that system is running KDE using DbusMethodCalls to some service
+        # - Test that system is running KDE using DBusMethodCalls to some service
         #   that should be running on KDE. Could also test that the version of
         #   KDE is something that is needed.
         # - If a Method depends on availability of certain software on PATH,
@@ -227,7 +227,7 @@ class Method(ABC, metaclass=MethodMeta):
         """
         return
 
-    def process_dbus_call(self, call: DbusMethodCall) -> Any:
+    def process_dbus_call(self, call: DBusMethodCall) -> Any:
         # Notes for subclassing
         # =====================
         # This method is always available for all subclasses of Method. This
@@ -239,7 +239,7 @@ class Method(ABC, metaclass=MethodMeta):
         if self._dbus_adapter is None:
             raise RuntimeError(
                 f'{self.__class__.__name__ }cannot process dbus method call "{call}" as'
-                " it does not have a DbusAdapter."
+                " it does not have a DBusAdapter."
             )
         return self._dbus_adapter.process(call)
 

--- a/wakepy/core/mode.py
+++ b/wakepy/core/mode.py
@@ -16,7 +16,7 @@ if typing.TYPE_CHECKING:
 
     from .activation import MethodsPriorityOrder
     from .constants import ModeName
-    from .dbus import DbusAdapter, DbusAdapterTypeSeq
+    from .dbus import DBusAdapter, DBusAdapterTypeSeq
     from .method import Method, StrCollection
 
     OnFail = Literal["error", "warn", "pass"] | Callable[[ActivationResult], None]
@@ -49,7 +49,7 @@ class ModeExit(Exception):
 
 
 class ModeController:
-    def __init__(self, dbus_adapter: Optional[DbusAdapter] = None):
+    def __init__(self, dbus_adapter: Optional[DBusAdapter] = None):
         self.dbus_adapter = dbus_adapter
         self.active_method: Method | None = None
         self.heartbeat: Heartbeat | None = None
@@ -147,7 +147,7 @@ class Mode(ABC):
         information about the activation process.
     dbus_adapter:
         For using a custom dbus-adapter. Optional. If not given, the
-        default dbus adapter is used, which is :class:`~wakepy.dbus_adapters.jeepney.JeepneyDbusAdapter`
+        default dbus adapter is used, which is :class:`~wakepy.dbus_adapters.jeepney.JeepneyDBusAdapter`
     """  # noqa: E501
 
     method_classes: list[Type[Method]]
@@ -177,7 +177,7 @@ class Mode(ABC):
     """The ``on_fail`` given when creating the :class:`Mode`.
     """
 
-    dbus_adapter: DbusAdapter | None
+    dbus_adapter: DBusAdapter | None
     """The DBus adapter used with ``Method``\ s which require DBus (if any)."""
 
     _controller_class: Type[ModeController] = ModeController
@@ -188,7 +188,7 @@ class Mode(ABC):
         methods_priority: Optional[MethodsPriorityOrder] = None,
         name: Optional[ModeName | str] = None,
         on_fail: OnFail = "error",
-        dbus_adapter: Type[DbusAdapter] | DbusAdapterTypeSeq | None = None,
+        dbus_adapter: Type[DBusAdapter] | DBusAdapterTypeSeq | None = None,
     ):
         """Initialize a `Mode` using `Method`\ s.
 

--- a/wakepy/dbus_adapters/__init__.py
+++ b/wakepy/dbus_adapters/__init__.py
@@ -1,6 +1,6 @@
 """This package contains dbus adapters to be used with wakepy.
 
 Each dbus adapter represents one python dbus library. A dbus adapter should
-subclass the wakepy.core.DbusAdapter, and it may be used as an argument to
+subclass the wakepy.core.DBusAdapter, and it may be used as an argument to
 wakepy modes (keep.running & keep.presenting).
 """

--- a/wakepy/dbus_adapters/jeepney.py
+++ b/wakepy/dbus_adapters/jeepney.py
@@ -2,23 +2,23 @@ from jeepney import DBusAddress, new_method_call
 from jeepney.io.blocking import open_dbus_connection
 from jeepney.wrappers import unwrap_msg
 
-from wakepy.core import DbusAdapter, DbusMethodCall
+from wakepy.core import DBusAdapter, DBusMethodCall
 
 
-class DbusNotFoundError(RuntimeError):
+class DBusNotFoundError(RuntimeError):
     ...
 
 
-class JeepneyDbusAdapter(DbusAdapter):
-    """An implementation of :class:`~wakepy.DbusAdapter` using `jeepney <https://jeepney.readthedocs.io/>`_.
-    Can be used to process DbusMethodCalls (communication with Dbus services
+class JeepneyDBusAdapter(DBusAdapter):
+    """An implementation of :class:`~wakepy.DBusAdapter` using `jeepney <https://jeepney.readthedocs.io/>`_.
+    Can be used to process DBusMethodCalls (communication with DBus services
     over a dbus-daemon).
     """
 
     # timeout for dbus calls, in seconds
     timeout = 2
 
-    def process(self, call: DbusMethodCall):
+    def process(self, call: DBusMethodCall):
         addr = DBusAddress(
             object_path=call.method.path,
             bus_name=call.method.service,
@@ -35,7 +35,7 @@ class JeepneyDbusAdapter(DbusAdapter):
             connection = open_dbus_connection(bus=call.method.bus)
         except KeyError as exc:
             if "DBUS_SESSION_BUS_ADDRESS" in str(exc):
-                raise DbusNotFoundError(
+                raise DBusNotFoundError(
                     "The environment variable DBUS_SESSION_BUS_ADDRESS is not set! "
                     "To use dbus-based methods with jeepney, a session (not system) "
                     "bus (dbus-daemon process) must be running, and the address of the "

--- a/wakepy/methods/freedesktop.py
+++ b/wakepy/methods/freedesktop.py
@@ -4,9 +4,9 @@ from typing import Optional
 
 from wakepy.core import (
     BusType,
-    DbusAddress,
-    DbusMethod,
-    DbusMethodCall,
+    DBusAddress,
+    DBusMethod,
+    DBusMethodCall,
     Method,
     ModeName,
     PlatformName,
@@ -22,14 +22,14 @@ class FreedesktopScreenSaverInhibit(Method):
     name = "org.freedesktop.ScreenSaver"
     mode = ModeName.KEEP_PRESENTING
 
-    screen_saver = DbusAddress(
+    screen_saver = DBusAddress(
         bus=BusType.SESSION,
         service="org.freedesktop.ScreenSaver",
         path="/org/freedesktop/ScreenSaver",
         interface="org.freedesktop.ScreenSaver",
     )
 
-    method_inhibit = DbusMethod(
+    method_inhibit = DBusMethod(
         name="Inhibit",
         signature="ss",
         params=("application_name", "reason_for_inhibit"),
@@ -37,7 +37,7 @@ class FreedesktopScreenSaverInhibit(Method):
         output_params=("cookie",),
     ).of(screen_saver)
 
-    method_uninhibit = DbusMethod(
+    method_uninhibit = DBusMethod(
         name="UnInhibit",
         signature="u",
         params=("cookie",),
@@ -50,7 +50,7 @@ class FreedesktopScreenSaverInhibit(Method):
         self.inhibit_cookie: Optional[int] = None
 
     def enter_mode(self):
-        call = DbusMethodCall(
+        call = DBusMethodCall(
             method=self.method_inhibit,
             args=dict(
                 application_name="wakepy",
@@ -70,7 +70,7 @@ class FreedesktopScreenSaverInhibit(Method):
             # Nothing to exit from.
             return
 
-        call = DbusMethodCall(
+        call = DBusMethodCall(
             method=self.method_uninhibit,
             args=dict(cookie=self.inhibit_cookie),
         )

--- a/wakepy/methods/gnome.py
+++ b/wakepy/methods/gnome.py
@@ -4,9 +4,9 @@ from typing import Optional
 
 from wakepy.core import (
     BusType,
-    DbusAddress,
-    DbusMethod,
-    DbusMethodCall,
+    DBusAddress,
+    DBusMethod,
+    DBusMethodCall,
     Method,
     ModeName,
     PlatformName,
@@ -30,14 +30,14 @@ class _GnomeSessionManager(Method, ABC):
     https://lira.no-ip.org:8443/doc/gnome-session/dbus/gnome-session.html#org.gnome.SessionManager.Inhibit
     """
 
-    session_manager = DbusAddress(
+    session_manager = DBusAddress(
         bus=BusType.SESSION,
         service="org.gnome.SessionManager",
         path="/org/gnome/SessionManager",
         interface="org.gnome.SessionManager",
     )
 
-    method_inhibit = DbusMethod(
+    method_inhibit = DBusMethod(
         name="Inhibit",
         signature="susu",
         params=("app_id", "toplevel_xid", "reason", "flags"),
@@ -45,7 +45,7 @@ class _GnomeSessionManager(Method, ABC):
         output_params=("inhibit_cookie",),
     ).of(session_manager)
 
-    method_uninhibit = DbusMethod(
+    method_uninhibit = DBusMethod(
         name="Uninhibit",
         signature="u",
         params=("inhibit_cookie",),
@@ -63,7 +63,7 @@ class _GnomeSessionManager(Method, ABC):
         self.inhibit_cookie: Optional[int] = None
 
     def enter_mode(self):
-        call = DbusMethodCall(
+        call = DBusMethodCall(
             method=self.method_inhibit,
             args=dict(
                 app_id="wakepy",
@@ -85,7 +85,7 @@ class _GnomeSessionManager(Method, ABC):
             # Nothing to exit from.
             return
 
-        call = DbusMethodCall(
+        call = DBusMethodCall(
             method=self.method_uninhibit,
             args=dict(inhibit_cookie=self.inhibit_cookie),
         )

--- a/wakepy/modes/keep.py
+++ b/wakepy/modes/keep.py
@@ -9,7 +9,7 @@ if typing.TYPE_CHECKING:
     from typing import Optional, Type
 
     from ..core.activation import MethodsPriorityOrder
-    from ..core.dbus import DbusAdapter, DbusAdapterTypeSeq
+    from ..core.dbus import DBusAdapter, DBusAdapterTypeSeq
     from ..core.method import StrCollection
     from ..core.mode import Mode, OnFail
 
@@ -19,7 +19,7 @@ def running(
     omit: Optional[StrCollection] = None,
     methods_priority: Optional[MethodsPriorityOrder] = None,
     on_fail: OnFail = "error",
-    dbus_adapter: Type[DbusAdapter] | DbusAdapterTypeSeq | None = None,
+    dbus_adapter: Type[DBusAdapter] | DBusAdapterTypeSeq | None = None,
 ) -> Mode:
     """Create a wakepy mode (a context manager) for keeping programs running.
 
@@ -63,7 +63,7 @@ def running(
         activation process.
     dbus_adapter: class or sequence of classes
         Optional argument which can be used to define a custom DBus adapter.
-        If given, should be a subclass of :class:`~wakepy.DbusAdapter`, or a
+        If given, should be a subclass of :class:`~wakepy.DBusAdapter`, or a
         list of such.
 
     Returns
@@ -92,7 +92,7 @@ def presenting(
     omit: Optional[StrCollection] = None,
     methods_priority: Optional[MethodsPriorityOrder] = None,
     on_fail: OnFail = "error",
-    dbus_adapter: Type[DbusAdapter] | DbusAdapterTypeSeq | None = None,
+    dbus_adapter: Type[DBusAdapter] | DBusAdapterTypeSeq | None = None,
 ) -> Mode:
     """Create a wakepy mode (a context manager) for keeping a system running
     and showing content.
@@ -137,7 +137,7 @@ def presenting(
         activation process.
     dbus_adapter: class or sequence of classes
         Optional argument which can be used to define a custom DBus adapter.
-        If given, should be a subclass of :class:`~wakepy.DbusAdapter`, or a
+        If given, should be a subclass of :class:`~wakepy.DBusAdapter`, or a
         list of such.
 
     Returns


### PR DESCRIPTION
Use upper case "B" everywhere where DBus is mentioned.

This seems to be the correct form. See, for example:
- https://dbus.freedesktop.org/doc/dbus-tutorial.html
- https://dbus.freedesktop.org/doc/dbus-java/api/org/freedesktop/dbus/DBusInterface.html (has subinterfaces called DBus, DBus.Binding.SingleTests, DBus.Binding.TestClient, DBus.Binding.Tests, DBus.Binding.TestSignals, DBus.Introspectable, DBus.Local, DBus.Peer, DBus.Properties ) 

Better to change this before 0.8.0 release.