### PR TITLE
add more python versions to tests

### DIFF
--- a/.github/workflows/build-and-run-tests.yml
+++ b/.github/workflows/build-and-run-tests.yml
@@ -63,6 +63,7 @@ jobs:
         uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d #v5.1
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
 
       - name: Run tox
         run: |
@@ -92,6 +93,7 @@ jobs:
         uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d #v5.1
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
 
       - name: Run tox
         run: |

--- a/.github/workflows/build-and-run-tests.yml
+++ b/.github/workflows/build-and-run-tests.yml
@@ -44,6 +44,7 @@ jobs:
           retention-days: 1
 
   test-supported-python-versions:
+    name: Tests (${{ matrix.python-version }} @${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     needs: build-python-distributions
     strategy:
@@ -70,6 +71,7 @@ jobs:
           tox -e show-uncovered-lines
 
   test-other-platforms:
+    name: Tests (${{ matrix.python-version }} @${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     needs: build-python-distributions
     strategy:

--- a/.github/workflows/build-and-run-tests.yml
+++ b/.github/workflows/build-and-run-tests.yml
@@ -83,10 +83,10 @@ jobs:
         python-version: ["3.7", "3.13"]
         exclude:
         - python-version: "3.7"
-          runs-on: macos-latest
+          os: macos-latest
         include:
           - python-version: "3.7"
-            runs-on: macos-13
+            os: macos-13
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-and-run-tests.yml
+++ b/.github/workflows/build-and-run-tests.yml
@@ -44,13 +44,28 @@ jobs:
           retention-days: 1
 
   test-supported-python-versions:
-    name: Tests (${{ matrix.python-version }} @${{ matrix.os }})
+    name: Tests (${{ matrix.python-version }} on ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     needs: build-python-distributions
     strategy:
       matrix:
         os: [ubuntu-latest]
+        # All supported python versions on linux
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        include:
+          # Oldest supported python on MacOS
+          - python-version: "3.7"
+            os: macos-13
+          # Newest supported python on MacOS
+          - python-version: "3.13"
+            os: macos-latest
+          # Oldest supported python on Windows
+          - python-version: "3.7"
+            os: windows-latest
+          # Newest supported python on Windows
+          - python-version: "3.13"
+            os: windows-latest
+      fail-fast: false
 
     steps:
       - uses: actions/checkout@v4
@@ -72,42 +87,6 @@ jobs:
           tox -e show-uncovered-lines
           tox -e mypy --skip-build
 
-  test-other-platforms:
-    name: Tests (${{ matrix.python-version }} @${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    needs: build-python-distributions
-    strategy:
-      matrix:
-        os: [macos-latest, windows-latest]
-        # Test only on oldest and newest supported versions
-        # different python versions are already tested in another step.
-        python-version: ["3.7", "3.13"]
-        exclude:
-        - python-version: "3.7"
-          os: macos-latest
-        include:
-          - python-version: "3.7"
-            os: macos-13
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
-        with:
-          name: wakepy-python-packages
-          path: ./dist/
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d #v5.1
-        with:
-          python-version: ${{ matrix.python-version }}
-          allow-prereleases: true
-
-      - name: Run tox
-        run: |
-          python -m pip install ${{ env.TOX_REQUIREMENT }}
-          tox -e ${{ matrix.python-version }} --skip-build
-          tox -e show-uncovered-lines
-
   check-code:
     # Reasons this is a separate job
     # (1) This runs fast. Different from the other steps, this does not require
@@ -119,6 +98,7 @@ jobs:
     #     folder. Note that some mypy check results depend on the used version
     #     of python and therefore it needs also a separate step (with multiple
     #     versions of python)
+    name: Check code
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -134,6 +114,7 @@ jobs:
         run: tox -e check
 
   test-build-docs:
+    name: Test building docs
     runs-on: ubuntu-latest
     needs: build-python-distributions
     steps:

--- a/.github/workflows/build-and-run-tests.yml
+++ b/.github/workflows/build-and-run-tests.yml
@@ -70,6 +70,7 @@ jobs:
           python -m pip install ${{ env.TOX_REQUIREMENT }}
           tox -e ${{ matrix.python-version }} --skip-build
           tox -e show-uncovered-lines
+          tox -e mypy --skip-build
 
   test-other-platforms:
     name: Tests (${{ matrix.python-version }} @${{ matrix.os }})
@@ -108,6 +109,16 @@ jobs:
           tox -e show-uncovered-lines
 
   check-code:
+    # Reasons this is a separate job
+    # (1) This runs fast. Different from the other steps, this does not require
+    #     the build step. It gives instant feedback if code has minor problems.
+    # (2) This runs isort + black + ruff + mypy. For most of there it is enough
+    #     to run it once with one version of python and one OS.
+    # (3) This runs more comprehensive mypy check as it checks also the tests
+    #     whereas the mypy check in test jobs only runs mypy on the /src
+    #     folder. Note that some mypy check results depend on the used version
+    #     of python and therefore it needs also a separate step (with multiple
+    #     versions of python)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -121,34 +132,6 @@ jobs:
           python${{ env.PYTHON_VERSION }} -m pip install ${{ env.TOX_REQUIREMENT }}
       - name: Check code
         run: tox -e check
-
-  additional-mypy-checks:
-    # This is an *additional* check for mypy using the oldest and newest
-    # supported python
-    runs-on: ubuntu-latest
-    # Note that it's not possible to build the package using python 3.7
-    # (build is only tested on the env.PYTHON_VERSION). Therefore this mypy
-    # check just uses the build from the previous step. And build is required
-    # since it creates the wakepy._version module.
-    needs: build-python-distributions
-    strategy:
-      matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.11", "3.12"]
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
-        with:
-          name: wakepy-python-packages
-          path: ./dist/
-      - name: Install python
-        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d #v5.1
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: install tox
-        run: python${{ matrix.python-version }} -m pip install ${{ env.TOX_REQUIREMENT }}
-      - name: Check code
-        run: tox -e mypy --skip-build
 
   test-build-docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-run-tests.yml
+++ b/.github/workflows/build-and-run-tests.yml
@@ -43,18 +43,16 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  test:
+  test-supported-python-versions:
     runs-on: ${{ matrix.os }}
     needs: build-python-distributions
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.7", "3.10", "3.12"]
-
+        os: [ubuntu-latest]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4
-
       - uses: actions/download-artifact@v4
         with:
           name: wakepy-python-packages
@@ -65,21 +63,39 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: install tox
+      - name: Run tox
         run: |
-          python -m pip install -U pip wheel &&
           python -m pip install ${{ env.TOX_REQUIREMENT }}
+          tox -e ${{ matrix.python-version }} --skip-build
+          tox -e show-uncovered-lines
 
-      - run: python -c "import sys; print(sys.executable)"
-      - run: python -c "import platform; print(platform.platform())"
+  test-other-platforms:
+    runs-on: ${{ matrix.os }}
+    needs: build-python-distributions
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest]
+        # Test only on oldest and newest supported versions
+        # different python versions are already tested in another step.
+        python-version: ["3.7", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: wakepy-python-packages
+          path: ./dist/
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d #v5.1
+        with:
+          python-version: ${{ matrix.python-version }}
 
       - name: Run tox
-        run: tox -e ${{ matrix.python-version }} --skip-build
-
-      - name: Show lines not covered by tests
-        # No need to run this is all tests and coverage check passes
-        if: failure()
-        run: tox -e show-uncovered-lines
+        run: |
+          python -m pip install ${{ env.TOX_REQUIREMENT }}
+          tox -e ${{ matrix.python-version }} --skip-build
+          tox -e show-uncovered-lines
 
   check-code:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-run-tests.yml
+++ b/.github/workflows/build-and-run-tests.yml
@@ -81,6 +81,12 @@ jobs:
         # Test only on oldest and newest supported versions
         # different python versions are already tested in another step.
         python-version: ["3.7", "3.13"]
+        exclude:
+        - python-version: "3.7"
+          runs-on: macos-latest
+        include:
+          - python-version: "3.7"
+            runs-on: macos-13
 
     steps:
       - uses: actions/checkout@v4

--- a/src/wakepy/methods/windows.py
+++ b/src/wakepy/methods/windows.py
@@ -38,7 +38,7 @@ class WindowsSetThreadExecutionState(Method, ABC):
 
     def _call_set_thread_execution_state(self, flags: int) -> None:
         try:
-            ctypes.windll.kernel32.SetThreadExecutionState(flags)  # type:ignore
+            ctypes.windll.kernel32.SetThreadExecutionState(flags)  # type: ignore[attr-defined,unused-ignore]
         except AttributeError as exc:
             raise RuntimeError("Could not use kernel32.dll!") from exc
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,12 @@
 [tox]
 envlist =
     py37
+    py38
+    py39
     py310
+    py311
     py312
+    py313
     check
 minversion = 4.8.0
 


### PR DESCRIPTION

* Add tests for python 3.8, 3.9, 3.11 and 3.13
* Test with all versions of python on linux
* Test with only the oldest and newest version of python on macos and
  windows
* Always run mypy for /src in tests. Do this in the test job instead of
  using a separate job.

Test matrix
-----------

was: 3.7, 3.10, 3.12 (linux, windows, mac)

now: 3.7 - 3.13 (linux)
     3.7 & 3.13 (windows, mac