### PR TITLE
Additional mypy runs on 3.7, 3.8, 3.9, 3.11 and 3.12 + fix mypy checks on py37-py39

### DIFF
--- a/.github/workflows/build-and-run-tests.yml
+++ b/.github/workflows/build-and-run-tests.yml
@@ -83,16 +83,20 @@ jobs:
 
   check-code:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.7", "3.10", "3.12"]
+
     steps:
       - uses: actions/checkout@v4
       - name: Install python
         uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d #v5.1
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: ${{ matrix.python-version }}
       - name: install tox
         run: |
-          python${{ env.PYTHON_VERSION }} -m pip install -U pip wheel && \
-          python${{ env.PYTHON_VERSION }} -m pip install ${{ env.TOX_REQUIREMENT }}
+          python${{ matrix.python-version }} -m pip install -U pip wheel && \
+          python${{ matrix.python-version }} -m pip install ${{ env.TOX_REQUIREMENT }}
       - name: Check code
         run: tox -e check
 

--- a/.github/workflows/build-and-run-tests.yml
+++ b/.github/workflows/build-and-run-tests.yml
@@ -83,9 +83,31 @@ jobs:
 
   check-code:
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install python
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d #v5.1
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: install tox
+        run: |
+          python${{ env.PYTHON_VERSION }} -m pip install -U pip wheel && \
+          python${{ env.PYTHON_VERSION }} -m pip install ${{ env.TOX_REQUIREMENT }}
+      - name: Check code
+        run: tox -e check
+
+  mypy-check-src:
+    # This is an *additional* check for mypy using the oldest and newest
+    # supported python
+    runs-on: ubuntu-latest
+    # Note that it's not possible to build the package using python 3.7
+    # (build is only tested on the env.PYTHON_VERSION). Therefore this mypy
+    # check just uses the build from the previous step. And build is required
+    # since it creates the wakepy._version module.
+    needs: build-python-distributions
     strategy:
       matrix:
-        python-version: ["3.7", "3.10", "3.12"]
+        python-version: ["3.7", "3.12"]
 
     steps:
       - uses: actions/checkout@v4
@@ -94,11 +116,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: install tox
-        run: |
-          python${{ matrix.python-version }} -m pip install -U pip wheel && \
-          python${{ matrix.python-version }} -m pip install ${{ env.TOX_REQUIREMENT }}
+        run: python${{ matrix.python-version }} -m pip install ${{ env.TOX_REQUIREMENT }}
       - name: Check code
-        run: tox -e check
+        run: tox -e mypy --skip-build
 
   test-build-docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-run-tests.yml
+++ b/.github/workflows/build-and-run-tests.yml
@@ -111,6 +111,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: wakepy-python-packages
+          path: ./dist/
       - name: Install python
         uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d #v5.1
         with:

--- a/.github/workflows/build-and-run-tests.yml
+++ b/.github/workflows/build-and-run-tests.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Check code
         run: tox -e check
 
-  mypy-check-src:
+  additional-mypy-checks:
     # This is an *additional* check for mypy using the oldest and newest
     # supported python
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-run-tests.yml
+++ b/.github/workflows/build-and-run-tests.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.7", "3.10", "3.12"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
 
     steps:

--- a/.github/workflows/build-and-run-tests.yml
+++ b/.github/workflows/build-and-run-tests.yml
@@ -107,7 +107,7 @@ jobs:
     needs: build-python-distributions
     strategy:
       matrix:
