### PR TITLE
ruff update 0.0.270 -> 0.3.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dev = [
     "mypy==1.3.0",
     "tox==4.6.0",
     "isort==5.12.0",
-    "ruff==0.0.270",
+    "ruff==0.3.2",
     # Jeepney is used in the integration tests for creating a D-Bus server
     "jeepney >= 0.7.1;sys_platform=='linux'"
 ]
@@ -94,17 +94,7 @@ profile = "black"
 [tool.ruff]
 # Same as Black.
 line-length = 88
-
-target-version = "py310"
-
-# Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
-select = ["E", "F"]
-ignore = []
-
 fix = true
-# Allow autofix for all enabled rules (when `--fix`) is provided.
-fixable = ["A", "B", "C", "D", "E", "F", "G", "I", "N", "Q", "S", "T", "W", "ANN", "ARG", "BLE", "COM", "DJ", "DTZ", "EM", "ERA", "EXE", "FBT", "ICN", "INP", "ISC", "NPY", "PD", "PGH", "PIE", "PL", "PT", "PTH", "PYI", "RET", "RSE", "RUF", "SIM", "SLF", "TCH", "TID", "TRY", "UP", "YTT"]
-unfixable = []
 
 # Exclude a variety of commonly ignored directories.
 exclude = [
@@ -121,5 +111,12 @@ exclude = [
     "venv",
 ]
 
+[tool.ruff.lint]
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+# Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
+select = ["E", "F"]
+ignore = []
+# Allow autofix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []

--- a/tox.ini
+++ b/tox.ini
@@ -26,12 +26,12 @@ allowlist_externals =
 description = Check formatting
 deps =
     black==23.3.0
-    ruff==0.0.270
+    ruff==0.3.2
     isort==5.12.0
     mypy==1.3.0
 skip_install = true
 commands =
     python -m isort ./wakepy --check --diff
     python -m black ./wakepy --check
-    python -m ruff ./wakepy
+    python -m ruff check ./wakepy
     python -m mypy ./wakepy


### PR DESCRIPTION
Also change the target-version = "py310". Just use the project.requires-python as recommended in the docs[1], and target to Python 3.7 as that is the oldest supported python version.

[1] https://docs.astral.sh/ruff/settings/#target-version