### PR TITLE
ActivationResults: Add __eq__ and __repr__

### DIFF
--- a/src/wakepy/core/activation.py
+++ b/src/wakepy/core/activation.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import datetime as dt
 import sys
 import typing
-from dataclasses import dataclass
+from dataclasses import InitVar, dataclass, field
 from typing import List, Sequence, Set, Union
 
 from .constants import PlatformName
@@ -63,10 +63,18 @@ class StageName(StrEnum):
 StageNameValue = Literal["NONE", "PLATFORM_SUPPORT", "REQUIREMENTS", "ACTIVATION"]
 
 
+@dataclass
 class ActivationResult:
     """The ActivationResult is responsible of keeping track on the possibly
     successful (max 1), failed and unused methods and providing different views
     on the results of the activation process.
+
+    Parameters
+    ---------
+    results:
+        The MethodActivationResults to be used to fill the ActivationResult
+    modename:
+        Name of the Mode. Optional.
 
     Attributes
     ----------
@@ -97,25 +105,20 @@ class ActivationResult:
         easier access, use .list_methods().
     """
 
-    def __init__(
+    results: InitVar[Optional[List[MethodActivationResult]]] = None
+    # These are the retuls for each of the used wakepy.Methods, in the
+    # order the methods were tried (first = highest priority, last =
+    # lowest priority)
+
+    _method_results: List[MethodActivationResult] = field(init=False)
+
+    modename: Optional[str] = None
+
+    def __post_init__(
         self,
         results: Optional[List[MethodActivationResult]] = None,
-        modename: Optional[str] = None,
     ):
-        """
-        Parameters
-        ---------
-        results:
-            The MethodActivationResults to be used to fill the ActivationResult
-        modename:
-            Name of the Mode. Optional.
-        """
-
-        # These are the retuls for each of the used wakepy.Methods, in the
-        # order the methods were tried (first = highest priority, last =
-        # lowest priority)
-        self._method_results: list[MethodActivationResult] = results or []
-        self.modename = modename
+        self._method_results = results or []
 
     @property
     def real_success(self) -> bool:

--- a/src/wakepy/core/activation.py
+++ b/src/wakepy/core/activation.py
@@ -110,10 +110,12 @@ class ActivationResult:
     # order the methods were tried (first = highest priority, last =
     # lowest priority)
 
-    _method_results: List[MethodActivationResult] = field(init=False)
-
     modename: Optional[str] = None
     """Name of the mode, if any."""
+
+    active_method: str | None = field(init=False)
+    """The name of the active (successful) method. If no methods are active,
+    this is None."""
 
     success: bool = field(init=False)
     """Tells is entering into a mode was successful.
@@ -130,9 +132,7 @@ class ActivationResult:
     failure: bool = field(init=False)
     """Always opposite of `success`. Included for convenience."""
 
-    active_method: str | None = field(init=False)
-    """The name of the active (successful) method. If no methods are active,
-    this is None."""
+    _method_results: List[MethodActivationResult] = field(init=False)
 
     def __post_init__(
         self,

--- a/src/wakepy/core/activation.py
+++ b/src/wakepy/core/activation.py
@@ -137,7 +137,7 @@ class ActivationResult:
     def __post_init__(
         self,
         results: Optional[List[MethodActivationResult]] = None,
-    ):
+    ) -> None:
         self._method_results = results or []
         self.success = self._get_success()
         self.failure = not self.success

--- a/tests/unit/test_core/test_activation/test_activationresult.py
+++ b/tests/unit/test_core/test_activation/test_activationresult.py
@@ -1,216 +1,337 @@
+from __future__ import annotations
+
 import re
+import typing
 
 import pytest
 
 from wakepy.core import ActivationResult, MethodActivationResult
 from wakepy.core.activation import StageName, WakepyFakeSuccess
 
-PLATFORM_SUPPORT_FAIL = MethodActivationResult(
-    success=False,
-    failure_stage=StageName.PLATFORM_SUPPORT,
-    method_name="fail-platform",
-    failure_reason="Platform XYZ not supported!",
-)
-REQUIREMENTS_FAIL = MethodActivationResult(
-    success=False,
-    failure_stage=StageName.REQUIREMENTS,
-    method_name="fail-requirements",
-    failure_reason="Missing requirement: Some SW v.1.2.3",
-)
-SUCCESS_RESULT = MethodActivationResult(
-    success=True,
-    method_name="a-successful-method",
-)
-UNUSED_RESULT = MethodActivationResult(
-    success=None,
-    method_name="some-unused-method",
-)
+if typing.TYPE_CHECKING:
+    from typing import List
 
-WAKEPY_FAKE_NOTINUSE = MethodActivationResult(
-    success=False,
-    failure_stage=StageName.ACTIVATION,
-    method_name=WakepyFakeSuccess.name,
-)
-WAKEPY_FAKE_SUCCESS = MethodActivationResult(
-    success=True,
-    failure_stage=StageName.ACTIVATION,
-    method_name=WakepyFakeSuccess.name,
-)
 
-METHODACTIVATIONRESULTS_1 = [
-    PLATFORM_SUPPORT_FAIL,
-    REQUIREMENTS_FAIL,
-    SUCCESS_RESULT,
-    UNUSED_RESULT,
-]
-
-METHODACTIVATIONRESULTS_2 = [
-    MethodActivationResult(
-        success=True,
-        method_name="1st.successfull.method",
-    ),
-    REQUIREMENTS_FAIL,
-    MethodActivationResult(
-        success=True,
-        method_name="2nd-successful-method",
-    ),
-    MethodActivationResult(
-        success=True,
-        method_name="last-successful-method",
-    ),
-]
-
-METHODACTIVATIONRESULTS_3_FAIL = [
-    MethodActivationResult(
+@pytest.fixture
+def mr_platform_support_fail() -> MethodActivationResult:
+    return MethodActivationResult(
         success=False,
         failure_stage=StageName.PLATFORM_SUPPORT,
         method_name="fail-platform",
         failure_reason="Platform XYZ not supported!",
-    ),
-    MethodActivationResult(
+    )
+
+
+@pytest.fixture
+def mr_requirements_fail() -> MethodActivationResult:
+    return MethodActivationResult(
         success=False,
         failure_stage=StageName.REQUIREMENTS,
         method_name="fail-requirements",
         failure_reason="Missing requirement: Some SW v.1.2.3",
-    ),
-]
-
-
-def test_activation_result_list_methods():
-    ar = ActivationResult(
-        [
-            PLATFORM_SUPPORT_FAIL,
-            REQUIREMENTS_FAIL,
-            SUCCESS_RESULT,
-            UNUSED_RESULT,
-        ]
-    )
-    # By default, the list_methods drops out failures occuring in the
-    # platform stage
-    assert ar.list_methods() == [
-        REQUIREMENTS_FAIL,
-        SUCCESS_RESULT,
-        UNUSED_RESULT,
-    ]
-
-    # The same as above but with explicit arguments.
-    assert ar.list_methods(ignore_platform_fails=True) == [
-        REQUIREMENTS_FAIL,
-        SUCCESS_RESULT,
-        UNUSED_RESULT,
-    ]
-
-    # Do not ignore platform fails
-    assert ar.list_methods(ignore_platform_fails=False) == [
-        PLATFORM_SUPPORT_FAIL,
-        REQUIREMENTS_FAIL,
-        SUCCESS_RESULT,
-        UNUSED_RESULT,
-    ]
-
-    # ignore unused
-    assert ar.list_methods(ignore_platform_fails=False, ignore_unused=True) == [
-        PLATFORM_SUPPORT_FAIL,
-        REQUIREMENTS_FAIL,
-        SUCCESS_RESULT,
-    ]
-
-
-def test_activation_result_query():
-    ar = ActivationResult(
-        [
-            PLATFORM_SUPPORT_FAIL,
-            REQUIREMENTS_FAIL,
-            SUCCESS_RESULT,
-            UNUSED_RESULT,
-        ]
-    )
-
-    # When no arguments given, return everything
-    assert ar.query() == [
-        PLATFORM_SUPPORT_FAIL,
-        REQUIREMENTS_FAIL,
-        SUCCESS_RESULT,
-        UNUSED_RESULT,
-    ]
-
-    # Possible to filter with status
-    assert ar.query(success=(False,)) == [
-        PLATFORM_SUPPORT_FAIL,
-        REQUIREMENTS_FAIL,
-    ]
-
-    # Possible to filter with fail_stage
-    assert ar.query(fail_stages=("REQUIREMENTS",)) == [
-        REQUIREMENTS_FAIL,
-        SUCCESS_RESULT,
-        UNUSED_RESULT,
-    ]
-
-    # or with both
-    assert ar.query(success=(False,), fail_stages=("REQUIREMENTS",)) == [
-        REQUIREMENTS_FAIL,
-    ]
-
-
-@pytest.mark.parametrize(
-    "results, success_expected, real_success_expected",
-    [
-        (METHODACTIVATIONRESULTS_1, True, True),
-        (METHODACTIVATIONRESULTS_2, True, True),
-        (METHODACTIVATIONRESULTS_3_FAIL + [WAKEPY_FAKE_NOTINUSE], False, False),
-        (METHODACTIVATIONRESULTS_3_FAIL + [WAKEPY_FAKE_SUCCESS], True, False),
-    ],
-)
-def test_activation_result_success(
-    results,
-    success_expected,
-    real_success_expected,
-):
-    with pytest.MonkeyPatch.context():
-        ar = ActivationResult(results)
-
-        assert ar.success == success_expected
-        assert ar.real_success == real_success_expected
-        assert ar.failure == (not success_expected)
-
-
-def test_activationresult_get_error_text_success():
-    ar = ActivationResult(METHODACTIVATIONRESULTS_1)
-    # error text is empty string in case of success.
-    assert ar.get_error_text() == ""
-
-
-def test_activationresult_get_error_text_failure():
-    ar = ActivationResult(
-        [PLATFORM_SUPPORT_FAIL, REQUIREMENTS_FAIL], modename="SomeMode"
-    )
-    assert ar.get_error_text() == (
-        'Could not activate Mode "SomeMode"!\n\nMethod usage results, in order '
-        '(highest priority first):\n[(FAIL @PLATFORM_SUPPORT, fail-platform, "Platform '
-        'XYZ not supported!"), (FAIL @REQUIREMENTS, fail-requirements, "Missing '
-        'requirement: Some SW v.1.2.3")]'
     )
 
 
-def test_active_method():
-    ar = ActivationResult(METHODACTIVATIONRESULTS_1)
-    assert ar.active_method == "a-successful-method"
+@pytest.fixture
+def mr_success_result() -> MethodActivationResult:
+    return MethodActivationResult(
+        success=True,
+        method_name="a-successful-method",
+    )
 
 
-def test_active_method_with_fails():
-    ar = ActivationResult([PLATFORM_SUPPORT_FAIL, REQUIREMENTS_FAIL])
-    assert ar.active_method is None
+@pytest.fixture
+def mr_unused_result() -> MethodActivationResult:
+    return MethodActivationResult(
+        success=None,
+        method_name="some-unused-method",
+    )
 
 
-def test_active_method_with_multiple_success():
-    ar = ActivationResult(METHODACTIVATIONRESULTS_2)
-    with pytest.raises(
-        ValueError,
-        match=re.escape(
-            "The ActivationResult cannot have more than one active methods! Active "
-            "methods: ['1st.successfull.method', '2nd-successful-method', "
-            "'last-successful-method']"
+@pytest.fixture
+def mr_wakepy_fake_notinuse() -> MethodActivationResult:
+    return MethodActivationResult(
+        success=False,
+        failure_stage=StageName.ACTIVATION,
+        method_name=WakepyFakeSuccess.name,
+    )
+
+
+@pytest.fixture
+def mr_wakepy_fake_success() -> MethodActivationResult:
+    return MethodActivationResult(
+        success=True,
+        failure_stage=StageName.ACTIVATION,
+        method_name=WakepyFakeSuccess.name,
+    )
+
+
+@pytest.fixture
+def method_activation_results1(
+    mr_platform_support_fail: MethodActivationResult,
+    mr_requirements_fail: MethodActivationResult,
+    mr_success_result: MethodActivationResult,
+    mr_unused_result: MethodActivationResult,
+) -> List[MethodActivationResult]:
+    return [
+        mr_platform_support_fail,
+        mr_requirements_fail,
+        mr_success_result,
+        mr_unused_result,
+    ]
+
+
+@pytest.fixture
+def method_activation_results2(
+    mr_requirements_fail: MethodActivationResult,
+) -> List[MethodActivationResult]:
+    return [
+        MethodActivationResult(
+            success=True,
+            method_name="1st.successful.method",
         ),
+        # Fails in Requirement stage
+        mr_requirements_fail,
+        MethodActivationResult(
+            success=True,
+            method_name="2nd-successful-method",
+        ),
+        MethodActivationResult(
+            success=True,
+            method_name="last-successful-method",
+        ),
+    ]
+
+
+@pytest.fixture
+def method_activation_results3_fail() -> List[MethodActivationResult]:
+    return [
+        MethodActivationResult(
+            success=False,
+            failure_stage=StageName.PLATFORM_SUPPORT,
+            method_name="fail-platform",
+            failure_reason="Platform XYZ not supported!",
+        ),
+        MethodActivationResult(
+            success=False,
+            failure_stage=StageName.REQUIREMENTS,
+            method_name="fail-requirements",
+            failure_reason="Missing requirement: Some SW v.1.2.3",
+        ),
+    ]
+
+
+@pytest.fixture
+def method_activation_results4a(
+    method_activation_results3_fail: List[MethodActivationResult],
+    mr_wakepy_fake_notinuse: MethodActivationResult,
+) -> List[MethodActivationResult]:
+    """Fails & WAKEPY_FAKE_SUCCESS not in use"""
+    return method_activation_results3_fail + [mr_wakepy_fake_notinuse]
+
+
+@pytest.fixture
+def method_activation_results4b(
+    method_activation_results3_fail: List[MethodActivationResult],
+    mr_wakepy_fake_success: MethodActivationResult,
+) -> List[MethodActivationResult]:
+    """Fails & WAKEPY_FAKE_SUCCESS in use"""
+    return method_activation_results3_fail + [mr_wakepy_fake_success]
+
+
+class TestActivationResult:
+    """Tests for ActivationResult"""
+
+    @staticmethod
+    @pytest.fixture
+    def ar(
+        mr_platform_support_fail: MethodActivationResult,
+        mr_requirements_fail: MethodActivationResult,
+        mr_success_result: MethodActivationResult,
+        mr_unused_result: MethodActivationResult,
+    ) -> ActivationResult:
+        return ActivationResult(
+            [
+                mr_platform_support_fail,
+                mr_requirements_fail,
+                mr_success_result,
+                mr_unused_result,
+            ]
+        )
+
+    def test_list_methods_ignore_platform_fails(
+        self,
+        mr_platform_support_fail: MethodActivationResult,
+        mr_requirements_fail: MethodActivationResult,
+        mr_success_result: MethodActivationResult,
+        mr_unused_result: MethodActivationResult,
+        ar: ActivationResult,
     ):
-        ar.active_method
+        # By default, the list_methods drops out failures occuring in the
+        # platform stage
+        assert mr_platform_support_fail not in ar.list_methods()
+
+        # This is what we expect (all but mr_platform_support_fail)
+        assert ar.list_methods() == [
+            mr_requirements_fail,
+            mr_success_result,
+            mr_unused_result,
+        ]
+        # The same as above but with explicit arguments.
+        assert ar.list_methods(ignore_platform_fails=True) == [
+            mr_requirements_fail,
+            mr_success_result,
+            mr_unused_result,
+        ]
+        # Do not ignore platform fails
+        assert ar.list_methods(ignore_platform_fails=False) == [
+            mr_platform_support_fail,
+            mr_requirements_fail,
+            mr_success_result,
+            mr_unused_result,
+        ]
+
+    def test_list_methods_ignore_unused(
+        self,
+        mr_platform_support_fail: MethodActivationResult,
+        mr_requirements_fail: MethodActivationResult,
+        mr_success_result: MethodActivationResult,
+        mr_unused_result: MethodActivationResult,
+        ar: ActivationResult,
+    ):
+        # Possible to ignore unused methods
+        assert mr_unused_result not in ar.list_methods(ignore_unused=True)
+
+        assert ar.list_methods(ignore_platform_fails=False, ignore_unused=True) == [
+            mr_platform_support_fail,
+            mr_requirements_fail,
+            mr_success_result,
+        ]
+
+    def test_query_without_args(
+        self,
+        ar: ActivationResult,
+        mr_platform_support_fail: MethodActivationResult,
+        mr_requirements_fail: MethodActivationResult,
+        mr_success_result: MethodActivationResult,
+        mr_unused_result: MethodActivationResult,
+    ):
+
+        # When no arguments given, return everything
+        assert ar.query() == [
+            mr_platform_support_fail,
+            mr_requirements_fail,
+            mr_success_result,
+            mr_unused_result,
+        ]
+
+    def test_query_success(
+        self,
+        ar: ActivationResult,
+        mr_platform_support_fail: MethodActivationResult,
+        mr_requirements_fail: MethodActivationResult,
+    ):
+        # Possible to filter with status
+        assert ar.query(success=(False,)) == [
+            mr_platform_support_fail,
+            mr_requirements_fail,
+        ]
+
+    def test_query_fail_stages(
+        self,
+        ar: ActivationResult,
+        mr_requirements_fail: MethodActivationResult,
+        mr_success_result: MethodActivationResult,
+        mr_unused_result: MethodActivationResult,
+    ):
+
+        # Possible to filter with fail_stage
+        assert ar.query(fail_stages=("REQUIREMENTS",)) == [
+            mr_requirements_fail,
+            mr_success_result,
+            mr_unused_result,
+        ]
+
+    def test_query_fail_stages_and_success(
+        self,
+        ar: ActivationResult,
+        mr_requirements_fail: MethodActivationResult,
+    ):
+
+        # or with both
+        assert ar.query(success=(False,), fail_stages=("REQUIREMENTS",)) == [
+            mr_requirements_fail,
+        ]
+
+    @pytest.mark.parametrize(
+        "method_activation_results, success_expected, real_success_expected",
+        [
+            ("method_activation_results1", True, True),
+            ("method_activation_results2", True, True),
+            ("method_activation_results4a", False, False),
+            ("method_activation_results4b", True, False),
+        ],
+    )
+    def test_activation_result_success(
+        self,
+        method_activation_results: List[MethodActivationResult],
+        success_expected: bool,
+        real_success_expected: bool,
+        request,
+    ):
+        method_activation_results = request.getfixturevalue(method_activation_results)
+        with pytest.MonkeyPatch.context():
+            ar = ActivationResult(method_activation_results)
+            assert ar.success == success_expected
+            assert ar.real_success == real_success_expected
+            assert ar.failure == (not success_expected)
+
+    def test_get_error_text_success(
+        self, method_activation_results1: List[MethodActivationResult]
+    ):
+        ar = ActivationResult(method_activation_results1)
+        # error text is empty string in case of success.
+        assert ar.get_error_text() == ""
+
+    def test_get_error_text_failure(
+        self,
+        mr_platform_support_fail: MethodActivationResult,
+        mr_requirements_fail: MethodActivationResult,
+    ):
+        ar = ActivationResult(
+            [mr_platform_support_fail, mr_requirements_fail], modename="SomeMode"
+        )
+        assert ar.get_error_text() == (
+            'Could not activate Mode "SomeMode"!\n\nMethod usage results, in order '
+            '(highest priority first):\n[(FAIL @PLATFORM_SUPPORT, fail-platform, "Platform '
+            'XYZ not supported!"), (FAIL @REQUIREMENTS, fail-requirements, "Missing '
+            'requirement: Some SW v.1.2.3")]'
+        )
+
+    def test_active_method(
+        self, method_activation_results1: List[MethodActivationResult]
+    ):
+        ar = ActivationResult(method_activation_results1)
+        assert ar.active_method == "a-successful-method"
+
+    def test_active_method_with_fails(
+        self,
+        mr_platform_support_fail: MethodActivationResult,
+        mr_requirements_fail: MethodActivationResult,
+    ):
+        ar = ActivationResult([mr_platform_support_fail, mr_requirements_fail])
+        assert ar.active_method is None
+
+    def test_active_method_with_multiple_success(
+        self, method_activation_results2: List[MethodActivationResult]
+    ):
+        ar = ActivationResult(method_activation_results2)
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "The ActivationResult cannot have more than one active methods! Active "
+                "methods: ['1st.successful.method', '2nd-successful-method', "
+                "'last-successful-method']"
+            ),
+        ):
+            ar.active_method

--- a/tests/unit/test_core/test_activation/test_activationresult.py
+++ b/tests/unit/test_core/test_activation/test_activationresult.py
@@ -354,13 +354,12 @@ class TestActivationResult:
         assert ar1 is not ar2
         assert ar1 == ar2
 
-    # TODO: Add __repr__ test
-    # def test__repr__(self, method_activation_results1: MethodActivationResult):
-    #     ar1 = ActivationResult(method_activation_results1, modename="foo")
-    #     assert (
-    #         ar1.__repr__()
-    #         == """ActivationResult(_method_results=[(FAIL @PLATFORM_SUPPORT, fail-platform, "Platform XYZ not supported!"), (FAIL @REQUIREMENTS, fail-requirements, "Missing requirement: Some SW v.1.2.3"), (SUCCESS, a-successful-method), (UNUSED, some-unused-method)], modename='foo')"""
-    #     )
+    def test__repr__(self, method_activation_results1: MethodActivationResult):
+        ar1 = ActivationResult(method_activation_results1, modename="foo")
+        assert (
+            ar1.__repr__()
+            == """ActivationResult(modename='foo', active_method='a-successful-method', success=True, real_success=True, failure=False, _method_results=[(FAIL @PLATFORM_SUPPORT, fail-platform, "Platform XYZ not supported!"), (FAIL @REQUIREMENTS, fail-requirements, "Missing requirement: Some SW v.1.2.3"), (SUCCESS, a-successful-method), (UNUSED, some-unused-method)])"""
+        )
 
 
 class TestMethodActivationResult:

--- a/tests/unit/test_core/test_activation/test_activationresult.py
+++ b/tests/unit/test_core/test_activation/test_activationresult.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import re
 import typing
 
@@ -335,6 +336,33 @@ class TestActivationResult:
             ),
         ):
             ar.active_method
+
+    @pytest.mark.parametrize(
+        "method_activation_results",
+        [
+            ("method_activation_results1"),
+            ("method_activation_results2"),
+            ("method_activation_results3_fail"),
+            ("method_activation_results4a"),
+            ("method_activation_results4b"),
+        ],
+    )
+    def test__eq__(
+        self, method_activation_results: List[MethodActivationResult], request
+    ):
+        method_activation_results = request.getfixturevalue(method_activation_results)
+        ar1 = ActivationResult(method_activation_results, modename="foo")
+        ar2 = ActivationResult(method_activation_results, modename="foo")
+
+        assert ar1 is not ar2
+        assert ar1 == ar2
+
+    def test__repr__(self, method_activation_results1: MethodActivationResult):
+        ar1 = ActivationResult(method_activation_results1, modename="foo")
+        assert (
+            ar1.__repr__()
+            == """ActivationResult(_method_results=[(FAIL @PLATFORM_SUPPORT, fail-platform, "Platform XYZ not supported!"), (FAIL @REQUIREMENTS, fail-requirements, "Missing requirement: Some SW v.1.2.3"), (SUCCESS, a-successful-method), (UNUSED, some-unused-method)], modename='foo')"""
+        )
 
 
 class TestMethodActivationResult:

--- a/tests/unit/test_core/test_activation/test_activationresult.py
+++ b/tests/unit/test_core/test_activation/test_activationresult.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import copy
 import re
 import typing
 
@@ -303,9 +302,9 @@ class TestActivationResult:
         )
         assert ar.get_error_text() == (
             'Could not activate Mode "SomeMode"!\n\nMethod usage results, in order '
-            '(highest priority first):\n[(FAIL @PLATFORM_SUPPORT, fail-platform, "Platform '
-            'XYZ not supported!"), (FAIL @REQUIREMENTS, fail-requirements, "Missing '
-            'requirement: Some SW v.1.2.3")]'
+            "(highest priority first):\n[(FAIL @PLATFORM_SUPPORT, fail-platform, "
+            '"Platform XYZ not supported!"), (FAIL @REQUIREMENTS, fail-requirements, '
+            '"Missing requirement: Some SW v.1.2.3")]'
         )
 
     def test_active_method(
@@ -333,7 +332,7 @@ class TestActivationResult:
                 "'last-successful-method']"
             ),
         ):
-            ar = ActivationResult(method_activation_results2_manysuccess)
+            ActivationResult(method_activation_results2_manysuccess)
 
     @pytest.mark.parametrize(
         "method_activation_results",
@@ -358,7 +357,7 @@ class TestActivationResult:
         ar1 = ActivationResult(method_activation_results1, modename="foo")
         assert (
             ar1.__repr__()
-            == """ActivationResult(modename='foo', active_method='a-successful-method', success=True, real_success=True, failure=False, _method_results=[(FAIL @PLATFORM_SUPPORT, fail-platform, "Platform XYZ not supported!"), (FAIL @REQUIREMENTS, fail-requirements, "Missing requirement: Some SW v.1.2.3"), (SUCCESS, a-successful-method), (UNUSED, some-unused-method)])"""
+            == """ActivationResult(modename='foo', active_method='a-successful-method', success=True, real_success=True, failure=False, _method_results=[(FAIL @PLATFORM_SUPPORT, fail-platform, "Platform XYZ not supported!"), (FAIL @REQUIREMENTS, fail-requirements, "Missing requirement: Some SW v.1.2.3"), (SUCCESS, a-successful-method), (UNUSED, some-unused-method)])"""  # noqa: E501
         )
 
 

--- a/tests/unit/test_core/test_activation/test_activationresult.py
+++ b/tests/unit/test_core/test_activation/test_activationresult.py
@@ -353,7 +353,7 @@ class TestActivationResult:
         assert ar1 is not ar2
         assert ar1 == ar2
 
-    def test__repr__(self, method_activation_results1: MethodActivationResult):
+    def test__repr__(self, method_activation_results1: List[MethodActivationResult]):
         ar1 = ActivationResult(method_activation_results1, modename="foo")
         assert (
             ar1.__repr__()

--- a/tests/unit/test_core/test_activation/test_activationresult.py
+++ b/tests/unit/test_core/test_activation/test_activationresult.py
@@ -83,7 +83,7 @@ def method_activation_results1(
 
 
 @pytest.fixture
-def method_activation_results2(
+def method_activation_results2_manysuccess(
     mr_requirements_fail: MethodActivationResult,
 ) -> List[MethodActivationResult]:
     return [
@@ -268,7 +268,6 @@ class TestActivationResult:
         "method_activation_results, success_expected, real_success_expected",
         [
             ("method_activation_results1", True, True),
-            ("method_activation_results2", True, True),
             ("method_activation_results4a", False, False),
             ("method_activation_results4b", True, False),
         ],
@@ -324,9 +323,8 @@ class TestActivationResult:
         assert ar.active_method is None
 
     def test_active_method_with_multiple_success(
-        self, method_activation_results2: List[MethodActivationResult]
+        self, method_activation_results2_manysuccess: List[MethodActivationResult]
     ):
-        ar = ActivationResult(method_activation_results2)
         with pytest.raises(
             ValueError,
             match=re.escape(
@@ -335,13 +333,12 @@ class TestActivationResult:
                 "'last-successful-method']"
             ),
         ):
-            ar.active_method
+            ar = ActivationResult(method_activation_results2_manysuccess)
 
     @pytest.mark.parametrize(
         "method_activation_results",
         [
             ("method_activation_results1"),
-            ("method_activation_results2"),
             ("method_activation_results3_fail"),
             ("method_activation_results4a"),
             ("method_activation_results4b"),
@@ -357,12 +354,13 @@ class TestActivationResult:
         assert ar1 is not ar2
         assert ar1 == ar2
 
-    def test__repr__(self, method_activation_results1: MethodActivationResult):
-        ar1 = ActivationResult(method_activation_results1, modename="foo")
-        assert (
-            ar1.__repr__()
-            == """ActivationResult(_method_results=[(FAIL @PLATFORM_SUPPORT, fail-platform, "Platform XYZ not supported!"), (FAIL @REQUIREMENTS, fail-requirements, "Missing requirement: Some SW v.1.2.3"), (SUCCESS, a-successful-method), (UNUSED, some-unused-method)], modename='foo')"""
-        )
+    # TODO: Add __repr__ test
+    # def test__repr__(self, method_activation_results1: MethodActivationResult):
+    #     ar1 = ActivationResult(method_activation_results1, modename="foo")
+    #     assert (
+    #         ar1.__repr__()
+    #         == """ActivationResult(_method_results=[(FAIL @PLATFORM_SUPPORT, fail-platform, "Platform XYZ not supported!"), (FAIL @REQUIREMENTS, fail-requirements, "Missing requirement: Some SW v.1.2.3"), (SUCCESS, a-successful-method), (UNUSED, some-unused-method)], modename='foo')"""
+    #     )
 
 
 class TestMethodActivationResult:

--- a/tests/unit/test_core/test_activation/test_activationresult.py
+++ b/tests/unit/test_core/test_activation/test_activationresult.py
@@ -335,3 +335,91 @@ class TestActivationResult:
             ),
         ):
             ar.active_method
+
+
+class TestMethodActivationResult:
+    """Tests for MethodActivationResult"""
+
+    @pytest.fixture
+    def a(self) -> MethodActivationResult:
+        return MethodActivationResult(
+            method_name="foo",
+            success=False,
+            failure_stage=StageName.REQUIREMENTS,
+            failure_reason="some-text",
+        )
+
+    @pytest.fixture
+    def b(self) -> MethodActivationResult:
+        return MethodActivationResult(
+            method_name="foo",
+            success=False,
+            failure_stage=StageName.REQUIREMENTS,
+            failure_reason="some-text",
+        )
+
+    def test_equality_check_similar(
+        self, a: MethodActivationResult, b: MethodActivationResult
+    ):
+        # MethodActivationResult implements __eq__
+        assert a is not b
+        assert a == b
+
+    @pytest.fixture
+    def c_different_method_name(self) -> MethodActivationResult:
+        return MethodActivationResult(
+            method_name="bar",
+            success=False,
+            failure_stage=StageName.REQUIREMENTS,
+            failure_reason="some-text",
+        )
+
+    @pytest.fixture
+    def c_different_success(self) -> MethodActivationResult:
+        return MethodActivationResult(
+            method_name="foo",
+            success=True,
+            failure_stage=StageName.REQUIREMENTS,
+            failure_reason="some-text",
+        )
+
+    @pytest.fixture
+    def c_different_failure_stage(self) -> MethodActivationResult:
+        return MethodActivationResult(
+            method_name="foo",
+            success=False,
+            failure_stage=StageName.PLATFORM_SUPPORT,
+            failure_reason="some-text",
+        )
+
+    @pytest.fixture
+    def c_different_failure_reason(self) -> MethodActivationResult:
+        return MethodActivationResult(
+            method_name="foo",
+            success=False,
+            failure_stage=StageName.REQUIREMENTS,
+            failure_reason="some-other-text",
+        )
+
+    def test_equality_check_different(
+        self,
+        a: MethodActivationResult,
+        c_different_method_name: MethodActivationResult,
+        c_different_success: MethodActivationResult,
+        c_different_failure_stage: MethodActivationResult,
+        c_different_failure_reason: MethodActivationResult,
+    ):
+
+        c_list = [
+            c_different_method_name,
+            c_different_success,
+            c_different_failure_stage,
+            c_different_failure_reason,
+        ]
+        # MethodActivationResult implements __eq__
+        assert all(isinstance(x, MethodActivationResult) for x in [a] + c_list)
+        for c in c_list:
+            assert a != c
+
+    def test_repr(self, a: MethodActivationResult):
+        assert a.__repr__() == '(FAIL @REQUIREMENTS, foo, "some-text")'


### PR DESCRIPTION
ActivationResult
----------------
Implement __eq__ and __repr__ (use dataclass). Now it's possible to
compare two ActivationResults with "==", and the ActivationResult when
printed has more infromation.

Before:
<wakepy.core.activation.ActivationResult at 0x70af4d994f70>

Now:
ActivationResult(modename='foo', active_method='a-successful-method',
success=True, real_success=True, failure=False, _method_results=[
(FAIL @PLATFORM_SUPPORT, fail-platform, "Platform XYZ not supported!"),
(FAIL @REQUIREMENTS, fail-requirements, "Missing requirement: Some SW
v.1.2.3"), (SUCCESS, a-successful-method), (UNUSED, some-unused-method)
])

In addition, refactor ActivationResult related tests.