### PR TITLE
Update/simplufy Mode activation + Add unused Methods to ActivationResult

### DIFF
--- a/docs/source/img/mode-state-diagram.svg
+++ b/docs/source/img/mode-state-diagram.svg
@@ -140,7 +140,7 @@
          y="63.378372"
          id="tspan7">&quot;with mode&quot; -statement  <tspan
    style="font-style:italic;font-weight:normal"
-   id="tspan8">or mode.activate()</tspan></tspan></text>
+   id="tspan8">or mode._activate()</tspan></tspan></text>
     <text
        xml:space="preserve"
        style="font-size:3.01591px;line-height:normal;font-family:FreeSans;-inkscape-font-specification:'FreeSans, Normal';text-align:center;text-decoration-color:#000000;text-anchor:middle;fill:#2f2f2f;fill-opacity:0.579625;stroke-width:0.35;stroke-dashoffset:0.415748"
@@ -153,7 +153,7 @@
          y="116.73844"
          id="tspan7-1">&quot;with mode&quot; -block ends <tspan
    style="font-style:italic;font-weight:normal"
-   id="tspan9">or mode.deactivate()</tspan></tspan></text>
+   id="tspan9">or mode._deactivate()</tspan></tspan></text>
     <text
        xml:space="preserve"
        style="font-size:3.01591px;line-height:normal;font-family:FreeSans;-inkscape-font-specification:'FreeSans, Normal';text-align:center;text-decoration-color:#000000;text-anchor:middle;fill:#2f2f2f;fill-opacity:0.579625;stroke-width:0.35;stroke-dashoffset:0.415748"

--- a/docs/source/wakepy-mode-lifecycle.md
+++ b/docs/source/wakepy-mode-lifecycle.md
@@ -96,18 +96,16 @@ This will put the Mode into *Active* or *Activation Failed* state through the in
 
 (activating-a-mode-note)=
 ````{note}
-**Using mode.activate directly**:
-
-It is also possible to call `mode.activate()` directly, but using the `with` statement is highly recommended as it makes sure that deactivation is done even if there are exceptions within the `USER_CODE`. The above `with mode:...` is roughly equal to
+The above `with mode:...` is roughly equal to
 
 ```{code-block} python
 :emphasize-lines: 1
 
-mode.activate()
+mode._activate()
 try:
     USER_CODE
 finally:
-    mode.deactivate()
+    mode._deactivate()
 ```
 
 ````
