### PR TITLE
move jobs to build.jobs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,16 +9,15 @@ python:
     - method: pip
       path: .
     - requirements: requirements/requirements-docs.txt
-  jobs:
-    build_wakepy:
-      #  Need to create the wakepy._version module (setuptools-scm)
-      - python -m build
-
 
 build:
   os: ubuntu-22.04
   tools:
     python: "3.10"
+  jobs:
+    pre_build:
+      #  Need to create the wakepy._version module (setuptools-scm)
+      - python -m build
 
 
 sphinx:


### PR DESCRIPTION
also: renamed the job to pre_build.

Related: 
* https://github.com/fohrloop/wakepy/pull/245
* https://github.com/fohrloop/wakepy/pull/246
