### PR TITLE
Add stricter mypy rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ warn_unreachable = true
 warn_unused_configs = true
 no_implicit_reexport = true
 disallow_untyped_defs = true
+disallow_any_unimported = true
 
 [[tool.mypy.overrides]]
 module = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ warn_redundant_casts = true
 warn_return_any = true
 warn_unreachable = true
 warn_unused_configs = true
+warn_unused_ignores = true
 no_implicit_reexport = true
 disallow_untyped_defs = true
 disallow_any_unimported = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ build-backend = "setuptools.build_meta"
 version_file = "src/wakepy/_version.py"
 
 [tool.mypy]
-exclude = ['venv', '.venv', 'docs', '.tox']
+exclude = ['venv/*', '.venv/*', 'docs/*', '.tox/*']
 check_untyped_defs = true
 disallow_any_generics = true
 no_implicit_optional = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,9 @@ ignore_missing_imports = true
 module = ['tests.*', 'tasks']
 disallow_untyped_defs = false
 
-
+[[tool.mypy.overrides]]
+module = ['toxfile']
+disallow_any_unimported = false
 
 [tool.pytest.ini_options]
 filterwarnings = "ignore:.*is deprecated in wakepy 0.7.0 and will be removed in a future version of wakepy.*:DeprecationWarning"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ build-backend = "setuptools.build_meta"
 version_file = "src/wakepy/_version.py"
 
 [tool.mypy]
-exclude = ['venv', '.venv', 'docs']
+exclude = ['venv', '.venv', 'docs', '.tox']
 check_untyped_defs = true
 disallow_any_generics = true
 no_implicit_optional = true

--- a/src/wakepy/__init__.py
+++ b/src/wakepy/__init__.py
@@ -2,8 +2,8 @@
 from . import methods as methods
 
 try:
-    from ._version import __version__ as __version__  # type:ignore
-    from ._version import version_tuple as version_tuple  # type:ignore
+    from ._version import __version__ as __version__
+    from ._version import version_tuple as version_tuple
 except ImportError:  # pragma: no cover
     # Likely an editable install. Should ever happen if installed from a
     # distribution package (sdist or wheel)

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,6 @@ commands =
 [testenv:check]
 description = Check the code
 deps = -r{toxinidir}/requirements/requirements-check.txt
-skip_install = true
 commands =
     python -m isort . --check --diff
     python -m black . --check


### PR DESCRIPTION
Add stricter mypy rules

New rules
---------
disallow_any_unimported = true
warn_unused_ignores = true

exclude folders better
----------------------
exclude folders from mypy a bit better (mypy has to do less unnecessary
work)

Build when running tox -e check
-------------------------------
Also removed the skip_intall=True in tox 'check' environment. (this made
things easier as wakepy.__init__ requires wakepy._version to be present
which is created in a build step, which is only done if skip_install is
not True, and if the wakepy._version is not available, mypy would complain
about it. And if we ignore the import line, mypy will next complain about
unused ignores (when the wakepy._version file is present).