### PR TITLE
Be more explicit in tests about which test is settings the WAKEPY_FAKE_SUCCESS + add test for missing methods in a Mode

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -39,7 +39,7 @@ def testutils():
 def empty_method_registry_fixture(monkeypatch):
     TestUtils.empty_method_registry(monkeypatch)
 
+
 @pytest.fixture(scope="function", name="WAKEPY_FAKE_SUCCESS_eq_1")
 def _wakepy_fake_success_fixture(monkeypatch):
     monkeypatch.setenv("WAKEPY_FAKE_SUCCESS", "1")
-

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -20,18 +20,14 @@ class TestUtils:
     """
 
     @staticmethod
-    def empty_method_registry(monkeypatch, fake_success=False):
+    def empty_method_registry(monkeypatch):
         """
         Make the method registry empty for duration of a test. Keep
-        the WakepyFakeSuccess method in the registry. and optionally set the
-        WAKEPY_FAKE_SUCCESS flag to a truthy value (if `fake_success` is True).
+        the WakepyFakeSuccess method in the registry.
         """
         monkeypatch.setattr("wakepy.core.registry._method_registry", (dict()))
         # The fake method should always be part of the registry.
         register_method(WakepyFakeSuccess)
-
-        if fake_success:
-            monkeypatch.setenv("WAKEPY_FAKE_SUCCESS", "1")
 
 
 @pytest.fixture(scope="session")
@@ -42,3 +38,8 @@ def testutils():
 @pytest.fixture(scope="function", name="empty_method_registry")
 def empty_method_registry_fixture(monkeypatch):
     TestUtils.empty_method_registry(monkeypatch)
+
+@pytest.fixture(scope="function", name="WAKEPY_FAKE_SUCCESS_eq_1")
+def _wakepy_fake_success_fixture(monkeypatch):
+    monkeypatch.setenv("WAKEPY_FAKE_SUCCESS", "1")
+

--- a/tests/unit/test_core/test_mode.py
+++ b/tests/unit/test_core/test_mode.py
@@ -44,7 +44,7 @@ def testmode_cls():
 @pytest.fixture
 def methods_abc(monkeypatch, testutils) -> List[Type[Method]]:
     """This fixture creates three methods, which belong to a given mode."""
-    testutils.empty_method_registry(monkeypatch, fake_success=True)
+    testutils.empty_method_registry(monkeypatch)
 
     class MethodA(Method):
         name = "MethodA"
@@ -95,38 +95,51 @@ def mode1_with_dbus(
     )
 
 
-def test_mode_contextmanager_protocol(
-    mode0: Mode,
-):
-    """Test that the Mode fulfills the context manager protocol"""
-    flag_end_of_with_block = False
+class TestModeContextManager:
 
-    # Test that the context manager protocol works
-    with mode0 as m:
+    @pytest.mark.usefixtures('WAKEPY_FAKE_SUCCESS_eq_1')
+    def test_mode_contextmanager_protocol(self,
+        mode0: Mode,
+    ):
+        """Test that the Mode fulfills the context manager protocol"""
+        flag_end_of_with_block = False
 
-        # The __enter__ returns the Mode
-        assert m is mode0
-        # We have activated the Mode
-        assert mode0.active
-        # There is an ActivationResult available in .activation_result
-        assert isinstance(m.activation_result, ActivationResult)
-        # The active method is also available
-        assert isinstance(mode0.active_method, Method)
+        # Test that the context manager protocol works
+        with mode0 as m:
 
-        activation_result = copy.deepcopy(m.activation_result)
-        flag_end_of_with_block = True
+            # The __enter__ returns the Mode
+            assert m is mode0
+            # We have activated the Mode
+            assert mode0.active
+            # There is an ActivationResult available in .activation_result
+            assert isinstance(m.activation_result, ActivationResult)
+            # The active method is also available
+            assert isinstance(mode0.active_method, Method)
 
-    # reached the end of the with block
-    assert flag_end_of_with_block
+            activation_result = copy.deepcopy(m.activation_result)
+            flag_end_of_with_block = True
 
-    # After exiting the mode, Mode.active is set to False
-    assert m.active is False
-    # The active_method is set to None
-    assert m.active_method is None
-    # The activation result is still there (not removed during deactivation)
-    assert activation_result == m.activation_result
+        # reached the end of the with block
+        assert flag_end_of_with_block
+
+        # After exiting the mode, Mode.active is set to False
+        assert m.active is False
+        # The active_method is set to None
+        assert m.active_method is None
+        # The activation result is still there (not removed during deactivation)
+        assert activation_result == m.activation_result
 
 
+    @pytest.mark.usefixtures('WAKEPY_FAKE_SUCCESS_eq_1')
+    def test_no_methods_succeeds_when_using_fake_success(self,
+    ):
+        # This will not fail as when the Mode is activated, the
+        # WakepyFakeSuccess method is added to the list of used methods.
+        with Mode(methods=[]):
+            ...
+
+
+@pytest.mark.usefixtures('WAKEPY_FAKE_SUCCESS_eq_1')
 class TestModeActivateDeactivate:
     """Tests for Mode._activate and Mode._deactivate"""
 
@@ -155,7 +168,7 @@ class TestModeActivateDeactivate:
                 # Setting active method
                 mode0.active_method = None
 
-
+@pytest.mark.usefixtures('WAKEPY_FAKE_SUCCESS_eq_1')
 class TestExitModeWithException:
     """Test cases when a Mode is exited with an Exception"""
 

--- a/tests/unit/test_core/test_mode.py
+++ b/tests/unit/test_core/test_mode.py
@@ -97,8 +97,9 @@ def mode1_with_dbus(
 
 class TestModeContextManager:
 
-    @pytest.mark.usefixtures('WAKEPY_FAKE_SUCCESS_eq_1')
-    def test_mode_contextmanager_protocol(self,
+    @pytest.mark.usefixtures("WAKEPY_FAKE_SUCCESS_eq_1")
+    def test_mode_contextmanager_protocol(
+        self,
         mode0: Mode,
     ):
         """Test that the Mode fulfills the context manager protocol"""
@@ -126,12 +127,13 @@ class TestModeContextManager:
         assert m.active is False
         # The active_method is set to None
         assert m.active_method is None
-        # The activation result is still there (not removed during deactivation)
+        # The activation result is still there (not removed during
+        # deactivation)
         assert activation_result == m.activation_result
 
-
-    @pytest.mark.usefixtures('WAKEPY_FAKE_SUCCESS_eq_1')
-    def test_no_methods_succeeds_when_using_fake_success(self,
+    @pytest.mark.usefixtures("WAKEPY_FAKE_SUCCESS_eq_1")
+    def test_no_methods_succeeds_when_using_fake_success(
+        self,
     ):
         # This will not fail as when the Mode is activated, the
         # WakepyFakeSuccess method is added to the list of used methods.
@@ -139,7 +141,7 @@ class TestModeContextManager:
             ...
 
 
-@pytest.mark.usefixtures('WAKEPY_FAKE_SUCCESS_eq_1')
+@pytest.mark.usefixtures("WAKEPY_FAKE_SUCCESS_eq_1")
 class TestModeActivateDeactivate:
     """Tests for Mode._activate and Mode._deactivate"""
 
@@ -168,7 +170,8 @@ class TestModeActivateDeactivate:
                 # Setting active method
                 mode0.active_method = None
 
-@pytest.mark.usefixtures('WAKEPY_FAKE_SUCCESS_eq_1')
+
+@pytest.mark.usefixtures("WAKEPY_FAKE_SUCCESS_eq_1")
 class TestExitModeWithException:
     """Test cases when a Mode is exited with an Exception"""
 


### PR DESCRIPTION
Be more explicit in tests about which test is settings the WAKEPY_FAKE_SUCCESS.

Add test: Mode without any methods (empty list) should still activate if WAKEPY_FAKE_SUCCESS is used. 