### PR TITLE
use tox-extras to list the "check" dependencies in pyproject.toml only

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,12 @@ envlist =
     py312
     check
 minversion = 4.6.0
+requires =
+    ; This is needed until something like --only-deps is added to pip[1]
+    ; Adds tox_extras option to tox.ini files. See [2]
+    ; [1] https://github.com/pypa/pip/issues/11440
+    ; [2] https://github.com/sclabs/tox-extras
+    tox-extras==0.0.1
 
 [testenv]
 description = run the tests with pytest
@@ -23,12 +29,11 @@ allowlist_externals =
     echo
 
 [testenv:check]
-description = Check formatting
-deps =
-    black==23.3.0
-    ruff==0.3.2
-    isort==5.12.0
-    mypy==1.3.0
+; Using tox_extras makes it possible to (1) list the dependencies in only one
+; place (pyproject.toml) and (2) to not force installing the package just for
+; linting (which makes tox run faster)
+description = Check the code
+tox_extras = check
 skip_install = true
 commands =
     python -m isort ./wakepy --check --diff


### PR DESCRIPTION
Using [tox_extras](https://github.com/sclabs/tox-extras) makes it possible to (1) list the dependencies in only one
place (pyproject.toml) and (2) to not force installing the package just for
linting (which makes tox run faster)