### PR TITLE
raise exception on warnings when running tests with "inv test"

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -86,8 +86,8 @@ def test(c, pdb: bool = False) -> None:
     run = get_run_with_print(c)
     pdb_flag = " --pdb " if pdb else ""
     res = run(
-        f"env -u DBUS_SESSION_BUS_ADDRESS python -m pytest {pdb_flag}--cov-branch "
-        "--cov wakepy --cov-fail-under=100",
+        f"env -u DBUS_SESSION_BUS_ADDRESS python -m pytest -W error {pdb_flag}"
+        "--cov-branch --cov wakepy --cov-fail-under=100",
         ignore_errors=True,
     )
     if res.exited:


### PR DESCRIPTION
When running tests with tox, and if there's a warning issued, the tests fail. This option was not used previously in tasks.py (for "invoke test"). 

Now, warnings will fail tests also when running "invoke test" (or: "inv test").