### PR TITLE
update setuptools-scm from 8.0.4 to 8.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ Changelog = "https://wakepy.readthedocs.io/stable/changelog.html"
 wakepy = "wakepy.__main__:main"
 
 [build-system]
-requires = ["setuptools==69.1.0", "setuptools_scm==8.0.4"]
+requires = ["setuptools==69.1.0", "setuptools_scm==8.1.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/tox.ini
+++ b/tox.ini
@@ -79,7 +79,7 @@ deps =
     ; Build tested working only on python 3.10. (and will not work on python
     ; 3.7)
     setuptools==69.1.0; python_version>='3.10'
-    setuptools_scm==8.0.4; python_version>='3.10'
+    setuptools_scm==8.1.0; python_version>='3.10'
     wheel==0.43.0; python_version>='3.10'
 commands =
     ; See also the tox_on_install in toxfile.py which is guaranteed to be


### PR DESCRIPTION
This tries to fix the failing pipeline in #297

See, for example https://github.com/apache/arrow/issues -> 41563
and https://github.com/pypa/setuptools_scm/issues -> 1038