### PR TITLE
build faster when running tox by using --no-isolation flag with `build`

### DIFF
--- a/tests/tox_build_wakepy.py
+++ b/tests/tox_build_wakepy.py
@@ -26,7 +26,7 @@ def build():
     # sdist. By running tests agains the wheel we test all, the source tree,
     # the sdist and the wheel.
     out = subprocess.run(
-        f"python -m build -o {dist_dir}", capture_output=True, shell=True
+        f"python -m build --no-isolation -o {dist_dir}", capture_output=True, shell=True
     )
     if out.stderr:
         raise RuntimeError(out.stderr.decode("utf-8"))

--- a/tox.ini
+++ b/tox.ini
@@ -59,6 +59,9 @@ commands =
 deps =
     ; The build package from PyPA. See: https://build.pypa.io/en/stable/
     build==1.1.1
+    ; The build backend required here as we build with --no-isolation flag
+    ; (which is faster). This is already an isolated environment.
+    flit_core >=3.2,<4
 commands =
     ; See also the tox_on_install in toxfile.py which is guaranteed to be
     ; called before any invocations of this command.


### PR DESCRIPTION
The wakepy sdist and wheel is created in the .pkg_external tox packaging environment. Make tox run 20% faster by not creating a separate virtual environment when building.