### PR TITLE
Method init signature: **kwargs instead of dbus_adapter

### DIFF
--- a/src/wakepy/core/method.py
+++ b/src/wakepy/core/method.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import sys
 import typing
 from abc import ABC
-from typing import Any, List, Optional, Set, Tuple, Type, TypeVar, Union
+from typing import Any, List, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
 from .constants import ModeName, PlatformName
 from .registry import register_method
@@ -124,7 +124,7 @@ class Method(ABC):
     def __init__(self, **kwargs: object) -> None:
         # The dbus-adapter may be used to process dbus calls. This is relevant
         # only on methods using D-Bus.
-        self.dbus_adapter: DBusAdapter | None = kwargs.pop("dbus_adapter", None)
+        self.dbus_adapter = cast("DBusAdapter | None", kwargs.pop("dbus_adapter", None))
         self.method_kwargs = kwargs
 
     def __init_subclass__(cls, **kwargs: object) -> None:

--- a/src/wakepy/core/method.py
+++ b/src/wakepy/core/method.py
@@ -17,27 +17,29 @@ from __future__ import annotations
 import sys
 import typing
 from abc import ABC
-from typing import Any, List, Optional, Set, Tuple, Type, TypeVar, Union, cast
+from typing import cast
 
-from .constants import ModeName, PlatformName
 from .registry import register_method
 from .strenum import StrEnum, auto
-
-if typing.TYPE_CHECKING:
-    from typing import Dict
-
-    from wakepy.core import DBusAdapter, DBusMethodCall
 
 if sys.version_info < (3, 8):  # pragma: no-cover-if-py-gte-38
     from typing_extensions import Literal
 else:  # pragma: no-cover-if-py-lt-38
     from typing import Literal
 
-MethodCls = Type["Method"]
-T = TypeVar("T")
-Collection = Union[List[T], Tuple[T, ...], Set[T]]
-MethodClsCollection = Collection[MethodCls]
-StrCollection = Collection[str]
+
+if typing.TYPE_CHECKING:
+    from typing import Any, Dict, List, Optional, Set, Tuple, Type, TypeVar, Union
+
+    from wakepy.core import DBusAdapter, DBusMethodCall
+
+    from .constants import ModeName, PlatformName
+
+    MethodCls = Type["Method"]
+    T = TypeVar("T")
+    Collection = Union[List[T], Tuple[T, ...], Set[T]]
+    MethodClsCollection = Collection[MethodCls]
+    StrCollection = Collection[str]
 
 
 class MethodError(RuntimeError):

--- a/src/wakepy/core/method.py
+++ b/src/wakepy/core/method.py
@@ -29,7 +29,7 @@ else:  # pragma: no-cover-if-py-lt-38
 
 
 if typing.TYPE_CHECKING:
-    from typing import Any, Dict, List, Optional, Set, Tuple, Type, TypeVar, Union
+    from typing import Any, List, Optional, Set, Tuple, Type, TypeVar, Union
 
     from wakepy.core import DBusAdapter, DBusMethodCall
 
@@ -111,7 +111,8 @@ class Method(ABC):
     the Method should not be listed anywhere (e.g. when Method is meant to be
     subclassed)."""
 
-    method_kwargs: Dict[str, object]
+    # waits for https://github.com/fohrloop/wakepy/issues/256
+    # method_kwargs: Dict[str, object]
     """The method arguments. This is created from two parts
 
     1) The common_method_kwargs (if any)
@@ -127,7 +128,9 @@ class Method(ABC):
         # The dbus-adapter may be used to process dbus calls. This is relevant
         # only on methods using D-Bus.
         self.dbus_adapter = cast("DBusAdapter | None", kwargs.pop("dbus_adapter", None))
-        self.method_kwargs = kwargs
+
+        # waits for https://github.com/fohrloop/wakepy/issues/256
+        # self.method_kwargs = kwargs
 
     def __init_subclass__(cls, **kwargs: object) -> None:
         register_method(cls)

