### PR TITLE
shift CLI cpinner one character to right

### DIFF
--- a/src/wakepy/__main__.py
+++ b/src/wakepy/__main__.py
@@ -164,7 +164,7 @@ def wait_until_keyboardinterrupt() -> None:
     spinner_symbols = ["⢎⡰", "⢎⡡", "⢎⡑", "⢎⠱", "⠎⡱", "⢊⡱", "⢌⡱", "⢆⡱"]
     try:
         for spinner_symbol in itertools.cycle(spinner_symbols):  # pragma: no branch
-            print("\r" + spinner_symbol + r" [Press Ctrl+C to exit] ", end="")
+            print("\r " + spinner_symbol + r" [Press Ctrl+C to exit] ", end="")
             time.sleep(0.8)
     except KeyboardInterrupt:
         pass


### PR DESCRIPTION
This aligns it better with rest of the stuff above.

Before:
```
                  _
                 | |
 __      __ __ _ | | __ ___  _ __   _   _
 \ \ /\ / // _` || |/ // _ \| '_ \ | | | |
  \ V  V /| (_| ||   <|  __/| |_) || |_| |
   \_/\_/  \__,_||_|\_\\___|| .__/  \__, |
  v.0.8.0                   | |      __/ |
                            |_|     |___/ 
 [x] System will continue running programs
 [x] Presentation mode is on

⠎⡱ [Press Ctrl+C to exit] ^C

```

After:

```
                  _
                 | |
 __      __ __ _ | | __ ___  _ __   _   _
 \ \ /\ / // _` || |/ // _ \| '_ \ | | | |
  \ V  V /| (_| ||   <|  __/| |_) || |_| |
   \_/\_/  \__,_||_|\_\\___|| .__/  \__, |
  v.0.8.0                   | |      __/ |
                            |_|     |___/ 
 [x] System will continue running programs
 [x] Presentation mode is on

 ⠎⡱ [Press Ctrl+C to exit] ^C

```