### PR TITLE
Pin dev dependencies (reproducible tests & doc builds)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,16 +34,16 @@ classifiers = [
 # For development
 dev = [
     "wakepy[test,doc,check]",
-    "sphinx-autobuild",
+    "sphinx-autobuild==2024.2.4",
     "IPython",
 ]
 # For building documentation
 doc = [
-    "sphinx~=7.0",
-    "sphinx_design>0.4.1",
-    "sphinx-copybutton~=0.5.2",
-    "myst-parser~=2.0.0",
-    "sphinx-book-theme~=1.1.0",
+    "sphinx==7.2.6",
+    "sphinx_design==0.5.0",
+    "sphinx-copybutton==0.5.2",
+    "myst-parser==2.0.0",
+    "sphinx-book-theme==1.1.2",
     # a numpydoc 1.7.0rc0.dev0. This one has https://github.com/numpy/numpydoc/pull/527 merged
     # At some point: Can use 1.7.0 (which is not available in PyPI at the time of writing)
     "numpydoc @ git+https://github.com/numpy/numpydoc.git@46f532a824639a97479039fc122533915cdfa10f"
@@ -51,11 +51,11 @@ doc = [
 # For running unit tests
 test =[
     "tox==4.6.0",
-    "pytest>6",
-    "pytest-cov",
-    "time-machine",
+    "pytest==8.1.1",
+    "pytest-cov==4.1.0",
+    "time-machine==2.14.0",
     # Jeepney is used in the integration tests for creating a D-Bus server
-    "jeepney >= 0.7.1;sys_platform=='linux'"
+    "jeepney==0.8.0;sys_platform=='linux'"
 ]
 # For linters, code analysis and formatting tools
 check = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,9 +51,13 @@ doc = [
 # For running unit tests
 test =[
     "tox==4.6.0",
-    "pytest==8.1.1",
+    "pytest==8.1.1; python_version>='3.8'",
+    # Python 3.7 support dropped in pytest 8.0.0
+    "pytest==7.4.4; python_version=='3.7'", 
     "pytest-cov==4.1.0",
-    "time-machine==2.14.0",
+    "time-machine==2.14.0; python_version>='3.8'",
+    # Python 3.7 support dropped in time-machine 2.11.0
+    "time-machine==2.10.0; python_version=='3.7'",
     # Jeepney is used in the integration tests for creating a D-Bus server
     "jeepney==0.8.0;sys_platform=='linux'"
 ]


### PR DESCRIPTION
Pin all development dependencies. Well, except for IPython which really is just there as convenience tool and not used within the repo.

Tests and building docs should be reproducible.

Python 3.7 gets special treatment as the support for it is dropped from many packages. I don't want to use older version of tools day-to-day and with every version of python just because of python 3.7. Hence, it has different versions pinned. If that becomes a problem, have to use the same (older) version also when testing with other python versions.
