### PR TITLE
build wakepy in readthedocs server

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -23,4 +23,3 @@ build:
 
 sphinx:
    configuration: docs/source/conf.py
-

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,17 +4,23 @@
 
 version: 2
 
-build:
-  os: ubuntu-22.04
-  tools:
-    python: "3.10"
-
-sphinx:
-   configuration: docs/source/conf.py
-
-
 python:
    install:
     - method: pip
       path: .
     - requirements: requirements/requirements-docs.txt
+  jobs:
+    build_wakepy:
+      #  Need to create the wakepy._version module (setuptools-scm)
+      - python -m build
+
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+
+
+sphinx:
+   configuration: docs/source/conf.py
+

--- a/requirements/requirements-docs.txt
+++ b/requirements/requirements-docs.txt
@@ -7,3 +7,5 @@ sphinx-book-theme==1.1.2
 # a numpydoc 1.7.0rc0.dev0. This one has https://github.com/numpy/numpydoc/pull/527 merged
 # At some point: Can use 1.7.0 (which is not available in PyPI at the time of writing)
 numpydoc @ git+https://github.com/numpy/numpydoc.git@46f532a824639a97479039fc122533915cdfa10f
+# Need to build in order to get the _version.py
+build==1.1.1


### PR DESCRIPTION
Aims to fix the missing version number in readthedocs. 

The version of wakepy is currently created by setuptools-scm in the build
step. This creates a wakepy._version module. Currently, that is not available
in the readthedocs server as that file is (and should not) be version
controlled.