### PR TITLE
Disallow Warnings in tests (raise Exception on any Warning)

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -2,6 +2,7 @@
 provides the services as fixtures. The services run in separate threads.
 """
 
+import gc
 import logging
 import subprocess
 import sys
@@ -17,6 +18,19 @@ else:
 from wakepy.core import DBusAddress, DBusMethod
 
 logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def gc_collect_after_dbus_integration_tests():
+    logger.debug("prepare for gc.collect")
+    yield
+    # A garbage collection has high change of triggering a ResourceWarning
+    # about an unclosed socket. Note that the warning can occur also before
+    # this as garbage colletion is triggered also automatically. The garbage
+    # collection must be triggered here manually as the warnings are
+    # ResourceWarning is only filtered away in the dbus integration tests.
+    gc.collect()
+    logger.debug("called gc.collect")
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -49,7 +49,14 @@ def private_bus():
     yield bus_address
 
     logger.info("Terminating private bus")
-    p.terminate()
+    p.terminate()  # send SIGTERM. Turns dbus-daemon into a zombie.
+    p.wait()  # cleaup the zombie
+    # This is required for closing the subprocess.PIPE. Otherwise, will get
+    # something like.
+    # ResourceWarning: unclosed file <_io.BufferedReader name=11>
+    # See: https://stackoverflow.com/a/58696973/3015186
+    p.stdout.close()
+    logger.info("Private bus terminated")
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/test_dbus_adapters.py
+++ b/tests/integration/test_dbus_adapters.py
@@ -16,6 +16,18 @@ import pytest
 from wakepy.core import DBusAddress, DBusMethod, DBusMethodCall
 from wakepy.dbus_adapters.jeepney import JeepneyDBusAdapter
 
+# For some unknown reason, when using jeepney, one will get a warning like
+# this:
+# ResourceWarning: unclosed <socket.socket fd=14, family=AddressFamily.AF_UNIX, type=SocketKind.SOCK_STREAM, proto=0, raddr=b'\x00/tmp/dbus-cTfPKAeBWk'>
+# This is just ignored. It only triggers at *random* line, on random test when
+# python does garbage collection.
+#
+# Ref1: https://docs.pytest.org/en/7.1.x/reference/reference.html#pytest-mark-filterwarnings
+# Ref2: https://docs.pytest.org/en/7.1.x/reference/reference.html#globalvar-pytestmark
+pytestmark = pytest.mark.filterwarnings(
+    r"ignore:unclosed.*raddr=b'\\x00/tmp/dbus-.*:ResourceWarning"
+)
+
 
 @pytest.mark.usefixtures("dbus_calculator_service")
 def test_jeepney_dbus_adapter_numberadd(numberadd_method):

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,8 @@ deps =
     pytest>=6
     jeepney >= 0.7.1;sys_platform=='linux'
 commands =
-    {envpython} -m pytest {tty:--color=yes} {posargs}
+    ; -W error: turn warnings into errors
+    {envpython} -m pytest -W error {tty:--color=yes} {posargs}
 allowlist_externals =
     echo
 

--- a/wakepy/core/mode.py
+++ b/wakepy/core/mode.py
@@ -178,7 +178,7 @@ class Mode(ABC):
     """
 
     dbus_adapter: DBusAdapter | None
-    """The DBus adapter used with ``Method``\ s which require DBus (if any)."""
+    r"""The DBus adapter used with ``Method``\ s which require DBus (if any)."""
 
     _controller_class: Type[ModeController] = ModeController
 
@@ -190,7 +190,7 @@ class Mode(ABC):
         on_fail: OnFail = "error",
         dbus_adapter: Type[DBusAdapter] | DBusAdapterTypeSeq | None = None,
     ):
-        """Initialize a `Mode` using `Method`\ s.
+        r"""Initialize a `Mode` using `Method`\ s.
 
         This is also where the activation process related settings, such as the
         dbus adapter to be used, are defined.


### PR DESCRIPTION
Prevents accidentally merging any code that issues new warnings.

Warnings fixed / silenced
--------------------------
Needed to fix some warnings issued in the tests.

ResourceWarning caused by unclosed subprocess.PIPE
* Fixed by closing it.

ResourceWarning caused by jeepney dbus connection (socket with
  raddr=b'\x00/tmp/dbus-cTfPKAeBWk' or similar).  
* Fixed by ignoring the ResourceWarning in dbus adapter tests. The warning
  is only issued when garbage collection is ran, which occurs randomly. 
  Therefore, added manual gc.collect() at end of dbus integration tests.
  (prevents the need to filter the warning in other tests)
* Could not find a way to close the socket as the connection and socket
  seem to be closed already. Could also be that the tests should use the
  jeepney.threading.io instead of jeepney.blocking.io, but that did not 
  seem to work (could be because the JeepneyDBusAdapter uses the blocking.io?)
* Not sure if worth investigating more at this point as this only affects
  tests. Could at some point see if JeepneyDBusAdapter should use the threaded
  blocking version instead. (from jeepney.threading.io)
  
Warnings caused by backslashes in docstrings.
* Used raw strings instead.