@@ -116,7 +114,7 @@ The {numref}`fig-activate-mode-activity-diagram` presents an activity diagram fr
 - ***Prioritize Methods***: In this step, methods are prioritized first with `methods_priority` from the user, if given. Then, the methods are prioritized using platform support information from `Method.supported_platform`.
 - ***Activate with a Method***: Try to activate the Mode using the Method with highest priority. This is explained in more detail in the [next section](#section-activating-with-a-method). Note that only *one* Method is ever used to activate a Mode; the first one which does not fail, in priority order.
 
-This process happens in the `activate_one_of_methods` function and it returns an `ActivationResult` object, the used `wakepy.Method` instance (if successful)  and a `Heartbeat` instance (if used).
+This process happens in the `Mode._activate` method and it returns an `ActivationResult` object, the used `wakepy.Method` instance (if successful)  and a `Heartbeat` instance (if used).
 
 :::{figure-md} fig-activate-mode-activity-diagram
 ![activity diagram for the "Activate Mode" action](./img/activate-mode-activity-diagram.svg){width=430px}

--- a/docs/source/wakepy-mode-lifecycle.md
+++ b/docs/source/wakepy-mode-lifecycle.md
@@ -116,7 +116,7 @@ The {numref}`fig-activate-mode-activity-diagram` presents an activity diagram fr
 - ***Prioritize Methods***: In this step, methods are prioritized first with `methods_priority` from the user, if given. Then, the methods are prioritized using platform support information from `Method.supported_platform`.
 - ***Activate with a Method***: Try to activate the Mode using the Method with highest priority. This is explained in more detail in the [next section](#section-activating-with-a-method). Note that only *one* Method is ever used to activate a Mode; the first one which does not fail, in priority order.
 
-This process happens in the `activate_mode` function and it returns an `ActivationResult` object, the used `wakepy.Method` instance (if successful)  and a `Heartbeat` instance (if used).
+This process happens in the `activate_one_of_methods` function and it returns an `ActivationResult` object, the used `wakepy.Method` instance (if successful)  and a `Heartbeat` instance (if used).
 
 :::{figure-md} fig-activate-mode-activity-diagram
 ![activity diagram for the "Activate Mode" action](./img/activate-mode-activity-diagram.svg){width=430px}

--- a/src/wakepy/core/mode.py
+++ b/src/wakepy/core/mode.py
@@ -288,6 +288,9 @@ class Mode:
         """Activates the mode with one of the methods which belong to the mode.
         The methods are used with descending priority; highest priority first,
         and the priority is determined with the mode.methods_priority.
+
+        The activation may be faked as to be successful by using the
+        WAKEPY_FAKE_SUCCESS environment variable.
         """
         if not self._dbus_adapter:
             self._dbus_adapter = get_dbus_adapter(self._dbus_adapter_cls)
@@ -465,11 +468,8 @@ def activate_mode(
     modename: Optional[str] = None,
 ) -> Tuple[ActivationResult, Optional[Method], Optional[Heartbeat]]:
     """Activates a mode defined by a collection of Methods. Only the first
-    Method which succeeds activation will be used, in order from highest
-    priority to lowest priority.
-
-    The activation may be faked as to be successful by using the
-    WAKEPY_FAKE_SUCCESS environment variable.
+    Method which succeeds activation will be used. The methods are tried in the
+    order given in `methods` argument.
 
     Parameters
     ----------

--- a/src/wakepy/core/mode.py
+++ b/src/wakepy/core/mode.py
@@ -172,8 +172,8 @@ class Mode:
 
         self._dbus_adapter_cls = dbus_adapter
         # Retrieved and updated using the _dbus_adapter property
-        self.__dbus_adapter_instance: DBusAdapter | None = None
-        self.__dbus_adapter_created: bool = False
+        self._dbus_adapter_instance: DBusAdapter | None = None
+        self._dbus_adapter_created: bool = False
 
         self._logger = logging.getLogger(__name__)
 
@@ -349,12 +349,12 @@ class Mode:
     def _dbus_adapter(self) -> DBusAdapter | None:
         """The DbusAdapter instance of the Mode, if any. Created on the first
         call."""
-        if not self.__dbus_adapter_created:
+        if not self._dbus_adapter_created:
             # Only do this once even if the returned instance is None, as this
             # might be a costly operation.
-            self.__dbus_adapter_instance = get_dbus_adapter(self._dbus_adapter_cls)
-            self.__dbus_adapter_created = True
-        return self.__dbus_adapter_instance
+            self._dbus_adapter_instance = get_dbus_adapter(self._dbus_adapter_cls)
+            self._dbus_adapter_created = True
+        return self._dbus_adapter_instance
 
 
 def select_methods(

--- a/src/wakepy/core/mode.py
+++ b/src/wakepy/core/mode.py
@@ -302,10 +302,12 @@ class Mode:
             method_classes, self.methods_priority
         )
 
-        self.activation_result, self.active_method, self.heartbeat = activate_mode(
-            methods=method_classes_ordered,
-            dbus_adapter=self._dbus_adapter,
-            modename=self.name,
+        self.activation_result, self.active_method, self.heartbeat = (
+            activate_one_of_methods(
+                methods=method_classes_ordered,
+                dbus_adapter=self._dbus_adapter,
+                modename=self.name,
+            )
         )
         self.active = self.activation_result.success
 
@@ -473,7 +475,7 @@ def should_fake_success(wakepy_fake_success: str | None) -> bool:
     return True
 
 
-def activate_mode(
+def activate_one_of_methods(
     methods: list[Type[Method]],
     dbus_adapter: Optional[DBusAdapter] = None,
     modename: Optional[str] = None,

--- a/tests/unit/test_core/test_mode.py
+++ b/tests/unit/test_core/test_mode.py
@@ -15,7 +15,7 @@ from wakepy.core.dbus import DBusAdapter
 from wakepy.core.heartbeat import Heartbeat
 from wakepy.core.mode import (
     ModeExit,
-    activate_mode,
+    activate_one_of_methods,
     add_fake_success_if_required,
     handle_activation_fail,
     select_methods,
@@ -329,10 +329,10 @@ class TestShouldFakeSuccess:
 
 
 class TestActivateMode:
-    """tests for activate_mode"""
+    """tests for activate_one_of_methods"""
 
     def test_activate_without_methods(self):
-        res, active_method, heartbeat = activate_mode([], None)
+        res, active_method, heartbeat = activate_one_of_methods([], None)
         assert res.list_methods() == []
         assert res.success is False
         assert active_method is None
@@ -343,7 +343,7 @@ class TestActivateMode:
         methodcls_fail = get_test_method_class(enter_mode=Exception("error"))
         methodcls_success = get_test_method_class(enter_mode=None)
 
-        result, active_method, heartbeat = activate_mode(
+        result, active_method, heartbeat = activate_one_of_methods(
             [methodcls_success, methodcls_fail],
         )
 
@@ -357,7 +357,7 @@ class TestActivateMode:
             enter_mode=None, heartbeat=None
         )
 
-        result, active_method, heartbeat = activate_mode(
+        result, active_method, heartbeat = activate_one_of_methods(
             [methodcls_success_with_hb],
         )
 
@@ -370,7 +370,7 @@ class TestActivateMode:
     def test_activate_function_failure(self):
         methodcls_fail = get_test_method_class(enter_mode=Exception("error"))
 
-        result, active_method, heartbeat = activate_mode([methodcls_fail])
+        result, active_method, heartbeat = activate_one_of_methods([methodcls_fail])
 
         # The activation failed, so active_method and heartbeat is None
         assert result.success is False

--- a/tests/unit/test_core/test_mode.py
+++ b/tests/unit/test_core/test_mode.py
@@ -356,24 +356,12 @@ class TestActivateMode:
         result, active_method, heartbeat = activate_mode(
             [methodcls_success, methodcls_fail],
             dbus_adapter=mocks.dbus_adapter,
-            methods_priority=[
-                methodcls_fail.name,
-                methodcls_success.name,
-            ],
         )
 
         # Assert
 
         # There is a successful method, so the activation succeeds.
         assert result.success is True
-
-        # The failing method is tried first because there is prioritization
-        # step which honors the `methods_priority`
-        assert [x.method_name for x in result.list_methods()] == [
-            methodcls_fail.name,
-            methodcls_success.name,
-        ]
-
         assert isinstance(active_method, methodcls_success)
         assert heartbeat is mocks.heartbeat
 


### PR DESCRIPTION
**Update Mode activation**
* Return list of MethodActivationResult instead a single ActivationResult. This way the function does not require method
  name as arg.
* Fix: Also the unused results are included in ActivationResult (and list of MethodActivationResult).
* Try to create the DbusAdapter instance for the Mode only once, even if the creation was unsuccesful the previous time.
  
**Simplifications**
* Simplify the Mode._activate
* Move activate_mode to Mode._activate_one_of_methods and simplify
* Simplify the Mode._activate_one_of_methods tests and remove Mocks.

