### PR TITLE
fix docs: Update information about support on linux

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -42,16 +42,16 @@ Wakepy may keep the following systems awake:
       <td>Distributions using <a href="https://en.wikipedia.org/wiki/GNOME">GNOME</a></td>
     </tr>
     <tr>
-      <td>Distributions using <a href="https://en.wikipedia.org/wiki/KDE_Plasma">KDE Plasma</a><sup>[2]</sup></td>
+      <td>Distributions using <a href="https://en.wikipedia.org/wiki/KDE_Plasma">KDE Plasma</a></td>
     </tr>
     <tr>
-      <td>Any other Desktop Environments which implement the <a href="https://en.wikipedia.org/wiki/Freedesktop.org">Freedesktop.org</a> <a href="https://people.freedesktop.org/~hadess/idle-inhibition-spec/re01.html">ScreenSaver</a> interface<sup>[2]</sup></td>
+      <td>Any other Desktop Environments which implement the <a href="https://en.wikipedia.org/wiki/Freedesktop.org">Freedesktop.org</a> <a href="https://people.freedesktop.org/~hadess/idle-inhibition-spec/re01.html">org.freedesktop.ScreenSaver</a> and org.freedesktop.PowerManagement interfaces</td>
     </tr>
   </tbody>
 </table>
 
 <p style="margin-top:1em;">
-<sup>[1]</sup> The Linux support is under active development. Target is to support at least GNOME, KDE, Xfce, Cinnamon, LXQt and MATE Desktop Environments. <sup>[2]</sup> Only the presentation mode currently.<p>
+<sup>[1]</sup> The Linux support is under active development. Target is to support at least GNOME, KDE, Xfce, Cinnamon, LXQt and MATE Desktop Environments.
 
 ## Installing
 


### PR DESCRIPTION
fixes: #329

The table in the documentation had old information. It said that wakepy
only supports keep.presenting mode on KDE, but in reality the
keep.running mode is also supported on wakepy 0.9.0.