### PR TITLE
Remove MethodError

### DIFF
--- a/src/wakepy/core/method.py
+++ b/src/wakepy/core/method.py
@@ -36,10 +36,6 @@ if typing.TYPE_CHECKING:
 MethodCls = Type["Method"]
 
 
-class MethodError(RuntimeError):
-    """Occurred inside wakepy.core.method.Method"""
-
-
 class MethodOutcome(StrEnum):
     NOT_IMPLEMENTED = auto()
     SUCCESS = auto()
@@ -301,7 +297,7 @@ def deactivate_method(method: Method, heartbeat: Optional[Heartbeat] = None) -> 
 
     Raises
     ------
-    MethodError (RuntimeError), if the deactivation was not successful.
+    RuntimeError, if the deactivation was not successful.
     """
 
     heartbeat_stopped = heartbeat.stop() if heartbeat is not None else True
@@ -324,10 +320,10 @@ def deactivate_method(method: Method, heartbeat: Optional[Heartbeat] = None) -> 
             if retval is not None:
                 raise ValueError("exit_mode returned a value other than None!")
         except Exception as e:
-            raise MethodError(errortxt + "Original error: " + str(e))
+            raise RuntimeError(errortxt + "Original error: " + str(e))
 
     if heartbeat_stopped is not True:
-        raise MethodError(
+        raise RuntimeError(
             f"The heartbeat of {method.__class__.__name__} ({method.name}) could not "
             "be stopped! Suggesting submitting a bug report and rebooting for "
             "clearing the mode. "

--- a/src/wakepy/core/mode.py
+++ b/src/wakepy/core/mode.py
@@ -383,8 +383,8 @@ class Mode:
 
         Raises
         ------
-        MethodError (RuntimeError) if there was active method but an error
-        occurred when trying to deactivate it."""
+        RuntimeError, if there was active method but an error occurred when
+        trying to deactivate it."""
 
         if self.active:
             if self._active_method is None:

--- a/tests/unit/test_core/test_method/test_activation.py
+++ b/tests/unit/test_core/test_method/test_activation.py
@@ -21,7 +21,6 @@ from wakepy.core import Method, MethodActivationResult, PlatformName, get_method
 from wakepy.core.constants import StageName, StageNameValue
 from wakepy.core.heartbeat import Heartbeat
 from wakepy.core.method import (
-    MethodError,
     activate_method,
     caniuse_fails,
     deactivate_method,
@@ -460,7 +459,7 @@ class TestDeactivateMethod:
     def test_fail_deactivation_at_exit_mode_bad_value(self):
         method = get_test_method_class(enter_mode=None, exit_mode=123)()
         with pytest.raises(
-            MethodError,
+            RuntimeError,
             match=re.escape(
                 f"The exit_mode of '{method.__class__.__name__}' ({method.name}) was "
                 "unsuccessful!"
@@ -473,7 +472,7 @@ class TestDeactivateMethod:
     def test_fail_deactivation_at_exit_mode_raises_exception(self):
         method = get_test_method_class(enter_mode=None, exit_mode=Exception("oh no"))()
         with pytest.raises(
-            MethodError,
+            RuntimeError,
             match=re.escape(
                 f"The exit_mode of '{method.__class__.__name__}' ({method.name}) was "
                 "unsuccessful"
@@ -487,7 +486,7 @@ class TestDeactivateMethod:
 
         method = get_test_method_class(enter_mode=None, exit_mode=None)()
         with pytest.raises(
-            MethodError,
+            RuntimeError,
             match=re.escape(
                 f"The heartbeat of {method.__class__.__name__} ({method.name}) could "
                 "not be stopped! Suggesting submitting a bug report and rebooting for "


### PR DESCRIPTION
The usage of MethodError does not seem systematic, and it is not clear when to use it. Replaced MethodError in the few places it was used with RuntimeError (MethodError's superclass).

Could add a MethodError or similar back if there is clear need for it. But for now, keeping it simple.