### PR TITLE
Update actions/setup-python from v4 to 5.1

### DIFF
--- a/.github/workflows/build-and-run-tests.yml
+++ b/.github/workflows/build-and-run-tests.yml
@@ -27,7 +27,7 @@ jobs:
           git describe --tags
           git describe --tags $(git rev-list --tags --max-count=1)
       - name: Install python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d #v5.1
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: install tox
@@ -61,7 +61,7 @@ jobs:
           path: ./dist/
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d #v5.1
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -86,7 +86,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d #v5.1
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: install tox
@@ -102,7 +102,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d #v5.1
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: install tox


### PR DESCRIPTION
In addition, use commit hash to pin the version.

Removes warnings from gh actions output (see, for example: https://github.com/fohrloop/wakepy/actions/runs/8621123171)