### PR TITLE
Sdist and wheel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 ## Manual additions
 
 .ruff_cache
-
+# Created automatically by setuptools-scm
+src/wakepy/_version.py
 #-----------------------------------------------
 # Copied from somewhere?
 #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,10 @@ wakepy = "wakepy.__main__:main"
 requires = ["setuptools>=64", "setuptools_scm>=8"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools]
+# Disable auto-discovery. See: https://github.com/pypa/setuptools/issues/3197#issuecomment-1078770109
+py-modules = []
+
 [tool.setuptools_scm]
 # Empty section just to silent warnings
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,10 +46,6 @@ wakepy = "wakepy.__main__:main"
 requires = ["setuptools>=64", "setuptools_scm>=8"]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools]
-# Disable auto-discovery. See: https://github.com/pypa/setuptools/issues/3197#issuecomment-1078770109
-py-modules = []
-
 [tool.setuptools_scm]
 # Empty section just to silent warnings
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ requires = ["setuptools>=64", "setuptools_scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
-# Empty section just to silent warnings
+version_file = "src/wakepy/_version.py"
 
 [tool.mypy]
 exclude = ['venv', '.venv']
@@ -90,7 +90,7 @@ source = [
 [tool.coverage.report]
 exclude_lines = [
     "pragma: no cover",
-    "if typing.TYPE_CHECKING:",
+    "if (?:typing\\.)?TYPE_CHECKING:",
     "@(abc\\.)?abstractmethod",
     "@(typing\\.)?overload",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,8 +43,8 @@ Homepage = "https://github.com/fohrloop/wakepy"
 wakepy = "wakepy.__main__:main"
 
 [build-system]
-requires = ["flit_core >=3.2,<4"]
-build-backend = "flit_core.buildapi"
+requires = ["setuptools>=64", "setuptools_scm>=8"]
+build-backend = "setuptools.build_meta"
 
 [tool.mypy]
 exclude = ['venv', '.venv']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,9 @@ wakepy = "wakepy.__main__:main"
 requires = ["setuptools>=64", "setuptools_scm>=8"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools_scm]
+# Empty section just to silent warnings
+
 [tool.mypy]
 exclude = ['venv', '.venv']
 check_untyped_defs = true

--- a/src/wakepy/__init__.py
+++ b/src/wakepy/__init__.py
@@ -1,5 +1,16 @@
 # NOTE The methods sub-package is imported for registering all the methods.
 from . import methods as methods
+
+try:
+    from ._version import __version__ as __version__
+    from ._version import version_tuple as version_tuple
+except ImportError:  # pragma: no cover
+    # Likely an editable install. Should ever happen if installed from a
+    # distribution package (sdist or wheel)
+    __version__ = "undefined"
+    version_tuple = (0, 0, 0, "undefined")
+
+
 from .core import ActivationError as ActivationError
 from .core import ActivationResult as ActivationResult
 from .core import DBusAdapter as DBusAdapter
@@ -7,5 +18,3 @@ from .core import Method as Method
 from .core import Mode as Mode
 from .core import ModeExit as ModeExit
 from .modes import keep as keep
-
-__version__ = "0.8.0.dev0"

--- a/tests/tox_build_wakepy.py
+++ b/tests/tox_build_wakepy.py
@@ -4,6 +4,7 @@ environment. See tox.ini for more details.
 
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 dist_dir = Path(__file__).resolve().parent.parent / "dist"
@@ -25,12 +26,17 @@ def build():
     # This creates first sdist from the source tree and then wheel from the
     # sdist. By running tests agains the wheel we test all, the source tree,
     # the sdist and the wheel.
+
     out = subprocess.run(
-        f"python -m build --no-isolation -o {dist_dir}", capture_output=True, shell=True
+        f"python -m build --no-isolation -o {dist_dir}",
+        stdout=sys.stdout,
+        stderr=sys.stderr,
+        shell=True,
     )
-    if out.stderr:
-        raise RuntimeError(out.stderr.decode("utf-8"))
-    print(out.stdout.decode("utf-8"))
+
+    if out.returncode != 0:
+        print("\n", end="")
+        raise subprocess.CalledProcessError(out.returncode, out.args)
 
 
 if __name__ == "__main__":

--- a/tox.ini
+++ b/tox.ini
@@ -62,7 +62,8 @@ deps =
     ; The build backend required here as we build with --no-isolation flag
     ; (which is faster). This is already an isolated environment.
     setuptools>=64
-    setuptools_scm>=8
+    setuptools_scm>=8; python_version>='3.8'
+    setuptools_scm<8; python_version<'3.8'
     # The last version to support Python 3.7 was wheel 0.42.0
     wheel==0.42.0
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -61,7 +61,8 @@ deps =
     build==1.1.1
     ; The build backend required here as we build with --no-isolation flag
     ; (which is faster). This is already an isolated environment.
-    flit_core >=3.2,<4
+    setuptools>=64
+    setuptools_scm>=8
 commands =
     ; See also the tox_on_install in toxfile.py which is guaranteed to be
     ; called before any invocations of this command.

--- a/tox.ini
+++ b/tox.ini
@@ -62,8 +62,7 @@ deps =
     ; The build backend required here as we build with --no-isolation flag
     ; (which is faster). This is already an isolated environment.
     setuptools>=64
-    setuptools_scm>=8; python_version>='3.8'
-    setuptools_scm<8; python_version<'3.8'
+    setuptools_scm>=8
     # The last version to support Python 3.7 was wheel 0.42.0
     wheel==0.42.0
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -63,6 +63,8 @@ deps =
     ; (which is faster). This is already an isolated environment.
     setuptools>=64
     setuptools_scm>=8
+    # The last version to support Python 3.7 was wheel 0.42.0
+    wheel==0.42.0
 commands =
     ; See also the tox_on_install in toxfile.py which is guaranteed to be
     ; called before any invocations of this command.


### PR DESCRIPTION
1) Create sdists with also docs + tests included and wheels with just the wakepy package. Sdists will contain all the repo contents that is not gitignored (using setuptools-scm). This way the sdist will always have all contents required to run tests, create documentation and create the wakepy wheel.

2) Version string & tuple
Take the version from git tags using setuptools-scm. The setuptools-scm is also responsible of creating wakepy.\_version
module from which wakepy.\_\_version\_\_ and wakepy.version\_tuple are read. Previously, the version string was defined in wakepy.\_\_init\_\_.py as variable (\_\_version\_\_).

3) Improve the build process: Now all errors are printed to stderr (tox colors these with red) and there is possibility to filter errors.

Transition from flit to setuptools. Just for setuptools-scm.
