### PR TITLE
modify the workflow file

### DIFF
--- a/.github/workflows/publish-a-release.yml
+++ b/.github/workflows/publish-a-release.yml
@@ -1,10 +1,11 @@
 name: Publish a wakepy release 📦
 
+# This workflow creates and pushes releases to PyPI and to GitHub Releases.
+# It can only be started manually.
+# NOTE: Before making a release, push a new tag to main branch. This workflow
+# uses the latest tag for setting the wakepy release version number.
 'on':
   workflow_dispatch:
-  push:
-    branches:
-      - main
 
 jobs:
 
@@ -36,8 +37,6 @@ jobs:
 
   publish-to-pypi:
     name: Publish wakepy to PyPI
-    # only publish to PyPI on tag pushes
-    if: startsWith(github.ref, 'refs/tags/')
     needs: sign-artifacts
     runs-on: ubuntu-latest
     environment:
@@ -57,8 +56,6 @@ jobs:
 
   publish-to-github-releases:
     name: Publish wakepy to GitHub
-    # only publish to GitHub Releases on tag pushes
-    if: startsWith(github.ref, 'refs/tags/')
     needs: sign-artifacts
     runs-on: ubuntu-latest
     environment:


### PR DESCRIPTION
Fixes #300

Changes how the publish-a-release workflow is triggered.

Previously
* PR merged to main or manual trigger
* Release required tag push to main -> never released.

Now:
* Only manual trigger
* Release does not require a tag push -> Triggering the workflow
  manually will build and release.