### PR TITLE
Code coverage 96% -> 100%

### DIFF
--- a/tests/unit/test_core/test_activation/test_activation.py
+++ b/tests/unit/test_core/test_activation/test_activation.py
@@ -460,6 +460,18 @@ def test_caniuse_fails(params):
     assert caniuse_fails(SomeMethod()) == params["expected"]
 
 
+def test_caniuse_fails_special_case():
+    """Tests the case when Method.caniuse raises an exception"""
+    err = ValueError("Cannot use")
+
+    class SomeMethod(Method):
+        def caniuse(self):
+            raise err
+
+    method = SomeMethod()
+    assert caniuse_fails(method) == (True, str(err))
+
+
 @pytest.mark.parametrize(
     "success, failure_stage, method_name, message, expected_string_representation",
     [

--- a/tests/unit/test_core/test_dbus.py
+++ b/tests/unit/test_core/test_dbus.py
@@ -1,5 +1,8 @@
 import pytest
 
+from unittest.mock import patch
+
+from wakepy.dbus_adapters.jeepney import JeepneyDBusAdapter
 from wakepy.core.dbus import (
     BusType,
     DBusAddress,
@@ -7,6 +10,7 @@ from wakepy.core.dbus import (
     DBusMethodCall,
     DBusAdapter,
     get_dbus_adapter,
+    get_default_dbus_adapter,
 )
 
 session_manager = DBusAddress(
@@ -87,3 +91,14 @@ class TestGetDbusAdapter:
     def test_no_supported_adapters(self, unsupported_dbus_adapter):
         adapter = get_dbus_adapter([unsupported_dbus_adapter])
         assert adapter is None
+
+
+def test_get_default_dbus_adapter_nonworking():
+    with patch.dict("sys.modules", {"wakepy.dbus_adapters.jeepney": None}):
+        # When jeepney is not installed, there is not default dbus adapter
+        assert get_default_dbus_adapter() is None
+
+
+def test_get_default_dbus_adapter_working():
+    # When jeepney is installed, we get the JeepneyDBusAdapter as default.
+    assert isinstance(get_default_dbus_adapter(), JeepneyDBusAdapter)

--- a/tests/unit/test_core/test_dbus.py
+++ b/tests/unit/test_core/test_dbus.py
@@ -2,7 +2,8 @@ import pytest
 
 from unittest.mock import patch
 
-from wakepy.dbus_adapters.jeepney import JeepneyDBusAdapter
+from wakepy.core.platform import CURRENT_PLATFORM, PlatformName
+
 from wakepy.core.dbus import (
     BusType,
     DBusAddress,
@@ -100,5 +101,12 @@ def test_get_default_dbus_adapter_nonworking():
 
 
 def test_get_default_dbus_adapter_working():
-    # When jeepney is installed, we get the JeepneyDBusAdapter as default.
-    assert isinstance(get_default_dbus_adapter(), JeepneyDBusAdapter)
+    try:
+        import jeepney as jeepney  # noqa
+    except:
+        assert get_default_dbus_adapter() is None
+    else:
+        from wakepy.dbus_adapters.jeepney import JeepneyDBusAdapter
+
+        # When jeepney is installed, we get the JeepneyDBusAdapter as default.
+        assert isinstance(get_default_dbus_adapter(), JeepneyDBusAdapter)

--- a/tests/unit/test_core/test_method.py
+++ b/tests/unit/test_core/test_method.py
@@ -169,3 +169,15 @@ def test_method_string_representations():
     method = MethodB()
     assert method.__str__() == "<wakepy Method: MethodB>"
     assert method.__repr__() == f"<wakepy Method: MethodB at {hex(id(method))}>"
+
+
+def test_process_dbus_call():
+    method = Method()
+    # when there is no dbus adapter..
+    assert method._dbus_adapter is None
+    # we get RuntimeError
+    with pytest.raises(
+        RuntimeError,
+        match=".*cannot process dbus method call.*as it does not have a DBusAdapter",
+    ):
+        assert method.process_dbus_call(None)

--- a/tests/unit/test_core/test_mode.py
+++ b/tests/unit/test_core/test_mode.py
@@ -5,7 +5,13 @@ from testmethods import get_test_method_class
 
 from wakepy.core.dbus import DBusAdapter
 from wakepy.core.heartbeat import Heartbeat
-from wakepy.core.mode import ActivationResult, Mode, ModeController, ModeExit
+from wakepy.core.mode import (
+    ActivationResult,
+    Mode,
+    ModeController,
+    ModeExit,
+    handle_activation_fail,
+)
 
 
 def mocks_for_test_mode():
@@ -197,6 +203,11 @@ def _assert_context_manager_used_correctly(mocks, mode):
         ),
         call.controller_class().deactivate(),
     ]
+
+
+def test_handle_activation_fail_bad_on_fail_value():
+    with pytest.raises(ValueError, match="on_fail must be one of"):
+        handle_activation_fail(on_fail="foo", result=Mock(spec_set=ActivationResult))
 
 
 def test_modecontroller(monkeypatch):

--- a/tests/unit/test_core/test_mode.py
+++ b/tests/unit/test_core/test_mode.py
@@ -176,6 +176,18 @@ def test_mode_exits_with_other_exception():
     _assert_context_manager_used_correctly(mocks, mode)
 
 
+def test_exiting_before_enter():
+
+    mocks, TestMode = get_mocks_and_testmode()
+    mode = TestMode(
+        mocks.methods,
+        methods_priority=mocks.methods_priority,
+        dbus_adapter=mocks.dbus_adapter_cls,
+    )
+    with pytest.raises(RuntimeError, match="Must __enter__ before __exit__!"):
+        mode.__exit__(None, None, None)
+
+
 def _assert_context_manager_used_correctly(mocks, mode):
     assert mocks.mock_calls.copy() == [
         call.dbus_adapter_cls(),

--- a/tests/unit/test_core/test_platform.py
+++ b/tests/unit/test_core/test_platform.py
@@ -1,0 +1,24 @@
+from unittest.mock import patch
+from wakepy.core.platform import get_current_platform, PlatformName
+
+import pytest
+
+
+class TestGetCurrentPlatform:
+
+    @patch("platform.system", lambda: "Windows")
+    def test_windows(self):
+        assert get_current_platform() == PlatformName.WINDOWS
+
+    @patch("platform.system", lambda: "Darwin")
+    def test_macos(self):
+        assert get_current_platform() == PlatformName.MACOS
+
+    @patch("platform.system", lambda: "Linux")
+    def test_linux(self):
+        assert get_current_platform() == PlatformName.LINUX
+
+    @patch("platform.system", lambda: "This does not exist")
+    def test_linux(self):
+        with pytest.warns(UserWarning, match="Could not detect current platform!"):
+            assert get_current_platform() == PlatformName.OTHER

--- a/tests/unit/test_core/test_strenum.py
+++ b/tests/unit/test_core/test_strenum.py
@@ -66,3 +66,13 @@ def test_constant_uniqueness():
         ANOTHER_FOO = "fooval"
 
     assert MyConst.ANOTHER_FOO == "fooval"
+
+
+def test_keys_and_values():
+    class MyConst(StrEnum):
+        FOO = "fooval"
+        ANOTHER = "another_val"
+
+    expected = dict(FOO="fooval", ANOTHER="another_val")
+    assert MyConst.keys() == expected.keys()
+    assert list(MyConst.values()) == list(expected.values())

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -140,7 +140,7 @@ class TestMain:
             call.get_startup_text(mode=parse_arguments.return_value),
             call.print(get_startup_text.return_value),
             call.mode.__enter__(),
-            # Checking only the exception type here. The exception and the trackeback
+            # Checking only the exception type here. The exception and the traceback
             # instances are assumed to be correct. Too complicated to catch them
             # just for the test.
             call.mode.__exit__(ModeExit, *exit_call_args[1:]),

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,5 +1,6 @@
 """Tests for the __main__ CLI"""
 
+import sys
 from typing import Optional
 from unittest.mock import MagicMock, Mock, call, patch
 
@@ -188,6 +189,10 @@ class TestMain:
 def test_handle_activation_error(print_mock):
     result = ActivationResult()
     handle_activation_error(result)
-    printed_text = "\n".join(print_mock.mock_calls[0].args)
+    if sys.version_info[:2] == (3, 7):
+        # on python 3.7, need to do other way.
+        printed_text = print_mock.mock_calls[0][1][0]
+    else:
+        printed_text = "\n".join(print_mock.mock_calls[0].args)
     # Some sensible text was printed to the user
     assert "Wakepy could not activate" in printed_text

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -12,6 +12,7 @@ from wakepy.__main__ import (
     main,
     parse_arguments,
     wait_until_keyboardinterrupt,
+    handle_activation_error,
 )
 from wakepy.core import Mode
 from wakepy.core.constants import ModeName
@@ -181,3 +182,12 @@ class TestMain:
         mocks.attach_mock(get_startup_text, "get_startup_text")
         mocks.attach_mock(wait_until_keyboardinterrupt, "wait_until_keyboardinterrupt")
         return mocks
+
+
+@patch("builtins.print")
+def test_handle_activation_error(print_mock):
+    result = ActivationResult()
+    handle_activation_error(result)
+    printed_text = "\n".join(print_mock.mock_calls[0].args)
+    # Some sensible text was printed to the user
+    assert "Wakepy could not activate" in printed_text

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -128,8 +128,7 @@ class TestMain:
         )
 
         with patch("sys.argv", mocks.sysarg), patch("builtins.print", mocks.print):
-            with pytest.raises(ModeExit):
-                main()
+            main()
 
         exit_call_args = mocks.mock_calls[-1][1]
         assert mocks.mock_calls == [
@@ -166,6 +165,7 @@ class TestMain:
         mockresult.success = mode_works
         mockmode = MagicMock(spec_set=TestMode)
         mockmode.__enter__.return_value = mockmode
+        mockmode.__exit__.return_value = True
         mockmode.activation_result = mockresult
         mockmode.active = mode_works
         sysarg = ["programname", cli_arg]

--- a/wakepy/core/method.py
+++ b/wakepy/core/method.py
@@ -239,8 +239,8 @@ class Method(ABC, metaclass=MethodMeta):
         # subclass, either. Typically one would *not* override this method.
         if self._dbus_adapter is None:
             raise RuntimeError(
-                f'{self.__class__.__name__ }cannot process dbus method call "{call}" as'
-                " it does not have a DBusAdapter."
+                f'{self.__class__.__name__ } cannot process dbus method call "{call}" '
+                "as it does not have a DBusAdapter."
             )
         return self._dbus_adapter.process(call)
 

--- a/wakepy/core/method.py
+++ b/wakepy/core/method.py
@@ -134,9 +134,10 @@ class Method(ABC, metaclass=MethodMeta):
         ------
         (a) If the Method is suitable, and can be used, return True.
         (b) If the result is uncertain, return None.
-        (c) If the Method is unsuitable, you may return False or a string.
+        (c) If the Method is unsuitable, may return False or a string.
             Returning a string is recommended, as it  also explains *why* the
-            Method is unsuitable.
+            Method is unsuitable. May also simply raise an Exception, in which
+            case the Exception message is used as failure reason.
         """
 
         # Notes for subclassing

--- a/wakepy/core/mode.py
+++ b/wakepy/core/mode.py
@@ -256,6 +256,9 @@ class Mode(ABC):
         self.active = False
 
         if exception is None or isinstance(exception, ModeExit):
+            # Returning True means that the exception within the with block is
+            # swallowed. We skip only ModeExit which should simply exit the
+            # with block.
             return True
 
         # Other types of exceptions are not handled; ignoring them here and

--- a/wakepy/core/strenum.py
+++ b/wakepy/core/strenum.py
@@ -57,11 +57,11 @@ class ConstantEnumMeta(EnumMeta):
         value:
             The `val` in the example
         """
-        return value in self.__members__.values()
+        return value in self.values()
 
     @property
     def keys(self):
-        return self.__members__.keys()
+        return self.__members__.keys
 
     @property
     def values(self):

--- a/wakepy/dbus_adapters/jeepney.py
+++ b/wakepy/dbus_adapters/jeepney.py
@@ -42,6 +42,8 @@ class JeepneyDBusAdapter(DBusAdapter):
                     "environment variable. To check if you're running a session "
                     "dbus-daemon, run `ps -x | grep dbus-daemon`"
                 ) from exc
+            else:
+                raise
         reply = connection.send_and_get_reply(msg, timeout=self.timeout)
         resp = unwrap_msg(reply)
         return resp


### PR DESCRIPTION
Add some edge case tests to increase code line coverage to 100%

Extras:
1) The StrEnum.keys is now callable, just like .values()
2) Fixed minor bug in JeepneyDBusAdapter.process: If the 
open_dbus_connection  (from jeepney) would raise KeyError without text
DBUS_SESSION_BUS_ADDRESS, this would be seen wrong type of error 
(connection not defined)
3) Small docstring/comment updates and fixes
