### PR TITLE
Rename: ActivationResult.get_failure_text()

### DIFF
--- a/src/wakepy/core/activationresult.py
+++ b/src/wakepy/core/activationresult.py
@@ -173,7 +173,7 @@ class ActivationResult:
 
         return out
 
-    def get_error_text(self) -> str:
+    def get_failure_text(self) -> str:
         """Gets information about a failure as text. In case the mode
         activation was successful, returns an empty string."""
 

--- a/src/wakepy/core/mode.py
+++ b/src/wakepy/core/mode.py
@@ -549,10 +549,10 @@ def handle_activation_fail(on_fail: OnFail, result: ActivationResult) -> None:
     if on_fail == "pass":
         return
     elif on_fail == "warn":
-        warnings.warn(result.get_error_text())
+        warnings.warn(result.get_failure_text())
         return
     elif on_fail == "error":
-        raise ActivationError(result.get_error_text())
+        raise ActivationError(result.get_failure_text())
     elif not callable(on_fail):
         raise ValueError(
             'on_fail must be one of "error", "warn", pass" or a callable which takes '

--- a/tests/unit/test_core/test_activationresult.py
+++ b/tests/unit/test_core/test_activationresult.py
@@ -288,14 +288,14 @@ class TestActivationResult:
             assert ar.real_success == real_success_expected
             assert ar.failure == (not success_expected)
 
-    def test_get_error_text_success(
+    def test_get_failure_text_success(
         self, method_activation_results1: List[MethodActivationResult]
     ):
         ar = ActivationResult(method_activation_results1)
         # error text is empty string in case of success.
-        assert ar.get_error_text() == ""
+        assert ar.get_failure_text() == ""
 
-    def test_get_error_text_failure(
+    def test_get_failure_text_failure(
         self,
         mr_platform_support_fail: MethodActivationResult,
         mr_requirements_fail: MethodActivationResult,
@@ -303,7 +303,7 @@ class TestActivationResult:
         ar = ActivationResult(
             [mr_platform_support_fail, mr_requirements_fail], modename="SomeMode"
         )
-        assert ar.get_error_text() == (
+        assert ar.get_failure_text() == (
             'Could not activate Mode "SomeMode"!\n\nMethod usage results, in order '
             "(highest priority first):\n[(FAIL @PLATFORM_SUPPORT, fail-platform, "
             '"Platform XYZ not supported!"), (FAIL @REQUIREMENTS, fail-requirements, '

--- a/tests/unit/test_core/test_mode.py
+++ b/tests/unit/test_core/test_mode.py
@@ -260,7 +260,7 @@ class TestHandleActivationFail:
     @staticmethod
     @pytest.fixture
     def error_text_match(result1):
-        return re.escape(result1.get_error_text())
+        return re.escape(result1.get_failure_text())
 
     def test_pass(self, result1):
         with warnings.catch_warnings():


### PR DESCRIPTION
was: get_error_text()

There are attributes called 'success' and 'failure' so it makes more sense if the method name is get_failure_text().