### PR TITLE
Fix publishing pipeline (Issue 304)

### DIFF
--- a/.github/workflows/publish-a-release.yml
+++ b/.github/workflows/publish-a-release.yml
@@ -37,7 +37,7 @@ jobs:
 
   publish-to-pypi:
     name: 📦 Publish wakepy to PyPI
-    needs: sign-artifacts
+    needs: build-and-test
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -47,7 +47,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: signed-wakepy-python-packages
+          name: wakepy-python-packages
           path: ./dist/
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@81e9d935c883d0b210363ab89cf05f3894778450 #v1.8.14

--- a/.github/workflows/publish-a-release.yml
+++ b/.github/workflows/publish-a-release.yml
@@ -36,7 +36,7 @@ jobs:
           retention-days: 1
 
   publish-to-pypi:
-    name: Publish wakepy to PyPI
+    name: 📦 Publish wakepy to PyPI
     needs: sign-artifacts
     runs-on: ubuntu-latest
     environment:
@@ -55,7 +55,7 @@ jobs:
           print-hash: true
 
   publish-to-github-releases:
-    name: Publish wakepy to GitHub
+    name: 📦 Publish wakepy to GitHub
     needs: sign-artifacts
     runs-on: ubuntu-latest
     environment:

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## wakepy 0.8.0
-🗓️ 2024-05-25
+🗓️ 2024-05-26
 
 ### 🏆 Highlights
 - This is a basically a complete rewrite of wakepy. It adds support for keep.running mode on Gnome, on-fail action, possibility to control the used methods and their priority, more information about the used methods and the activation process and possibility to exit the mode early. In addition, testing and CI pipelines were updated to ease maintenance.


### PR DESCRIPTION
Fixes #304

The publishing job failed in the pipelines because PyPI does not support
uploading the signature files. Upload the non-signed versions to PyPI
and signed versions to GitHub Releases.

Also update the 0.8.0 release date to 2024-05-26.