--- a/src/wakepy/methods/freedesktop.py
+++ b/src/wakepy/methods/freedesktop.py
@@ -17,8 +17,6 @@ from wakepy.core import (
 if typing.TYPE_CHECKING:
     from typing import Optional
 
-    from wakepy.core import DBusAdapter
-
 
 class FreedesktopScreenSaverInhibit(Method):
     """Method using org.freedesktop.ScreenSaver D-Bus API
@@ -52,8 +50,8 @@ class FreedesktopScreenSaverInhibit(Method):
 
     supported_platforms = (PlatformName.LINUX,)
 
-    def __init__(self, dbus_adapter: Optional[DBusAdapter] = None) -> None:
-        super().__init__(dbus_adapter=dbus_adapter)
+    def __init__(self, **kwargs: object) -> None:
+        super().__init__(**kwargs)
         self.inhibit_cookie: Optional[int] = None
 
     def enter_mode(self) -> None:

--- a/src/wakepy/methods/gnome.py
+++ b/src/wakepy/methods/gnome.py
@@ -17,8 +17,6 @@ from wakepy.core import (
 if typing.TYPE_CHECKING:
     from typing import Optional
 
-    from wakepy.core import DBusAdapter
-
 
 class GnomeFlag(enum.IntFlag):
     INHIBIT_LOG_OUT = 1
@@ -64,8 +62,8 @@ class _GnomeSessionManager(Method, ABC):
     @abstractmethod
     def flags(self) -> GnomeFlag: ...
 
-    def __init__(self, dbus_adapter: Optional[DBusAdapter] = None) -> None:
-        super().__init__(dbus_adapter=dbus_adapter)
+    def __init__(self, **kwargs: object) -> None:
+        super().__init__(**kwargs)
         self.inhibit_cookie: Optional[int] = None
 
     def enter_mode(self) -> None:

--- a/src/wakepy/methods/macos.py
+++ b/src/wakepy/methods/macos.py
@@ -10,8 +10,6 @@ from wakepy.core import Method, ModeName, PlatformName
 if typing.TYPE_CHECKING:
     from typing import Optional
 
-    from wakepy.core import DBusAdapter
-
 
 class _MacCaffeinate(Method, ABC):
     """This is a method which calls the `caffeinate` command.
@@ -22,8 +20,8 @@ class _MacCaffeinate(Method, ABC):
 
     supported_platforms = (PlatformName.MACOS,)
 
-    def __init__(self, dbus_adapter: Optional[DBusAdapter] = None) -> None:
-        super().__init__(dbus_adapter=dbus_adapter)
+    def __init__(self, **kwargs: object) -> None:
+        super().__init__(**kwargs)
         self.logger = logging.getLogger(__name__)
         self._process: Optional[Popen[bytes]] = None
 

--- a/tests/unit/test_core/test_method.py
+++ b/tests/unit/test_core/test_method.py
@@ -166,7 +166,7 @@ def test_method_string_representations():
 def test_process_dbus_call(dbus_method: DBusMethod):
     method = Method()
     # when there is no dbus adapter..
-    assert method._dbus_adapter is None
+    assert method.dbus_adapter is None
     # we get RuntimeError
     with pytest.raises(
         RuntimeError,


### PR DESCRIPTION
Change Method.\_\_init\_\_ signature from 

```python
def __init__(self, dbus_adapter: Optional[DBusAdapter] = None) -> None:
    self._dbus_adapter = dbus_adapter
```

to

```python
def __init__(self, **kwargs: object) -> None:
    self.dbus_adapter = kwargs.pop("dbus_adapter", None)
```

this makes subclassing and explaining subclassing easier; instead of using

```python
def __init__(self, dbus_adapter: Optional[DBusAdapter] = None) -> None:
    super().__init__(dbus_adapter=dbus_adapter)
```

which is confusing when a Method does not need dbus at all, user has to define simply:

```python
def __init__(self, **kwargs: object) -> None:
    super().__init__(**kwargs)
```

In addition, this is one step closer to implementing https://github.com/fohrloop/wakepy/issues/256 (support for passing kwargs to Methods).