### PR TITLE
Docs: Fix supported platforms table background on dark theme

### DIFF
--- a/docs/source/_static/wakepy-docs.css
+++ b/docs/source/_static/wakepy-docs.css
@@ -9,6 +9,10 @@ html[data-theme=light] {
     --wakepy-color-inline-code: #d70936;
     --wakepy-color-code-block-bg: #fcfcfd;
     --wakepy-color-code-block-border: #d1d5da;
+    /* tables */
+    --wakepy-table-color-header-bg: #f6f6f6;
+    --wakepy-table-color-bg: #fff;
+    --wakepy-table-color-border: #ddd;
     /* Regular links color */
     --pst-color-link: #0250e3;
     /* Navigation links color */
@@ -23,6 +27,9 @@ html[data-theme=dark] {
     --wakepy-color-inline-code:#dd7886;
     --wakepy-color-code-block-bg: #272822;
     --wakepy-color-code-block-border: #3c3d2e;
+    --wakepy-table-color-header-bg: #29313d;
+    --wakepy-table-color-bg: #0f1216;
+    --wakepy-table-color-border: #29313d;
     /* Regular links color */
     --pst-color-link: #6e91d8;
     /* Navigation links color */
@@ -102,13 +109,13 @@ dl.py > dd > ul {
 
 .wakepy-table th,
 .wakepy-table td {
-  border: 1px solid #ddd;
+  border: 1px solid var(--wakepy-table-color-border);
   padding: 12px;
   text-align: left;
 }
 
 .wakepy-table th {
-  background-color: #f6f6f6;
+  background-color: var(--wakepy-table-color-header-bg);
   font-weight: bold;
 }
 
@@ -117,5 +124,5 @@ dl.py > dd > ul {
 }
 
 .wakepy-table td {
-  background-color: #fff;
+  background-color: var(--wakepy-table-color-bg);
 }

--- a/docs/source/_static/wakepy-docs.css
+++ b/docs/source/_static/wakepy-docs.css
@@ -104,7 +104,8 @@ dl.py > dd > ul {
     border-collapse: collapse;
     border-radius: 8px;
     overflow: hidden;
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    border: 1px solid var(--wakepy-table-color-border);
+    outline: 1px solid var(--wakepy-table-color-border);
   }
 
 .wakepy-table th,

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -11,6 +11,7 @@
 - Document that the [org.freedesktop.ScreenSaver](keep-presenting-org-freedesktop-screensaver) method for keep.presenting mode also supports KDE Plasma. ([#324](https://github.com/fohrloop/wakepy/pull/324))
 - Update dev docs ([#308](https://github.com/fohrloop/wakepy/pull/308))
 - Mention that shell should be restarted for wakepy CLI tool ([#321](https://github.com/fohrloop/wakepy/pull/321))
+- Fix: Supported Platforms table background does not support dark mode ([#316](https://github.com/fohrloop/wakepy/pull/316))
 
 ## wakepy 0.8.0
 🗓️ 2024-05-26


### PR DESCRIPTION
Fixes: #316

There was a bug on the documentation overview page "Supported Platforms"
table: It had a white background even on dark theme. Now there's
separate background color for white and dark theme. Also fixed the
table's borders which were a bit disjoint.