### PR TITLE
fix a syntax error in readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,7 +5,7 @@
 version: 2
 
 python:
-   install:
+  install:
     - method: pip
       path: .
     - requirements: requirements/requirements-docs.txt


### PR DESCRIPTION
extra space causing build to fail:

![image](https://github.com/fohrloop/wakepy/assets/17479683/fb44b7b3-c1ef-494b-a73f-83acd72ce422)
