### PR TITLE
Issue 276 gnome sessionmanager

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,7 @@ exclude_lines = [
     "if (?:typing\\.)?TYPE_CHECKING:",
     "@(abc\\.)?abstractmethod",
     "@(typing\\.)?overload",
+    "raise NotImplementedError"
 ]
 
 [tool.coverage.coverage_conditional_plugin.omit]

--- a/src/wakepy/core/dbus.py
+++ b/src/wakepy/core/dbus.py
@@ -279,6 +279,10 @@ class DBusAdapter:
     wakepy (Modes).
     """
 
+    def __init__(self) -> None:
+        # The values are DBusConnections. Type is defined by the used library.
+        self._connections: Dict[Optional[Union[str, BusType]], object] = dict()
+
     def process(self, call: DBusMethodCall) -> object:
         """Processes a :class:`~wakepy.core.DBusMethodCall`.
 
@@ -289,6 +293,29 @@ class DBusAdapter:
           bus to use (session / system / custom addr), the connection must be
           created within the :func:`~wakepy.DBusAdapter.process` call (this may
           of course be cached)."""
+
+    def _get_connection(
+        self, bus: Optional[Union[str, BusType]] = BusType.SESSION
+    ) -> object:
+        """Gets either a new connection or a cached one, if there is such.
+        Caching of connections is done on bus level."""
+
+        if bus in self._connections:
+            return self._connections[bus]
+
+        connection = self._create_new_connection(bus)
+
+        self._connections[bus] = connection
+        return connection
+
+    def _create_new_connection(
+        self, bus: Optional[Union[str, BusType]] = BusType.SESSION
+    ) -> object:
+        """Create a new Dbus connection for a bus using the library of choice.
+        For example, when creating DBusAdapter subclass for jeepney, could
+        return an instance of ``jeepney.io.blocking.DBusConnection``.
+        """
+        raise NotImplementedError("Implement in subclass")
 
 
 def get_dbus_adapter(

--- a/src/wakepy/core/dbus.py
+++ b/src/wakepy/core/dbus.py
@@ -264,7 +264,7 @@ class DBusMethodCall:
         return f"<{self.method.service} {self.args} | bus: {self.method.bus}>"
 
 
-class DBusAdapter:
+class DBusAdapter:  # pragma: no-cover-if-no-dbus
     """Defines the DBusAdapter interface. This is to be subclassed, and each
     subclass is usually an implementation for a DBusAdapter using single
     python (dbus-)library.

--- a/tasks.py
+++ b/tasks.py
@@ -86,7 +86,8 @@ def test(c, pdb: bool = False) -> None:
     run = get_run_with_print(c)
     pdb_flag = " --pdb " if pdb else ""
     res = run(
-        f"python -m pytest {pdb_flag}--cov-branch --cov wakepy --cov-fail-under=100",
+        f"env -u DBUS_SESSION_BUS_ADDRESS python -m pytest {pdb_flag}--cov-branch "
+        "--cov wakepy --cov-fail-under=100",
         ignore_errors=True,
     )
     if res.exited:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -6,6 +6,7 @@ import gc
 import logging
 import subprocess
 import sys
+import warnings
 
 import pytest
 
@@ -32,7 +33,11 @@ def gc_collect_after_dbus_integration_tests():
     # this as garbage colletion is triggered also automatically. The garbage
     # collection must be triggered here manually as the warnings are
     # ResourceWarning is only filtered away in the dbus integration tests.
-    gc.collect()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        gc.collect()
+
     logger.debug("called gc.collect")
 
 

--- a/tests/integration/test_dbus_adapters.py
+++ b/tests/integration/test_dbus_adapters.py
@@ -182,9 +182,9 @@ class TestFailuresOnConnectionCreation:
                 self.adapter.process(self.call)
 
 
-def test_jeepney_adapter_caching():
+def test_jeepney_adapter_caching(private_bus: str):
     adapter = JeepneyDBusAdapter()
-    con = adapter._get_connection("SESSION")
+    con = adapter._get_connection(private_bus)
 
     # Call again with same bus name -> get same (cached) connection.
-    assert adapter._get_connection("SESSION") is con
+    assert adapter._get_connection(private_bus) is con

--- a/tests/integration/test_dbus_adapters.py
+++ b/tests/integration/test_dbus_adapters.py
@@ -180,3 +180,11 @@ class TestFailuresOnConnectionCreation:
                 match="Some other reason",
             ):
                 self.adapter.process(self.call)
+
+
+def test_jeepney_adapter_caching():
+    adapter = JeepneyDBusAdapter()
+    con = adapter._get_connection("SESSION")
+
+    # Call again with same bus name -> get same (cached) connection.
+    assert adapter._get_connection("SESSION") is con

--- a/tox.ini
+++ b/tox.ini
@@ -13,8 +13,6 @@ minversion = 4.8.0
 [testenv]
 description = run the tests with pytest
 deps = -r{toxinidir}/requirements/requirements-test.txt
-passenv =
-    DBUS_SESSION_BUS_ADDRESS
 commands =
     ; -W error: turn warnings into errors
     {envpython} -m pytest -W error {tty:--color=yes} \


### PR DESCRIPTION
Fixes the error with Gnome SessionManager based keepawake (#276)

DBus Adapters
-------------
* All DBusAdapters now have to keep reference to the connection(s).  This was required as if the connection instance was garbage collected, the inhibit cookie created by Gnome SessionManager was wiped. 
  
* The DBusAdapter class now has _get_connection(bus) method or getting a connection instance for an adapter.
  
* The DBusAdapter subclasses now must implement a _create_new_connection(bus) method.
  
Other
----

Temporarily ignore warnings in tests/integration/conftest.py while running gc.collect(). This should be addressed later (likely as part of https://github.com/fohrloop/wakepy/issues/277)

