### PR TITLE
Mypy: Set disallow_untyped_defs = true

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,7 +6,12 @@
 #
 # -- Project information -----------------------------------------------------
 
+import typing
+
 from wakepy import __version__
+
+if typing.TYPE_CHECKING:
+    from sphinx.application import Sphinx
 
 project = "wakepy"
 copyright = "2023–2024, Niko Föhr"
@@ -98,5 +103,5 @@ html_theme_options = {
 numpydoc_class_members_toctree = False
 
 
-def setup(app):
+def setup(app: Sphinx) -> None:
     app.add_js_file("wakepy.js", loading_method="defer")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,12 +65,12 @@ warn_unused_configs = true
 no_implicit_reexport = true
 
 [[tool.mypy.overrides]]
-module = 'jeepney.*'
+module = [
+    'jeepney.*',
+    'tox.*'
+]
 ignore_missing_imports = true
 
-[[tool.mypy.overrides]]
-module = 'tox.*'
-ignore_missing_imports = true
 
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ build-backend = "setuptools.build_meta"
 version_file = "src/wakepy/_version.py"
 
 [tool.mypy]
-exclude = ['venv', '.venv']
+exclude = ['venv', '.venv', 'docs']
 check_untyped_defs = true
 disallow_any_generics = true
 no_implicit_optional = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ warn_return_any = true
 warn_unreachable = true
 warn_unused_configs = true
 no_implicit_reexport = true
+disallow_untyped_defs = true
 
 [[tool.mypy.overrides]]
 module = [
@@ -70,6 +71,10 @@ module = [
     'tox.*'
 ]
 ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ['tests.*', 'tasks']
+disallow_untyped_defs = false
 
 
 

--- a/src/wakepy/__main__.py
+++ b/src/wakepy/__main__.py
@@ -42,7 +42,7 @@ WAKEPY_TICKBOXES_TEMPLATE = """
 """
 
 
-def main():
+def main() -> None:
     modename = parse_arguments(sys.argv[1:])
     mode = create_mode(modename=modename, on_fail=handle_activation_error)
     print(get_startup_text(mode=modename))
@@ -56,7 +56,7 @@ def main():
         print("\n\nExited.")
 
 
-def handle_activation_error(result: ActivationResult):
+def handle_activation_error(result: ActivationResult) -> None:
     from wakepy import __version__
 
     error_text = f"""
@@ -152,7 +152,7 @@ def get_startup_text(mode: ModeName) -> str:
     return "\n".join((wakepy_text, options_txt)) + "\n"
 
 
-def wait_until_keyboardinterrupt():
+def wait_until_keyboardinterrupt() -> None:
     spinning_chars = ["|", "/", "-", "\\"]
     try:
         for char in itertools.cycle(spinning_chars):  # pragma: no branch

--- a/src/wakepy/core/activation.py
+++ b/src/wakepy/core/activation.py
@@ -617,7 +617,11 @@ def deactivate_method(method: Method, heartbeat: Optional[Heartbeat] = None) -> 
             f"a bug report and rebooting for clearing the mode. "
         )
         try:
-            retval = method.exit_mode()  # type: ignore
+            # The Method.exit_mode() *should* always return None. However, it
+            # is not possible to control user created Methods implementation,
+            # so this is a safety net for users not having strict static type
+            # checking.
+            retval = method.exit_mode()  # type: ignore[func-returns-value]
             if retval is not None:
                 raise ValueError("exit_mode returned a value other than None!")
         except Exception as e:
@@ -824,6 +828,10 @@ def _rollback_with_exit(method: Method) -> None:
         return
 
     try:
+        # The Method.exit_mode() *should* always return None. However, it
+        # is not possible to control user created Methods implementation,
+        # so this is a safety net for users not having strict static type
+        # checking.
         exit_outcome = method.exit_mode()  # type: ignore[func-returns-value]
         if exit_outcome is not None:
             raise ValueError("exit_method did not return None")

--- a/src/wakepy/core/activation.py
+++ b/src/wakepy/core/activation.py
@@ -807,7 +807,7 @@ def _try_method_call(method: Method, mthdname: str) -> Tuple[MethodOutcome, str]
     return outcome, err_message
 
 
-def _rollback_with_exit(method):
+def _rollback_with_exit(method) -> None:
     """Roll back entering a mode by exiting it.
 
     Raises
@@ -853,7 +853,7 @@ class WakepyFakeSuccess(Method):
 
     supported_platforms = (CURRENT_PLATFORM,)
 
-    def enter_mode(self):
+    def enter_mode(self) -> None:
         """Function which says if fake success should be enabled
 
         Fake success is controlled via WAKEPY_FAKE_SUCCESS environment

--- a/src/wakepy/core/activation.py
+++ b/src/wakepy/core/activation.py
@@ -617,7 +617,7 @@ def deactivate_method(method: Method, heartbeat: Optional[Heartbeat] = None) -> 
             f"a bug report and rebooting for clearing the mode. "
         )
         try:
-            retval = method.exit_mode()
+            retval = method.exit_mode()  # type: ignore
             if retval is not None:
                 raise ValueError("exit_mode returned a value other than None!")
         except Exception as e:

--- a/src/wakepy/core/activation.py
+++ b/src/wakepy/core/activation.py
@@ -265,7 +265,7 @@ class MethodActivationResult:
 
     failure_reason: str = ""
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         error_at = " @" + self.failure_stage if self.failure_stage else ""
         failure_reason = f', "{self.failure_reason}"' if self.success is False else ""
         success_str = (
@@ -807,7 +807,7 @@ def _try_method_call(method: Method, mthdname: str) -> Tuple[MethodOutcome, str]
     return outcome, err_message
 
 
-def _rollback_with_exit(method) -> None:
+def _rollback_with_exit(method: Method) -> None:
     """Roll back entering a mode by exiting it.
 
     Raises
@@ -824,7 +824,7 @@ def _rollback_with_exit(method) -> None:
         return
 
     try:
-        exit_outcome = method.exit_mode()
+        exit_outcome = method.exit_mode()  # type: ignore[func-returns-value]
         if exit_outcome is not None:
             raise ValueError("exit_method did not return None")
     except Exception as exc:

--- a/src/wakepy/core/dbus.py
+++ b/src/wakepy/core/dbus.py
@@ -277,7 +277,7 @@ class DBusAdapter:
     Exception will be omitted if using the high-level API of wakepy.
     """
 
-    def process(self, call: DBusMethodCall):
+    def process(self, call: DBusMethodCall) -> object:
         """Processes a :class:`~wakepy.core.DBusMethodCall`.
 
         Parameters

--- a/src/wakepy/core/dbus.py
+++ b/src/wakepy/core/dbus.py
@@ -231,7 +231,7 @@ class DBusMethodCall:
         assert isinstance(args, dict), "args may only be tuple, list or dict"
         return self.__dict_args_as_tuple(args, method)
 
-    def __check_args_length(self, args: Tuple[Any, ...], method: DBusMethod):
+    def __check_args_length(self, args: Tuple[Any, ...], method: DBusMethod) -> None:
         if method.params is None:
             # not possible to check.
             return

--- a/src/wakepy/core/method.py
+++ b/src/wakepy/core/method.py
@@ -126,7 +126,7 @@ class Method(ABC, metaclass=MethodMeta):
         # only on methods using D-Bus.
         self._dbus_adapter = dbus_adapter
 
-    def __init_subclass__(cls, **kwargs) -> None:
+    def __init_subclass__(cls, **kwargs: object) -> None:
         """These are automatically added. They tell if the `enter_mode`,
         `exit_mode` and `heartbeat` methods are implemented in the Method
         subclass. (should not to touch these manually)"""

--- a/src/wakepy/core/method.py
+++ b/src/wakepy/core/method.py
@@ -172,7 +172,7 @@ class Method(ABC, metaclass=MethodMeta):
         #   could test that it exist on PATH. (and that the version is
         #   suitable)
 
-    def enter_mode(self):
+    def enter_mode(self) -> None:
         """Enter to a Mode using this Method. Pair with a `exit_mode`.
 
         Returns
@@ -202,7 +202,7 @@ class Method(ABC, metaclass=MethodMeta):
         #
         return
 
-    def exit_mode(self):
+    def exit_mode(self) -> None:
         """Exit from a Mode using this Method. Paired with `enter_mode`
 
         Returns
@@ -232,7 +232,7 @@ class Method(ABC, metaclass=MethodMeta):
     `heartbeat()`.
     """
 
-    def heartbeat(self):
+    def heartbeat(self) -> None:
         """Called periodically, every `heartbeat_period` seconds.
 
         Returns
@@ -270,14 +270,14 @@ class Method(ABC, metaclass=MethodMeta):
     def has_heartbeat(self) -> bool:
         return self._has_heartbeat
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"<wakepy Method: {self.__class__.__name__}>"
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<wakepy Method: {self.__class__.__name__} at {hex(id(self))}>"
 
     @classmethod
-    def _is_unnamed(cls):
+    def _is_unnamed(cls) -> bool:
         return cls.name == unnamed
 
 

--- a/src/wakepy/core/mode.py
+++ b/src/wakepy/core/mode.py
@@ -306,7 +306,7 @@ def create_mode(
     return Mode(name=modename, methods=selected_methods, **kwargs)
 
 
-def handle_activation_fail(on_fail: OnFail, result: ActivationResult):
+def handle_activation_fail(on_fail: OnFail, result: ActivationResult) -> None:
     if on_fail == "pass":
         return
     elif on_fail == "warn" or on_fail == "error":

--- a/src/wakepy/core/registry.py
+++ b/src/wakepy/core/registry.py
@@ -53,7 +53,7 @@ class MethodRegistryError(RuntimeError):
     """Any error which is related to the method registry"""
 
 
-def register_method(method_class: Type[Method]):
+def register_method(method_class: Type[Method]) -> None:
     """Registers a subclass of Method to the method registry"""
 
     if method_class._is_unnamed():

--- a/src/wakepy/core/strenum.py
+++ b/src/wakepy/core/strenum.py
@@ -11,7 +11,7 @@ from enum import Enum, EnumMeta, auto
 
 if typing.TYPE_CHECKING:
     from enum import _EnumDict
-    from typing import Any, Dict, Tuple, Type, ValuesView
+    from typing import Any, Callable, Dict, KeysView, Tuple, Type, ValuesView
 
 
 class StrEnumMeta(EnumMeta):
@@ -49,7 +49,7 @@ class StrEnumMeta(EnumMeta):
 
         return super().__new__(metacls, clsname, bases, classdict)
 
-    def __init__(cls, *_, unique=False):
+    def __init__(cls, *_: Tuple[object, ...], unique: bool = False) -> None:
         if unique:
             cls._check_uniqueness()
 
@@ -73,11 +73,11 @@ class StrEnumMeta(EnumMeta):
         return value in cls.values()
 
     @property
-    def keys(cls):
+    def keys(cls) -> Callable[[], KeysView[str]]:
         return cls.__members__.keys
 
     @property
-    def values(cls):
+    def values(cls) -> Callable[[], ValuesView[str]]:
         return cls.__members__.values
 
 
@@ -121,7 +121,9 @@ class StrEnum(str, Enum, metaclass=StrEnumMeta):
     """
 
     @staticmethod
-    def _generate_next_value_(name: str, *_) -> str:
+    def _generate_next_value_(
+        name: str, start: int, count: int, last_values: list[Any]
+    ) -> str:
         """Turn auto() value to be a string corresponding to the enumeration
         member name
 

--- a/src/wakepy/core/strenum.py
+++ b/src/wakepy/core/strenum.py
@@ -22,11 +22,20 @@ class StrEnumMeta(EnumMeta):
     2) `unique` parameter when creating constants.
     """
 
+    # The __prepare__ function signature has some problems in mypy 1.9.0
+    # CPython 3.10.12. It says that `Signature of "__prepare__" incompatible
+    # with supertype X` where X is "EnumMeta" or "type". Could not find a
+    # function signature which would be okay with both the EnumMeta and type
+    # superclasses so just ignoring the error.
     @classmethod
-    def __prepare__(metacls, clsname, bases, **_):
+    def __prepare__(  # type: ignore[override]
+        metacls: Type[StrEnumMeta],
+        clsname: str,
+        bases: Tuple[type, ...],
+        **_: Any,
+    ) -> _EnumDict:
         # This is needed since we have to allow passing kwargs to __init__
         # Needed on 3.7.x, not needed on 3.10. (not tested 3.8 & 3.9)
-
         return super().__prepare__(clsname, bases)
 
     def __new__(

--- a/src/wakepy/core/strenum.py
+++ b/src/wakepy/core/strenum.py
@@ -6,8 +6,12 @@ supported."""
 
 from __future__ import annotations
 
+import typing
 from enum import Enum, EnumMeta, auto
-from typing import Any, ValuesView
+
+if typing.TYPE_CHECKING:
+    from enum import _EnumDict
+    from typing import Any, Dict, Tuple, Type, ValuesView
 
 
 class StrEnumMeta(EnumMeta):
@@ -22,10 +26,18 @@ class StrEnumMeta(EnumMeta):
     def __prepare__(metacls, clsname, bases, **_):
         # This is needed since we have to allow passing kwargs to __init__
         # Needed on 3.7.x, not needed on 3.10. (not tested 3.8 & 3.9)
+
         return super().__prepare__(clsname, bases)
 
-    def __new__(metacls, clsname, bases, classdict, **_):
+    def __new__(
+        metacls: Type[StrEnumMeta],
+        clsname: str,
+        bases: Tuple[Type[object], ...],
+        classdict: _EnumDict,
+        **_: Dict[str, object],
+    ) -> StrEnumMeta:
         # This is needed since we have to allow passing kwargs to __init__
+
         return super().__new__(metacls, clsname, bases, classdict)
 
     def __init__(cls, *_, unique=False):

--- a/src/wakepy/core/strenum.py
+++ b/src/wakepy/core/strenum.py
@@ -32,7 +32,7 @@ class StrEnumMeta(EnumMeta):
         if unique:
             cls._check_uniqueness()
 
-    def _check_uniqueness(cls):
+    def _check_uniqueness(cls) -> None:
         vals: ValuesView[Enum] = cls.__members__.values()
         if len(vals) > len(set(vals)):
             raise ValueError("The values must be unique!")

--- a/src/wakepy/dbus_adapters/jeepney.py
+++ b/src/wakepy/dbus_adapters/jeepney.py
@@ -17,7 +17,7 @@ class JeepneyDBusAdapter(DBusAdapter):
     # timeout for dbus calls, in seconds
     timeout = 2
 
-    def process(self, call: DBusMethodCall):
+    def process(self, call: DBusMethodCall) -> object:
         addr = DBusAddress(
             object_path=call.method.path,
             bus_name=call.method.service,

--- a/src/wakepy/methods/freedesktop.py
+++ b/src/wakepy/methods/freedesktop.py
@@ -1,6 +1,8 @@
 """The Freedesktop.org related methods"""
 
-from typing import Optional
+from __future__ import annotations
+
+import typing
 
 from wakepy.core import (
     BusType,
@@ -11,6 +13,9 @@ from wakepy.core import (
     ModeName,
     PlatformName,
 )
+
+if typing.TYPE_CHECKING:
+    from typing import Optional
 
 
 class FreedesktopScreenSaverInhibit(Method):
@@ -45,11 +50,11 @@ class FreedesktopScreenSaverInhibit(Method):
 
     supported_platforms = (PlatformName.LINUX,)
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: object, **kwargs: object) -> None:
         super().__init__(*args, **kwargs)
         self.inhibit_cookie: Optional[int] = None
 
-    def enter_mode(self):
+    def enter_mode(self) -> None:
         call = DBusMethodCall(
             method=self.method_inhibit,
             args=dict(
@@ -65,7 +70,7 @@ class FreedesktopScreenSaverInhibit(Method):
             )
         self.inhibit_cookie = retval[0]
 
-    def exit_mode(self):
+    def exit_mode(self) -> None:
         if self.inhibit_cookie is None:
             # Nothing to exit from.
             return

--- a/src/wakepy/methods/freedesktop.py
+++ b/src/wakepy/methods/freedesktop.py
@@ -17,6 +17,8 @@ from wakepy.core import (
 if typing.TYPE_CHECKING:
     from typing import Optional
 
+    from wakepy.core import DBusAdapter
+
 
 class FreedesktopScreenSaverInhibit(Method):
     """Method using org.freedesktop.ScreenSaver D-Bus API
@@ -50,8 +52,8 @@ class FreedesktopScreenSaverInhibit(Method):
 
     supported_platforms = (PlatformName.LINUX,)
 
-    def __init__(self, *args: object, **kwargs: object) -> None:
-        super().__init__(*args, **kwargs)
+    def __init__(self, dbus_adapter: Optional[DBusAdapter] = None) -> None:
+        super().__init__(dbus_adapter=dbus_adapter)
         self.inhibit_cookie: Optional[int] = None
 
     def enter_mode(self) -> None:

--- a/src/wakepy/methods/gnome.py
+++ b/src/wakepy/methods/gnome.py
@@ -57,11 +57,11 @@ class _GnomeSessionManager(Method, ABC):
     @abstractmethod
     def flags(self) -> GnomeFlag: ...
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.inhibit_cookie: Optional[int] = None
 
-    def enter_mode(self):
+    def enter_mode(self) -> None:
         call = DBusMethodCall(
             method=self.method_inhibit,
             args=dict(
@@ -79,7 +79,7 @@ class _GnomeSessionManager(Method, ABC):
             )
         self.inhibit_cookie = retval[0]
 
-    def exit_mode(self):
+    def exit_mode(self) -> None:
         if self.inhibit_cookie is None:
             # Nothing to exit from.
             return

--- a/src/wakepy/methods/gnome.py
+++ b/src/wakepy/methods/gnome.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import enum
+import typing
 from abc import ABC, abstractmethod
-from typing import Optional
 
 from wakepy.core import (
     BusType,
@@ -11,6 +13,11 @@ from wakepy.core import (
     ModeName,
     PlatformName,
 )
+
+if typing.TYPE_CHECKING:
+    from typing import Optional
+
+    from wakepy.core import DBusAdapter
 
 
 class GnomeFlag(enum.IntFlag):
@@ -57,8 +64,8 @@ class _GnomeSessionManager(Method, ABC):
     @abstractmethod
     def flags(self) -> GnomeFlag: ...
 
-    def __init__(self, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
+    def __init__(self, dbus_adapter: Optional[DBusAdapter] = None) -> None:
+        super().__init__(dbus_adapter=dbus_adapter)
         self.inhibit_cookie: Optional[int] = None
 
     def enter_mode(self) -> None:

--- a/src/wakepy/methods/macos.py
+++ b/src/wakepy/methods/macos.py
@@ -10,6 +10,8 @@ from wakepy.core import Method, ModeName, PlatformName
 if typing.TYPE_CHECKING:
     from typing import Optional
 
+    from wakepy.core import DBusAdapter
+
 
 class _MacCaffeinate(Method, ABC):
     """This is a method which calls the `caffeinate` command.
@@ -20,8 +22,8 @@ class _MacCaffeinate(Method, ABC):
 
     supported_platforms = (PlatformName.MACOS,)
 
-    def __init__(self, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
+    def __init__(self, dbus_adapter: Optional[DBusAdapter] = None) -> None:
+        super().__init__(dbus_adapter=dbus_adapter)
         self.logger = logging.getLogger(__name__)
         self._process: Optional[Popen[bytes]] = None
 

--- a/src/wakepy/methods/macos.py
+++ b/src/wakepy/methods/macos.py
@@ -20,16 +20,16 @@ class _MacCaffeinate(Method, ABC):
 
     supported_platforms = (PlatformName.MACOS,)
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.logger = logging.getLogger(__name__)
         self._process: Optional[Popen[bytes]] = None
 
-    def enter_mode(self):
+    def enter_mode(self) -> None:
         self.logger.debug('Running "%s"', self.command)
         self._process = Popen(self.command.split(), stdin=PIPE, stdout=PIPE)
 
-    def exit_mode(self):
+    def exit_mode(self) -> None:
         if self._process is None:
             self.logger.debug("No need to terminate process (not started)")
             return

--- a/src/wakepy/methods/windows.py
+++ b/src/wakepy/methods/windows.py
@@ -28,15 +28,15 @@ class WindowsSetThreadExecutionState(Method, ABC):
     # Server 2003 and above (server)
     supported_platforms = (PlatformName.WINDOWS,)
 
-    def enter_mode(self):
+    def enter_mode(self) -> None:
         # Sets the flags until Flags.RELEASE is used or until the thread
         # which called this dies.
         self._call_set_thread_execution_state(self.flags.value)
 
-    def exit_mode(self):
+    def exit_mode(self) -> None:
         self._call_set_thread_execution_state(Flags.RELEASE.value)
 
-    def _call_set_thread_execution_state(self, flags: int):
+    def _call_set_thread_execution_state(self, flags: int) -> None:
         try:
             ctypes.windll.kernel32.SetThreadExecutionState(flags)  # type:ignore
         except AttributeError as exc:

--- a/tests/unit/test_core/test_activation/test_activation.py
+++ b/tests/unit/test_core/test_activation/test_activation.py
@@ -622,7 +622,7 @@ def test_wakepy_fake_success_truthy_values(val, monkeypatch):
     method = WakepyFakeSuccess()
 
     with wakepy_fake_value_set(monkeypatch, val):
-        assert method.enter_mode() is None
+        assert method.enter_mode() is None  # type: ignore
 
 
 def test_wakepy_fake_success_without_the_env_var_set(monkeypatch):

--- a/tests/unit/test_core/test_activation/test_activation.py
+++ b/tests/unit/test_core/test_activation/test_activation.py
@@ -622,7 +622,7 @@ def test_wakepy_fake_success_truthy_values(val, monkeypatch):
     method = WakepyFakeSuccess()
 
     with wakepy_fake_value_set(monkeypatch, val):
-        assert method.enter_mode() is None  # type: ignore
+        assert method.enter_mode() is None  # type: ignore[func-returns-value]
 
 
 def test_wakepy_fake_success_without_the_env_var_set(monkeypatch):

--- a/tests/unit/test_core/test_method.py
+++ b/tests/unit/test_core/test_method.py
@@ -170,9 +170,9 @@ def test_select_methods():
 def test_method_defaults():
     """tests the Method enter_mode, exit_mode and heartbeat defaults"""
     m = Method()
-    assert m.enter_mode() is None
-    assert m.heartbeat() is None
-    assert m.exit_mode() is None
+    assert m.enter_mode() is None  # type: ignore
+    assert m.heartbeat() is None  # type: ignore
+    assert m.exit_mode() is None  # type: ignore
 
 
 @pytest.mark.usefixtures("provide_methods_a_f")

--- a/tests/unit/test_methods/test_freedesktop.py
+++ b/tests/unit/test_methods/test_freedesktop.py
@@ -46,7 +46,7 @@ def test_screensaver_enter_mode():
     assert method.inhibit_cookie is None
 
     # Act
-    enter_retval = method.enter_mode()
+    enter_retval = method.enter_mode()  # type: ignore
 
     # Assert
     assert enter_retval is None
@@ -71,7 +71,7 @@ def test_screensaver_exit_mode():
     method.inhibit_cookie = fake_cookie
 
     # Act
-    exit_retval = method.exit_mode()
+    exit_retval = method.exit_mode()  # type: ignore
 
     # Assert
     assert exit_retval is None
@@ -82,7 +82,7 @@ def test_screensaver_exit_mode():
 def test_screensaver_exit_before_enter():
     method = FreedesktopScreenSaverInhibit(dbus_adapter=DBusAdapter())
     assert method.inhibit_cookie is None
-    assert method.exit_mode() is None
+    assert method.exit_mode() is None  # type: ignore
 
 
 def test_with_dbus_adapter_which_returns_none():
@@ -98,4 +98,4 @@ def test_with_dbus_adapter_which_returns_none():
             "Could not get inhibit cookie from org.freedesktop.ScreenSaver"
         ),
     ):
-        assert method.enter_mode() is False
+        assert method.enter_mode() is False  # type: ignore

--- a/tests/unit/test_methods/test_freedesktop.py
+++ b/tests/unit/test_methods/test_freedesktop.py
@@ -46,7 +46,7 @@ def test_screensaver_enter_mode():
     assert method.inhibit_cookie is None
 
     # Act
-    enter_retval = method.enter_mode()  # type: ignore
+    enter_retval = method.enter_mode()  # type: ignore[func-returns-value]
 
     # Assert
     assert enter_retval is None
@@ -71,7 +71,7 @@ def test_screensaver_exit_mode():
     method.inhibit_cookie = fake_cookie
 
     # Act
-    exit_retval = method.exit_mode()  # type: ignore
+    exit_retval = method.exit_mode()  # type: ignore[func-returns-value]
 
     # Assert
     assert exit_retval is None
@@ -82,7 +82,7 @@ def test_screensaver_exit_mode():
 def test_screensaver_exit_before_enter():
     method = FreedesktopScreenSaverInhibit(dbus_adapter=DBusAdapter())
     assert method.inhibit_cookie is None
-    assert method.exit_mode() is None  # type: ignore
+    assert method.exit_mode() is None  # type: ignore[func-returns-value]
 
 
 def test_with_dbus_adapter_which_returns_none():
@@ -98,4 +98,4 @@ def test_with_dbus_adapter_which_returns_none():
             "Could not get inhibit cookie from org.freedesktop.ScreenSaver"
         ),
     ):
-        assert method.enter_mode() is False  # type: ignore
+        assert method.enter_mode() is False  # type: ignore[func-returns-value]

--- a/toxfile.py
+++ b/toxfile.py
@@ -18,7 +18,7 @@ tox_asks_rebuild = dist_dir / ".TOX-ASKS-REBUILD"
 
 
 @impl
-def tox_on_install(tox_env: ToxEnv, arguments: Any, section: str, of_type: str):
+def tox_on_install(tox_env: ToxEnv, arguments: Any, section: str, of_type: str) -> None:
     """Make it possible to have tox packaging environment for setting
     "package=external" (.pkg_external) which builds the wheel *only once*, or
     zero times if --skip-build command line argument is given.
@@ -60,7 +60,7 @@ def tox_on_install(tox_env: ToxEnv, arguments: Any, section: str, of_type: str):
 
 
 @impl
-def tox_add_option(parser: ToxParser):
+def tox_add_option(parser: ToxParser) -> None:
     """Adds custom option, --skip-build to the tox command."""
     parser.add_argument(
         "--skip-build",


### PR DESCRIPTION
Set `disallow_untyped_defs = true`. This is a bit stricter policy than before. 

* Disallows defining functions without type annotations or with incomplete type annotations 
* Also disallows mismatched function signatures; if a method is defined def foo(self, a=1), 
  if is not possible to use it in subclass as super().foo(*args, **kwargs). This discourages
  the usage of *args, **kwargs in places where they're not really needed.
  
See: https://mypy.readthedocs.io/en/stable/config_file.html#confval-disallow_untyped_defs