### PR TITLE
Disallow trailing whitespace in python files (W291)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,8 @@ exclude = [
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 # Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
 # W505: doc-line-too-long. Ref: https://docs.astral.sh/ruff/rules/doc-line-too-long/
-select = ["E", "F", "W505"]
+# W291: trailing-whitespace. Ref: https://docs.astral.sh/ruff/rules/trailing-whitespace/
+select = ["E", "F", "W505", "W291"]
 ignore = []
 # Allow autofix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]


### PR DESCRIPTION
Added in tox check phase (ruff) the rule W291 which disallows trailing whitespace.