### PR TITLE
Wakepy fake success update

### DIFF
--- a/docs/source/modes.md
+++ b/docs/source/modes.md
@@ -97,4 +97,4 @@ manual reversal.
 ## General questions
 **What if the process holding the lock dies?**: The lock is automatically removed.
 
-**How to use wakepy in tests / CI**: One problem with tests and/or CI systems is that many times the environment is different, and preventing system going to sleep works differently there. To fake a successful inhibit lock in tests, you may set an environment variable: `WAKEPY_FAKE_SUCCESS` to `yes`.
+**How to use wakepy in tests / CI**: One problem with tests and/or CI systems is that many times the environment is different, and preventing system going to sleep works differently there. To fake a successful inhibit lock in tests, you may set an environment variable: [`WAKEPY_FAKE_SUCCESS`](#WAKEPY_FAKE_SUCCESS) to a truthy value like `1`.

--- a/docs/source/tests-and-ci.md
+++ b/docs/source/tests-and-ci.md
@@ -2,8 +2,9 @@
 
 If you're using wakepy in Continuous Integration tests, note that typically CI is running on a system where there is no Desktop Environment available. In addition, the available services and executables might be different from the services and executables on the machine where the code using wakepy is meant to be running. For this reason, even if wakepy is able to activate a mode on your development machine, it might not be able to do so in CI tests. *In most cases it is recommended to make wakepy always succeed in the mode activation in unit tests and CI by setting the `WAKEPY_FAKE_SUCCESS` environment variable.*
 
+(WAKEPY_FAKE_SUCCESS)=
 ## WAKEPY_FAKE_SUCCESS
-To force wakepy to fake a successful mode activation, you may set an environment variable `WAKEPY_FAKE_SUCCESS` to a *truthy value* like `yes` or `1`.  This makes wakepy to use a special fake method called `WakepyFakeSuccess`, which is guaranteed to success. This works with any mode and on any platform. The `WakepyFakeSuccess` Method is tried *before* any other possible Methods, which guarantees that there will be no IO (except for the env var check), and no calling of any executables or 3rd party services when WAKEPY_FAKE_SUCCESS is used.
+To force wakepy to fake a successful mode activation, you may set an environment variable `WAKEPY_FAKE_SUCCESS` to a *truthy value* like `yes` or `1`.  This makes all wakepy Modes to insert a special fake method called `WakepyFakeSuccess` to its list of Methods. This method is always the highest priority (tried first), and it's activation guaranteed to succeed. This works with any mode and on any platform. Since the `WakepyFakeSuccess` Method is tried *before* any other possible Methods,  there will be no IO (except for the env var check), and no calling of any executables or 3rd party services when `WAKEPY_FAKE_SUCCESS` is used.
 
 
 ```{admonition} Truthy and falsy values
@@ -42,8 +43,6 @@ def tests(session):
     session.env["WAKEPY_FAKE_SUCCESS"] = "yes"
     # ... run tests
 ```
-
-
 
 ## Tests without using faked success
 

--- a/docs/source/tests-and-ci.md
+++ b/docs/source/tests-and-ci.md
@@ -9,7 +9,7 @@ To force wakepy to fake a successful mode activation, you may set an environment
 
 ```{admonition} Truthy and falsy values
 :class: info
-Only `0`, `no` and `false` are considered as falsy values (case ignored). Any other value is considered truthy.
+Only `0`, `no`, `N`, `false`, `F` and the empty string are considered as falsy values (case ignored). Any other value is considered truthy.
 ```
 
 ### pytest

--- a/src/wakepy/core/activationresult.py
+++ b/src/wakepy/core/activationresult.py
@@ -66,7 +66,7 @@ class ActivationResult:
     """
 
     results: InitVar[Optional[List[MethodActivationResult]]] = None
-    # These are the retuls for each of the used wakepy.Methods, in the
+    # These are the results for each of the used wakepy.Methods, in the
     # order the methods were tried (first = highest priority, last =
     # lowest priority)
 
@@ -168,11 +168,6 @@ class ActivationResult:
             if res.success not in success:
                 continue
             elif res.success is False and res.failure_stage not in fail_stages:
-                continue
-            elif res.success is False and res.method_name == WAKEPY_FAKE_SUCCESS:
-                # The fake method is only listed if it was requested to be,
-                # used, and when it is not requested to be used, the
-                # res.success is False.
                 continue
             out.append(res)
 

--- a/src/wakepy/core/constants.py
+++ b/src/wakepy/core/constants.py
@@ -14,6 +14,13 @@ WAKEPY_FAKE_SUCCESS = "WAKEPY_FAKE_SUCCESS"
 """Name of the Wakepy fake success method and the environment variable used
 to set it"""
 
+# This variable should only contain lower-case characters.
+FALSY_ENV_VAR_VALUES = ("0", "no", "false")
+"""The falsy environment variable values. All other values are considered to be
+truthy. These values are case insensitive; Also "NO", "False" and "FALSE" are
+falsy.
+"""
+
 
 class PlatformName(StrEnum):
     WINDOWS = auto()

--- a/src/wakepy/core/constants.py
+++ b/src/wakepy/core/constants.py
@@ -15,7 +15,7 @@ WAKEPY_FAKE_SUCCESS = "WAKEPY_FAKE_SUCCESS"
 to set it"""
 
 # This variable should only contain lower-case characters.
-FALSY_ENV_VAR_VALUES = ("0", "no", "false")
+FALSY_ENV_VAR_VALUES = ("0", "no", "false", "n", "f", "")
 """The falsy environment variable values. All other values are considered to be
 truthy. These values are case insensitive; Also "NO", "False" and "FALSE" are
 falsy.

--- a/src/wakepy/core/mode.py
+++ b/src/wakepy/core/mode.py
@@ -488,7 +488,11 @@ def activate_mode(
         error messages (can be "any string" which makes sense to you).
         Optional.
 
-    # TODO: Add Returns
+    Returns
+    -------
+    ActivationResult, Optional[Method], Optional[Heartbeat]
+        A three-tuple: The activation result object, the activated method (
+        None if not any), the activated heartbeat (None if not any).
     """
 
     prioritized_methods = order_methods_by_priority(methods, methods_priority)

--- a/src/wakepy/core/mode.py
+++ b/src/wakepy/core/mode.py
@@ -279,8 +279,8 @@ class Mode:
 
         # Other types of exceptions are not handled; ignoring them here and
         # returning False will tell python to re-raise the exception. Can't
-        # return None as type-checkers will mark code after with block
-        # unreachable
+        # return None as type-checkers would mark code after with block
+        # unreachable.
 
         return False
 

--- a/src/wakepy/core/mode.py
+++ b/src/wakepy/core/mode.py
@@ -409,7 +409,7 @@ def add_fake_success_if_required(
     wakepy_fake_success:
         Value read from WAKEPY_FAKE_SUCCESS environment variable; either None
         or a string. For example: '0', '1', 'True', or 'False'. None has same
-        behavior as falsy values ('0', 'no', 'false')
+        behavior as falsy values ('0', 'no', 'false', 'f', 'n', '').
     """
     if not should_fake_success(wakepy_fake_success):
         return method_classes
@@ -425,7 +425,7 @@ def should_fake_success(wakepy_fake_success: str | None) -> bool:
     wakepy_fake_success:
         Value read from WAKEPY_FAKE_SUCCESS environment variable; either None
         or a string. For example: '0', '1', 'True', or 'False'. None has same
-        behavior as falsy values ('0', 'no', 'false')
+        behavior as falsy values ('0', 'no', 'false', 'f', 'n', '').
 
     Returns
     -------

--- a/src/wakepy/core/mode.py
+++ b/src/wakepy/core/mode.py
@@ -464,13 +464,11 @@ def activate_mode(
         Name of the Mode. Used for communication to user, logging and in
         error messages (can be "any string" which makes sense to you).
         Optional.
+
+    # TODO: Add Returns
     """
 
     prioritized_methods = order_methods_by_priority(methods, methods_priority)
-
-    if not prioritized_methods:
-        # Cannot activate anything as there are no methods.
-        return ActivationResult(modename=modename), None, None
 
     methodresults = []
     for methodcls in prioritized_methods:

--- a/src/wakepy/methods/_testing.py
+++ b/src/wakepy/methods/_testing.py
@@ -16,42 +16,8 @@ class WakepyFakeSuccess(Method):
 
     name = WAKEPY_FAKE_SUCCESS
     mode = "_fake"
-
-    environment_variable = name
-
-    # All other values are considered to be truthy. Comparison is case
-    # insensitive
-    falsy_values = ("0", "no", "false")
-
     supported_platforms = (CURRENT_PLATFORM,)
 
     def enter_mode(self) -> None:
-        """Function which says if fake success should be enabled
-
-        Fake success is controlled via WAKEPY_FAKE_SUCCESS environment
-        variable. If that variable is set to a truthy value,fake success is
-        activated.
-
-        Falsy values: '0', 'no', 'false' (case ignored)
-        Truthy values: everything else
-
-        Motivation:
-        -----------
-        When running on CI system, wakepy might fail to acquire an inhibitor
-        lock just because there is no Desktop Environment running. In these
-        cases, it might be useful to just tell with an environment variable
-        that wakepy should fake the successful inhibition anyway. Faking the
-        success is done after every other method is tried (and failed).
-        """
-        # The os.environ seems to be populated when os is imported -> delay the
-        # import until here.
-        import os
-
-        if self.environment_variable not in os.environ:
-            raise RuntimeError(f"{self.environment_variable} not set.")
-
-        val = os.environ[self.environment_variable]
-        if val.lower() in self.falsy_values:
-            raise RuntimeError(
-                f"{self.environment_variable} set to falsy value: {val}."
-            )
+        """Does nothing ("succeeds" automatically there are never any
+        Exceptions)"""

--- a/src/wakepy/methods/_testing.py
+++ b/src/wakepy/methods/_testing.py
@@ -19,5 +19,5 @@ class WakepyFakeSuccess(Method):
     supported_platforms = (CURRENT_PLATFORM,)
 
     def enter_mode(self) -> None:
-        """Does nothing ("succeeds" automatically there are never any
-        Exceptions)"""
+        """Does nothing ("succeeds" automatically; Will never raise an
+        Exception)"""

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -22,12 +22,15 @@ class TestUtils:
     @staticmethod
     def empty_method_registry(monkeypatch, fake_success=False):
         """
-        Make the method registry empty for duration of a test. Optionally, keep
-        the WakepyFakeSuccess method in the registry.
+        Make the method registry empty for duration of a test. Keep
+        the WakepyFakeSuccess method in the registry. and optionally set the
+        WAKEPY_FAKE_SUCCESS flag to a truthy value (if `fake_success` is True).
         """
         monkeypatch.setattr("wakepy.core.registry._method_registry", (dict()))
+        # The fake method should always be part of the registry.
+        register_method(WakepyFakeSuccess)
+
         if fake_success:
-            register_method(WakepyFakeSuccess)
             monkeypatch.setenv("WAKEPY_FAKE_SUCCESS", "1")
 
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -28,7 +28,7 @@ class TestUtils:
         monkeypatch.setattr("wakepy.core.registry._method_registry", (dict()))
         if fake_success:
             register_method(WakepyFakeSuccess)
-            monkeypatch.setenv("WAKEPY_FAKE_SUCCESS", "yes")
+            monkeypatch.setenv("WAKEPY_FAKE_SUCCESS", "1")
 
 
 @pytest.fixture(scope="session")

--- a/tests/unit/test_core/test_mode.py
+++ b/tests/unit/test_core/test_mode.py
@@ -281,7 +281,20 @@ class TestSelectMethods:
 
 
 # These are the only "falsy" values for WAKEPY_FAKE_SUCCESS
-FALSY_TEST_VALUES = (None, "0", "no", "NO", "False", "false", "FALSE")
+FALSY_TEST_VALUES = (
+    None,
+    "0",
+    "no",
+    "NO",
+    "N",
+    "n",
+    "False",
+    "false",
+    "FALSE",
+    "F",
+    "f",
+    "",
+)
 TRUTHY_TEST_VALUES = ("1", "yes", "True", "anystring")
 
 

--- a/tests/unit/test_core/test_mode.py
+++ b/tests/unit/test_core/test_mode.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
 import copy
-import os
 import re
 import typing
 import warnings
-from contextlib import contextmanager
 from unittest.mock import Mock
 
 import pytest

--- a/tests/unit/test_core/test_prioritization.py
+++ b/tests/unit/test_core/test_prioritization.py
@@ -138,7 +138,8 @@ class TestOrderMethodsByPriority:
         WindowsA, LinuxA, LinuxB, WakepyFakeSuccess = get_methods(
             ["WinA", "LinuxA", "LinuxB", WAKEPY_FAKE_SUCCESS]
         )
-        # If WAKEPY_FAKE_SUCCESS is used, it is *always* prioritized the highest
+        # If WAKEPY_FAKE_SUCCESS is used, it is *always* prioritized the
+        # highest
         assert order_methods_by_priority(
             [WindowsA, LinuxA, LinuxB, WakepyFakeSuccess],
             methods_priority=["*"],
@@ -154,7 +155,8 @@ class TestOrderMethodsByPriority:
         WindowsA, LinuxA, LinuxB, WakepyFakeSuccess = get_methods(
             ["WinA", "LinuxA", "LinuxB", WAKEPY_FAKE_SUCCESS]
         )
-        # If WAKEPY_FAKE_SUCCESS is used, it is *always* prioritized the highest
+        # If WAKEPY_FAKE_SUCCESS is used, it is *always* prioritized the
+        # highest
         assert order_methods_by_priority(
             [WindowsA, LinuxA, LinuxB, WakepyFakeSuccess],
             methods_priority=[{"WinA", "LinuxB"}, "*"],

--- a/tests/unit/test_core/test_prioritization.py
+++ b/tests/unit/test_core/test_prioritization.py
@@ -6,6 +6,7 @@ import typing
 import pytest
 
 from wakepy.core import PlatformName
+from wakepy.core.constants import WAKEPY_FAKE_SUCCESS
 from wakepy.core.prioritization import (
     _check_methods_priority,
     _order_set_of_methods_by_priority,
@@ -131,6 +132,38 @@ class TestOrderMethodsByPriority:
         assert order_methods_by_priority(
             [LinuxA, LinuxB, WindowsA, WindowsB, LinuxC, MultiPlatformA],
         ) == [MultiPlatformA, WindowsA, WindowsB, LinuxA, LinuxB, LinuxC]
+
+    @pytest.mark.usefixtures("set_current_platform_to_linux")
+    def test_fake_success_prioritized_first_asterisk(self):
+        WindowsA, LinuxA, LinuxB, WakepyFakeSuccess = get_methods(
+            ["WinA", "LinuxA", "LinuxB", WAKEPY_FAKE_SUCCESS]
+        )
+        # If WAKEPY_FAKE_SUCCESS is used, it is *always* prioritized the highest
+        assert order_methods_by_priority(
+            [WindowsA, LinuxA, LinuxB, WakepyFakeSuccess],
+            methods_priority=["*"],
+        ) == [
+            WakepyFakeSuccess,
+            LinuxA,
+            LinuxB,
+            WindowsA,
+        ]
+
+    @pytest.mark.usefixtures("set_current_platform_to_linux")
+    def test_fake_success_prioritized_first_set_before_asterisk(self):
+        WindowsA, LinuxA, LinuxB, WakepyFakeSuccess = get_methods(
+            ["WinA", "LinuxA", "LinuxB", WAKEPY_FAKE_SUCCESS]
+        )
+        # If WAKEPY_FAKE_SUCCESS is used, it is *always* prioritized the highest
+        assert order_methods_by_priority(
+            [WindowsA, LinuxA, LinuxB, WakepyFakeSuccess],
+            methods_priority=[{"WinA", "LinuxB"}, "*"],
+        ) == [
+            WakepyFakeSuccess,  # always first.
+            LinuxB,  # platform is linux so it comes before WinA
+            WindowsA,
+            LinuxA,
+        ]
 
 
 @pytest.mark.usefixtures("provide_methods_a_f")

--- a/tests/unit/test_modes.py
+++ b/tests/unit/test_modes.py
@@ -122,7 +122,7 @@ def test_keep_presenting(monkeypatch, fake_dbus_adapter):
 
 
 @pytest.mark.parametrize(
-    "modefactory, expected_name",
+    "mode_under_test, expected_name",
     [
         (keep.running, "keep.running"),
         (keep.presenting, "keep.presenting"),
@@ -132,23 +132,23 @@ class TestOnFail:
     """Test failure handling for keep.presenting and keep.running. (the on_fail
     parameter)"""
 
-    def test_on_fail_pass(self, modefactory, expected_name):
-        with modefactory(methods=[], on_fail="pass") as m:
+    def test_on_fail_pass(self, mode_under_test, expected_name):
+        with mode_under_test(methods=[], on_fail="pass") as m:
             self._assertions_for_activation_failure(m, expected_name)
 
-    def test_on_fail_warn(self, modefactory, expected_name):
+    def test_on_fail_warn(self, mode_under_test, expected_name):
         err_txt = f'Could not activate Mode "{expected_name}"!'
         with pytest.warns(UserWarning, match=re.escape(err_txt)):
-            with modefactory(methods=[], on_fail="warn") as m:
+            with mode_under_test(methods=[], on_fail="warn") as m:
                 self._assertions_for_activation_failure(m, expected_name)
 
-    def test_on_fail_error(self, modefactory, expected_name):
+    def test_on_fail_error(self, mode_under_test, expected_name):
         err_txt = f'Could not activate Mode "{expected_name}"!'
         with pytest.raises(ActivationError, match=re.escape(err_txt)):
-            with modefactory(methods=[], on_fail="error") as m:
+            with mode_under_test(methods=[], on_fail="error") as m:
                 self._assertions_for_activation_failure(m, expected_name)
 
-    def test_on_fail_callable(self, modefactory, expected_name):
+    def test_on_fail_callable(self, mode_under_test, expected_name):
         called = False
 
         def my_callable(result):
@@ -156,7 +156,7 @@ class TestOnFail:
             called = True
             assert isinstance(result, ActivationResult)
 
-        with modefactory(methods=[], on_fail=my_callable) as m:
+        with mode_under_test(methods=[], on_fail=my_callable) as m:
             assert called is True
             self._assertions_for_activation_failure(m, expected_name)
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,8 +11,6 @@ description = run the tests with pytest
 deps = -r{toxinidir}/requirements/requirements-test.txt
 passenv =
     DBUS_SESSION_BUS_ADDRESS
-setenv =
-    WAKEPY_FAKE_SUCCESS = "yes"
 commands =
     ; -W error: turn warnings into errors
     {envpython} -m pytest -W error {tty:--color=yes} \


### PR DESCRIPTION
* Checking WAKEPY_FAKE_SUCCESS env variable is only done in Mode._activate. If that is set to truthy value, insert the
  WakepyFakeSuccess method to the start of the methods list. This means that any Mode is quaranteed to be succesful with
  WAKEPY_FAKE_SUCCESS, but there's no guarantee for any particular Method (using Methods separately is not part of the public API  of wakepy, so this does not matter)
* WakepyFakeSuccess Method now always succeeds
* Always prioritize WAKEPY_FAKE_SUCCESS method to be the first,  if it is used.
* Update WAKEPY_FAKE_SUCCESS docs.