### PR TITLE
install the requirements-docs.txt in readthedocs pipelines

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,5 +17,4 @@ python:
    install:
     - method: pip
       path: .
-      extra_requirements:
-        - doc
+    - requirements: requirements/requirements-docs.txt


### PR DESCRIPTION
The [PR 228](https://github.com/fohrloop/wakepy/pull/228) broke the readthedocs pipelines, since it tried to install with extras and not using the new requirements files.