-        python-version: ["3.7", "3.10", "3.12"]
+        python-version: ["3.7", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-and-run-tests.yml
+++ b/.github/workflows/build-and-run-tests.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.7", "3.10", "3.12"]
 
 
     steps:

--- a/.github/workflows/build-and-run-tests.yml
+++ b/.github/workflows/build-and-run-tests.yml
@@ -107,7 +107,7 @@ jobs:
     needs: build-python-distributions
     strategy:
       matrix:
-        python-version: ["3.7", "3.12"]
+        python-version: ["3.7", "3.10", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-and-run-tests.yml
+++ b/.github/workflows/build-and-run-tests.yml
@@ -107,7 +107,7 @@ jobs:
     needs: build-python-distributions
     strategy:
       matrix:
-        python-version: ["3.7", "3.12"]
+        python-version: ["3.7", "3.8", "3.9", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/requirements/requirements-check.txt
+++ b/requirements/requirements-check.txt
@@ -1,13 +1,6 @@
 # requirements for code style; linters, code analysis and formatting tools
 invoke==2.2.0
 black==24.2.0
-mypy==1.9.0
 isort==5.13.2
 ruff==0.3.2
-
-# The following are for mypy
-# some version of pytest required for checking types. Perhaps any recent
-# version of pytest will do.
-pytest
-types-colorama
-time-machine==2.14.0
+-r requirements-mypy.txt

--- a/requirements/requirements-mypy.txt
+++ b/requirements/requirements-mypy.txt
@@ -6,10 +6,8 @@ mypy==1.4.1; python_version=='3.7'
 
 # The following installs are for mypy.
 pytest -c requirements-test.txt
+time-machine -c requirements-test.txt
 
 types-colorama
 types-colorama==0.4.15.12; python_version>='3.7'
 
-time-machine==2.14.0; python_version>='3.8'
-# Last time-machine version to support Python 3.7
-time-machine==2.10.0; python_version>='3.8'

--- a/requirements/requirements-mypy.txt
+++ b/requirements/requirements-mypy.txt
@@ -1,0 +1,15 @@
+# mypy 1.9.0 only supports Python 3.8+
+mypy==1.9.0; python_version>='3.8'
+# Last mypy version to support Python 3.7
+mypy==1.4.1; python_version=='3.7'
+
+
+# The following installs are for mypy.
+pytest -c requirements-test.txt
+
+types-colorama
+types-colorama==0.4.15.12; python_version>='3.7'
+
+time-machine==2.14.0; python_version>='3.8'
+# Last time-machine version to support Python 3.7
+time-machine==2.10.0; python_version>='3.8'

--- a/src/wakepy/core/mode.py
+++ b/src/wakepy/core/mode.py
@@ -26,15 +26,22 @@ from .prioritization import order_methods_by_priority
 from .registry import get_method, get_methods_for_mode
 
 if typing.TYPE_CHECKING:
+    import sys
     from types import TracebackType
-    from typing import Callable, List, Literal, Optional, Tuple, Type
+    from typing import Callable, List, Optional, Tuple, Type, Union
 
     from .constants import Collection, ModeName, StrCollection
     from .dbus import DBusAdapter, DBusAdapterTypeSeq
     from .method import Method, MethodCls
     from .prioritization import MethodsPriorityOrder
 
-    OnFail = Literal["error", "warn", "pass"] | Callable[[ActivationResult], None]
+
+    if sys.version_info < (3, 8):  # pragma: no-cover-if-py-gte-38
+        from typing_extensions import Literal
+    else:  # pragma: no-cover-if-py-lt-38
+        from typing import Literal
+
+    OnFail = Union[Literal["error", "warn", "pass"], Callable[[ActivationResult], None]]
 
     MethodClsCollection = Collection[MethodCls]
 

--- a/src/wakepy/core/mode.py
+++ b/src/wakepy/core/mode.py
@@ -35,7 +35,6 @@ if typing.TYPE_CHECKING:
     from .method import Method, MethodCls
     from .prioritization import MethodsPriorityOrder
 
-
     if sys.version_info < (3, 8):  # pragma: no-cover-if-py-gte-38
         from typing_extensions import Literal
     else:  # pragma: no-cover-if-py-lt-38

--- a/src/wakepy/core/prioritization.py
+++ b/src/wakepy/core/prioritization.py
@@ -18,12 +18,18 @@ from .constants import WAKEPY_FAKE_SUCCESS
 from .platform import CURRENT_PLATFORM
 
 if typing.TYPE_CHECKING:
-    from typing import Callable, List, Literal, Optional, Tuple
+    import sys
+    from typing import Callable, List, Optional, Tuple, Union
 
     from .constants import Collection
     from .method import MethodCls
 
-    OnFail = Literal["error", "warn", "pass"] | Callable[[ActivationResult], None]
+    if sys.version_info < (3, 8):  # pragma: no-cover-if-py-gte-38
+        from typing_extensions import Literal
+    else:  # pragma: no-cover-if-py-lt-38
+        from typing import Literal
+
+    OnFail = Union[Literal["error", "warn", "pass"], Callable[[ActivationResult], None]]
 
     MethodClsCollection = Collection[MethodCls]
 

--- a/src/wakepy/core/prioritization.py
+++ b/src/wakepy/core/prioritization.py
@@ -13,25 +13,13 @@ from __future__ import annotations
 import typing
 from typing import List, Sequence, Set, Union
 
-from .activationresult import ActivationResult
 from .constants import WAKEPY_FAKE_SUCCESS
 from .platform import CURRENT_PLATFORM
 
 if typing.TYPE_CHECKING:
-    import sys
-    from typing import Callable, List, Optional, Tuple, Union
+    from typing import List, Optional, Tuple, Union
 
-    from .constants import Collection
     from .method import MethodCls
-
-    if sys.version_info < (3, 8):  # pragma: no-cover-if-py-gte-38
-        from typing_extensions import Literal
-    else:  # pragma: no-cover-if-py-lt-38
-        from typing import Literal
-
-    OnFail = Union[Literal["error", "warn", "pass"], Callable[[ActivationResult], None]]
-
-    MethodClsCollection = Collection[MethodCls]
 
     """The strings in MethodsPriorityOrder are names of wakepy.Methods or the
     asterisk ('*')."""

--- a/src/wakepy/core/registry.py
+++ b/src/wakepy/core/registry.py
@@ -24,6 +24,7 @@ from .constants import ModeName, ModeNameValue
 
 if typing.TYPE_CHECKING:
     from typing import (
+        Dict,
         List,
         Optional,
         Set,
@@ -40,8 +41,8 @@ if typing.TYPE_CHECKING:
     T = TypeVar("T")
 
     Collection: TypeAlias = Union[List[T], Tuple[T, ...], Set[T]]
-    MethodDict = dict[str, MethodCls]
-    MethodRegistry = dict[str, MethodDict]
+    MethodDict = Dict[str, MethodCls]
+    MethodRegistry = Dict[str, MethodDict]
 
 
 _method_registry: MethodRegistry = dict()

--- a/src/wakepy/core/registry.py
+++ b/src/wakepy/core/registry.py
@@ -23,24 +23,13 @@ from typing import overload
 from .constants import ModeName, ModeNameValue
 
 if typing.TYPE_CHECKING:
-    from typing import (
-        Dict,
-        List,
-        Optional,
-        Set,
-        Tuple,
-        Type,
-        TypeAlias,
-        TypeVar,
-        Union,
-        overload,
-    )
+    from typing import Dict, List, Optional, Set, Tuple, Type, TypeVar, Union, overload
 
     from wakepy.core.method import Method, MethodCls
 
     T = TypeVar("T")
 
-    Collection: TypeAlias = Union[List[T], Tuple[T, ...], Set[T]]
+    Collection = Union[List[T], Tuple[T, ...], Set[T]]
     MethodDict = Dict[str, MethodCls]
     MethodRegistry = Dict[str, MethodDict]
 

--- a/tox.ini
+++ b/tox.ini
@@ -37,6 +37,15 @@ commands =
     python -m ruff check --no-fix .
     python -m mypy .
 
+[testenv:mypy]
+; This is a separate tox environment from the 'check' as this one
+; is means to be ran solely in the CI pipelines and used to check the
+; code with mypy using the oldest supported python version.
+description = Run mypy for /src
+deps = -r{toxinidir}/requirements/requirements-mypy.txt
+commands =
+    python -m mypy src
+
 [testenv:builddocs]
 description = Build documentation
 deps = -r{toxinidir}/requirements/requirements-docs.txt


### PR DESCRIPTION
As wakepy is a type annotated library and supports python versions from 3.7 to 3.12, and supported type annotations depend on the used version of python, the mypy checks should be running also on versions other than 3.10. 

Added mypy checks to CI pipelines, running on Python 3.7, 3.8, 3.9, 3.11 and 3.12

This revealed that the static type checks were failing on versions 3.7-3.9. Fixed the errors.