### PR TITLE
Improve docs CSS style: colors of links, code blocks, inline code

### DIFF
--- a/docs/source/_static/wakepy-docs.css
+++ b/docs/source/_static/wakepy-docs.css
@@ -28,3 +28,24 @@ a:link, a:visited {
 a:hover, a:active {
     text-decoration: underline !important;
 }
+
+
+a:link > code > span.pre,
+a:visited > code > span.pre {
+    /* Use the same link color in code links as in "normal links" */
+    color: var(--pst-color-link) !important;
+}
+
+a:active  > code > span.pre,
+a:hover > code > span.pre {
+    /* Use the same link color in code links as in "normal links" */
+    color:var(--pst-color-link-hover) !important;
+}
+
+/* inline code */
+code.literal  {
+    /* Remove the gray box around inline code */
+    background-color: rgba(255, 255, 255, 0) !important;
+    padding: 0 !important;
+    border: 0 !important;
+}

--- a/docs/source/_static/wakepy-docs.css
+++ b/docs/source/_static/wakepy-docs.css
@@ -1,0 +1,21 @@
+
+html[data-theme=light] {
+    /* the contents directive */
+    --wakepy-color-contents-bg: #f9f9fb;
+    --wakepy-color-contents-border: #eff0f0;
+}
+
+
+html[data-theme=dark] {
+    /* for explanations, refer to the light theme definitions */
+    --wakepy-color-contents-bg: #191825;
+    --wakepy-color-contents-border: #293342;
+}
+
+nav.contents  {
+    /* For the "contents" directive block */
+    background: var(--wakepy-color-contents-bg) !important;
+    border-color: var(--wakepy-color-contents-border) !important;
+    box-shadow: none !important;
+}
+

--- a/docs/source/_static/wakepy-docs.css
+++ b/docs/source/_static/wakepy-docs.css
@@ -19,3 +19,9 @@ nav.contents  {
     box-shadow: none !important;
 }
 
+a:link, a:visited {
+    text-decoration: none !important;
+}
+a:hover, a:active {
+    text-decoration: underline !important;
+}

--- a/docs/source/_static/wakepy-docs.css
+++ b/docs/source/_static/wakepy-docs.css
@@ -6,6 +6,7 @@ html[data-theme=light] {
     /* the contents directive */
     --wakepy-color-contents-bg: #f9f9fb;
     --wakepy-color-contents-border: #eff0f0;
+    --wakepy-color-inline-code: #d1157f;
 }
 
 
@@ -13,6 +14,7 @@ html[data-theme=dark] {
     /* for explanations, refer to the light theme definitions */
     --wakepy-color-contents-bg: #191825;
     --wakepy-color-contents-border: #293342;
+    --wakepy-color-inline-code:#f35eaa;
 }
 
 nav.contents  {
@@ -30,20 +32,27 @@ a:hover, a:active {
 }
 
 
+/* inline code (both, the links and normal text)*/
+code > span.pre,
+span.sig-name > span.pre {
+    color: var(--wakepy-color-inline-code) !important;
+}
+
+/* inline code, but just the links*/
 a:link > code > span.pre,
 a:visited > code > span.pre {
     /* Use the same link color in code links as in "normal links" */
     color: var(--pst-color-link) !important;
 }
-
 a:active  > code > span.pre,
 a:hover > code > span.pre {
     /* Use the same link color in code links as in "normal links" */
     color:var(--pst-color-link-hover) !important;
 }
 
+
 /* inline code */
-code.literal  {
+code.literal {
     /* Remove the gray box around inline code */
     background-color: rgba(255, 255, 255, 0) !important;
     padding: 0 !important;

--- a/docs/source/_static/wakepy-docs.css
+++ b/docs/source/_static/wakepy-docs.css
@@ -1,3 +1,6 @@
+/* Some variables available from the Pydata Sphinx Theme.
+See: https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/styling.html */
+
 
 html[data-theme=light] {
     /* the contents directive */

--- a/docs/source/_static/wakepy-docs.css
+++ b/docs/source/_static/wakepy-docs.css
@@ -7,6 +7,8 @@ html[data-theme=light] {
     --wakepy-color-contents-bg: #f9f9fb;
     --wakepy-color-contents-border: #eff0f0;
     --wakepy-color-inline-code: #d1157f;
+    --wakepy-color-code-block-bg: #fcfcfd;
+    --wakepy-color-code-block-border: #d1d5da;
 }
 
 
@@ -15,6 +17,8 @@ html[data-theme=dark] {
     --wakepy-color-contents-bg: #191825;
     --wakepy-color-contents-border: #293342;
     --wakepy-color-inline-code:#f35eaa;
+    --wakepy-color-code-block-bg: #272822;
+    --wakepy-color-code-block-border: #3c3d2e;
 }
 
 nav.contents  {
@@ -57,4 +61,13 @@ code.literal {
     background-color: rgba(255, 255, 255, 0) !important;
     padding: 0 !important;
     border: 0 !important;
+}
+
+
+/* code blocks */
+div.highlight > pre {
+    background-color: var(--wakepy-color-code-block-bg) !important;
+    border-color: var(--wakepy-color-code-block-border) !important;
+    /* Add bit more air to the code blocks */
+    line-height: 155% !important;
 }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -77,6 +77,7 @@ templates_path = ["_templates"]
 exclude_patterns: list[str] = []
 
 html_static_path = ["_static"]
+html_css_files = ["wakepy-docs.css"]
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/source/methods-reference.md
+++ b/docs/source/methods-reference.md
@@ -5,7 +5,7 @@
 **What are wakepy Methods?**
 Methods are different ways of entering/keeping in a Mode. A Method may support one or more platforms, and may have one or more requirements for software it should be able to talk to or execute. For example, on Linux. using the Inhibit method of the [org.gnome.SessionManager](#keep-running-org-gnome-sessionmanager) D-Bus service is one way of entering  the [`keep.running`](#keep-running-section) mode, and it required D-Bus and (a certain version of) GNOME. The following methods exist:
 
-
+<!-- using the contents directive https://myst-parser.readthedocs.io/en/latest/syntax/organising_content.html -->
 ```{contents}
 :local: True
 :depth: 2


### PR DESCRIPTION
code blocks
* lighter background for code blocks in light theme
* browner border for code blocks in dark theme (was bluish)
    
inline code (non-links)
* remove the gray box around the text
* change the color to be fucsia
   
code' links styling
* same color as other links (blue, was turqoise)
* Remove the gray box around them
* Now inline code links are just like regular links, but
  monospace + bold.

all links
* remove underlining