### PR TITLE
Reduce impact of org.gnome.SessionManager slow-down / freeze (issue 277)

### DIFF
--- a/docs/source/methods-reference.md
+++ b/docs/source/methods-reference.md
@@ -26,6 +26,12 @@ Methods are different ways of entering/keeping in a Mode. A Method may support o
 - **Requirements**: D-Bus, GNOME Desktop Environment with gnome-session running. The exact version of required GNOME is unknown, but this should work from GNOME 2.24 ([2008-09-23](https://gitlab.gnome.org/GNOME/gnome-session/-/tags/GNOME_SESSION_2_24_0)) onwards. See [version history of org.gnome.SessionManager.xml](https://gitlab.gnome.org/GNOME/gnome-session/-/commits/main/gnome-session/org.gnome.SessionManager.xml). At least [this](https://fedoraproject.org/wiki/Desktop/Whiteboards/InhibitApis) and [this](https://bugzilla.redhat.com/show_bug.cgi?id=529287#c3) mention GNOME 2.24.
 - **Tested on**:  Ubuntu 22.04.3 LTS with GNOME 42.9 ([PR #138](https://github.com/fohrloop/wakepy/pull/138) by [fohrloop](https://github.com/fohrloop/)).
 
+````{admonition} May slow down system if called repeatedly
+:class: warning
+
+If used hundreds or thousands of times, may slow down system. See: [wakepy/#277](https://github.com/fohrloop/wakepy/issues/277)
+````
+
 (keep-running-windows-stes)=
 ### SetThreadExecutionState
 
@@ -33,7 +39,6 @@ Methods are different ways of entering/keeping in a Mode. A Method may support o
 :class: warning
 
 Since this method prevents sleep, screen can be only locked automatically if a screen saver is enabled and it set to ask for password. See [this](#checking-if-windows-will-lock-screen-automatically) for details.
-
 
 ````
 
@@ -105,6 +110,12 @@ print('SPI_GETSCREENSAVETIMEOUT', retval.value)
 - **How to check it?**: Similarly as checking [keep.running](#keep-running-org-gnome-sessionmanager) using org.gnome.SessionManager.
 - **Requirements**: Same as [keep.running](#keep-running-org-gnome-sessionmanager) using org.gnome.SessionManager.
 - **Tested on**:  Ubuntu 22.04.3 LTS with GNOME 42.9 ([PR #138](https://github.com/fohrloop/wakepy/pull/138) by [fohrloop](https://github.com/fohrloop/)).
+
+````{admonition} May slow down system if called repeatedly
+:class: warning
+
+If used hundreds or thousands of times, may slow down system. See: [wakepy/#277](https://github.com/fohrloop/wakepy/issues/277)
+````
 
 (keep-presenting-org-freedesktop-screensaver)=
 ### org.freedesktop.ScreenSaver

--- a/src/wakepy/core/dbus.py
+++ b/src/wakepy/core/dbus.py
@@ -317,6 +317,15 @@ class DBusAdapter:  # pragma: no-cover-if-no-dbus
         """
         raise NotImplementedError("Implement in subclass")
 
+    def close_connections(self):
+        """Close all the connections open in this adapter."""
+        for connection in self._connections.values():
+            self.close_connection(connection)
+
+    def close_connection(self, connection: object):
+        """Close a dbus connection. Implement in a subclass"""
+        raise NotImplementedError("Implement in subclass")
+
 
 def get_dbus_adapter(
     dbus_adapter: Optional[Type[DBusAdapter] | DBusAdapterTypeSeq] = None,

--- a/src/wakepy/core/dbus.py
+++ b/src/wakepy/core/dbus.py
@@ -318,7 +318,7 @@ class DBusAdapter:  # pragma: no-cover-if-no-dbus
         """
         raise NotImplementedError("Implement in subclass")
 
-    def close_connections(self):
+    def close_connections(self) -> None:
         """Close all the connections open in this adapter."""
 
         for bus in list(self._connections):
@@ -334,7 +334,7 @@ class DBusAdapter:  # pragma: no-cover-if-no-dbus
             # See: https://github.com/fohrloop/wakepy/issues/277
             gc.collect()
 
-    def close_connection(self, connection: object):
+    def close_connection(self, connection: object) -> None:
         """Close a dbus connection. Implement in a subclass"""
         raise NotImplementedError("Implement in subclass")
 

--- a/src/wakepy/core/method.py
+++ b/src/wakepy/core/method.py
@@ -368,6 +368,9 @@ def deactivate_method(method: Method, heartbeat: Optional[Heartbeat] = None) -> 
             "clearing the mode. "
         )
 
+    if method.dbus_adapter:
+        method.dbus_adapter.close_connections()
+
 
 def get_platform_supported(method: Method, platform: PlatformName) -> bool:
     """Checks if method is supported by the platform

--- a/src/wakepy/dbus_adapters/jeepney.py
+++ b/src/wakepy/dbus_adapters/jeepney.py
@@ -1,3 +1,5 @@
+# mypy: disable-error-code="no-any-unimported"
+
 from __future__ import annotations
 
 import typing
@@ -42,12 +44,12 @@ class JeepneyDBusAdapter(DBusAdapter):
             body=call.args,
         )
 
-        connection = cast(DBusConnection, self._get_connection(call.method.bus))  # type: ignore[no-any-unimported]
+        connection = cast(DBusConnection, self._get_connection(call.method.bus))
         reply = connection.send_and_get_reply(msg, timeout=self.timeout)
         resp = unwrap_msg(reply)
         return resp
 
-    def _create_new_connection(  # type: ignore[no-any-unimported]
+    def _create_new_connection(
         self, bus: TypeOfBus = BusType.SESSION
     ) -> DBusConnection:
         try:
@@ -65,5 +67,5 @@ class JeepneyDBusAdapter(DBusAdapter):
             else:
                 raise
 
-    def close_connection(self, connection: DBusConnection):
+    def close_connection(self, connection: DBusConnection) -> None:
         connection.close()

--- a/src/wakepy/dbus_adapters/jeepney.py
+++ b/src/wakepy/dbus_adapters/jeepney.py
@@ -64,3 +64,6 @@ class JeepneyDBusAdapter(DBusAdapter):
                 ) from exc
             else:
                 raise
+
+    def close_connection(self, connection: DBusConnection):
+        connection.close()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -6,7 +6,6 @@ import gc
 import logging
 import subprocess
 import sys
-import warnings
 
 import pytest
 
@@ -33,10 +32,7 @@ def gc_collect_after_dbus_integration_tests():
     # this as garbage colletion is triggered also automatically. The garbage
     # collection must be triggered here manually as the warnings are
     # ResourceWarning is only filtered away in the dbus integration tests.
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        gc.collect()
+    gc.collect()
 
     logger.debug("called gc.collect")
 

--- a/tests/integration/test_dbus_adapters.py
+++ b/tests/integration/test_dbus_adapters.py
@@ -177,6 +177,16 @@ class TestFailuresOnConnectionCreation:
 
 
 class TestJeepneyDbusAdapter:
+
+    def test_close_connections(self, private_bus: str):
+        adapter = JeepneyDBusAdapter()
+        con = adapter._get_connection(private_bus)
+        # There seems to be no other way checking that the connection is
+        # active..?
+        assert not con.sock._closed  # type: ignore[attr-defined]
+        adapter.close_connections()
+        assert con.sock._closed  # type: ignore[attr-defined]
+
     def test_adapter_caching(self, private_bus: str):
         adapter = JeepneyDBusAdapter()
         con = adapter._get_connection(private_bus)


### PR DESCRIPTION
This provides a partial solution to #277

Previously: Using the org.gnome.SessionManager method repeatedly would
freeze system in 400-600 iterations.

Now: Get to ~2000 iterations before system freezes. 

Contents
--------
* Dbus connections are now closed. In addition, gc.collect() is called
  each time connection is closed (at least for now), as adding it helped
  to get more iteration cycles.
* Add warning to docs of org.gnome.SessionManager
* bonus: Some refactoring of dbus adapter tests + remove the temporary
  warning ignore introduced in #278. 