### PR TITLE
Fix: Isolate SetThreadExecutionState modes on same thread from each other

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -3,7 +3,7 @@
 ## wakepy 0.10.0
 🗓️ Unreleased
 
-### ✨ Features
+### 🐞 Bug fixes
 - The [SetThreadExecutionState](#windows-stes) Method may now have multiple modes (same or different) activated within the same python thread without them interfering with each other on activation or deactivation, as wakepy creates a *separate worker thread* for the single purpose of setting and keeping the thread execution flag each time you activate a mode with the `SetThreadExecutionState` wakepy.Method. ([#342](https://github.com/fohrloop/wakepy/pull/342))
 
 ## wakepy 0.9.0.post1

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## wakepy 0.10.0
+🗓️ Unreleased
+
+### ✨ Features
+- The [SetThreadExecutionState](#windows-stes) Method may now have multiple modes (same or different) activated within the same python thread without them interfering with each other on activation or deactivation, as wakepy creates a *separate worker thread* for the single purpose of setting and keeping the thread execution flag each time you activate a mode with the `SetThreadExecutionState` wakepy.Method.
+
 ## wakepy 0.9.0.post1
 🗓️ 2024-06-01
 

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -4,7 +4,7 @@
 🗓️ Unreleased
 
 ### ✨ Features
-- The [SetThreadExecutionState](#windows-stes) Method may now have multiple modes (same or different) activated within the same python thread without them interfering with each other on activation or deactivation, as wakepy creates a *separate worker thread* for the single purpose of setting and keeping the thread execution flag each time you activate a mode with the `SetThreadExecutionState` wakepy.Method.
+- The [SetThreadExecutionState](#windows-stes) Method may now have multiple modes (same or different) activated within the same python thread without them interfering with each other on activation or deactivation, as wakepy creates a *separate worker thread* for the single purpose of setting and keeping the thread execution flag each time you activate a mode with the `SetThreadExecutionState` wakepy.Method. ([#342](https://github.com/fohrloop/wakepy/pull/342))
 
 ## wakepy 0.9.0.post1
 🗓️ 2024-06-01

--- a/docs/source/methods-reference.md
+++ b/docs/source/methods-reference.md
@@ -4,13 +4,13 @@
 **What are wakepy Methods?**
 Methods are different ways of entering in (or keeping a) Mode. A Method may support one or more platforms, and may have one or more requirements for software it should be able to talk to or execute. For example, on Linux. using the Inhibit method of the [org.gnome.SessionManager](#org-gnome-sessionmanager) D-Bus service is one way of entering  the [`keep.running`](#keep-running-mode) mode, and it requires D-Bus and (a certain version of) GNOME. The following methods exist (⌛: [`keep.running`](#keep-running-mode), 🖥️: [`keep.presenting`](#keep-presenting-mode)): 
 
-| Method                          | Modes |
-| ------------------------------- | ----- |
-| [caffeinate](#macos-caffeinate) | ⌛ 🖥️ |
-| [org.freedesktop.PowerManagement](org-freedesktop-powermanagement) | ⌛ |
-| [org.freedesktop.ScreenSaver](org-freedesktop-screensaver) | 🖥️ |
-| [org.gnome.SessionManager](org-gnome-sessionmanager) | ⌛🖥️ |
-| [SetThreadExecutionState](windows-stes) | ⌛🖥️ |
+| Method                                                             | Modes |
+| ------------------------------------------------------------------ | ----- |
+| [caffeinate](#macos-caffeinate)                                    | ⌛ 🖥️   |
+| [org.freedesktop.PowerManagement](org-freedesktop-powermanagement) | ⌛     |
+| [org.freedesktop.ScreenSaver](org-freedesktop-screensaver)         | 🖥️     |
+| [org.gnome.SessionManager](org-gnome-sessionmanager)               | ⌛🖥️    |
+| [SetThreadExecutionState](windows-stes)                            | ⌛🖥️    |
 
 
 (macos-caffeinate)=
@@ -84,7 +84,8 @@ Since this method prevents sleep, screen can be only locked automatically if a s
 - **Name**: `SetThreadExecutionState`
 - **Modes**: [`keep.running`](#keep-running-mode), [`keep.presenting`](#keep-presenting-mode)
 - **Introduced in**: wakepy 0.1.0
-- **How it works**: It calls the [SetThreadExecutionState](https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-setthreadexecutionstate) function from the Kernel32.dll with ES_CONTINUOUS and ES_SYSTEM_REQUIRED flags when activating [`keep.running`](#keep-running-mode) mode, and additionally ES_DISPLAY_REQUIRED flag when activating [`keep.presenting`](#keep-presenting-mode) mode. Uses the  ES_CONTINUOUS flag for deactivating. Note that currently it is not possible to use two wakepy modes using SetThreadExecutionState at the same time in the same thread! (See: [Issue 167](https://github.com/fohrloop/wakepy/issues/167))
+- **How it works**: It calls the [SetThreadExecutionState](https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-setthreadexecutionstate) function from the Kernel32.dll with ES_CONTINUOUS and ES_SYSTEM_REQUIRED flags when activating [`keep.running`](#keep-running-mode) mode, and additionally ES_DISPLAY_REQUIRED flag when activating [`keep.presenting`](#keep-presenting-mode) mode. It then uses the ES_CONTINUOUS flag for deactivating.
+- **Wakepy specialities**: Note that as of wakepy 0.10.0 you can have multiple modes (same or different) activated within the same python thread without them interfering with each other on activation or deactivation, as wakepy creates a *separate worker thread* for the single purpose of setting and keeping the thread execution flag each time you activate a mode with the `SetThreadExecutionState` wakepy.Method.
 - **Multiprocess safe?**: Yes
 - **What if the process holding the lock dies?**: The lock is automatically removed.
 - **How to check it?**: Run `powercfg /requests` in an elevated cmd or Powershell.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,8 @@ exclude_lines = [
 [tool.coverage.coverage_conditional_plugin.omit]
 # Dbus adapters are only available on linux
 "platform_system != 'Linux'" = "**/wakepy/dbus_adapters/*.py"
+# Windows methods only need to be tested on Windows
+"platform_system != 'Windows'" = "**/wakepy/methods/windows.py"
 
 [tool.coverage.coverage_conditional_plugin.rules]
 no-cover-if-no-dbus = "platform_system != 'Linux'"

--- a/src/wakepy/methods/windows.py
+++ b/src/wakepy/methods/windows.py
@@ -67,9 +67,10 @@ class WindowsSetThreadExecutionState(Method, ABC):
         self._inhibiting_thread = None
 
     def _check_thread_response(self) -> None:
-        """Waits a message from the inhibitor thread queue. If the item put
-        into the queue is not None, raises an Exception. Re-raises any
-        Exceptions put into the queue.
+        """Waits a message from the inhibitor thread queue. It should be an
+        integer representing the previous thread execution state flags. If 
+        it's not, raises an Exception. Re-raises any Exceptions put into the
+        queue.
         """
         res = self._queue_from_thread.get(timeout=self._wait_timeout)
 

--- a/src/wakepy/methods/windows.py
+++ b/src/wakepy/methods/windows.py
@@ -135,7 +135,7 @@ def _call_set_thread_execution_state(flags: int) -> int:
         # This sets the return type to be unsigned 32-bit integer. Otherwise it
         # will be a signed 32-bit integer which is overflown. So for example
         # instead of returning 2147483649 it would return -2147483647.
-        ctypes.windll.kernel32.SetThreadExecutionState.restype = ctypes.c_uint32 # type: ignore[attr-defined,unused-ignore]
+        ctypes.windll.kernel32.SetThreadExecutionState.restype = ctypes.c_uint32  # type: ignore[attr-defined,unused-ignore]
         logger.debug(
             "Calling SetThreadExecutionState with flags: %s (%s)", flags, Flags(flags)
         )

--- a/src/wakepy/methods/windows.py
+++ b/src/wakepy/methods/windows.py
@@ -4,6 +4,7 @@ import ctypes
 import enum
 import logging
 import threading
+import typing
 from abc import ABC, abstractmethod
 from queue import Queue
 from threading import Event, Thread
@@ -94,7 +95,7 @@ def _inhibit_until_released(
     _call_and_put_result_in_queue(Flags.RELEASE.value, queue)
 
 
-_release_event_timeout = None
+_release_event_timeout: int | float | None = None
 """Timeout for the release events (to stop a inhibit thread). None means
 wait indefinitely. This attribute exists for tests (make tests not to
 wait forever).
@@ -147,7 +148,7 @@ def _call_set_thread_execution_state(flags: int) -> int:
     if retval == 0:
         raise RuntimeError("SetThreadExecutionState returned NULL")
 
-    return retval
+    return typing.cast(int, retval)
 
 
 class WindowsKeepRunning(WindowsSetThreadExecutionState):

--- a/src/wakepy/methods/windows.py
+++ b/src/wakepy/methods/windows.py
@@ -95,7 +95,7 @@ def _inhibit_until_released(
 
 
 _release_event_timeout = None
-"""Timeout for the release events (to stop a inhibit thread). None means 
+"""Timeout for the release events (to stop a inhibit thread). None means
 wait indefinitely. This attribute exists for tests (make tests not to
 wait forever).
 """

--- a/src/wakepy/methods/windows.py
+++ b/src/wakepy/methods/windows.py
@@ -88,8 +88,6 @@ class WindowsSetThreadExecutionState(Method, ABC):
 def _inhibit_until_released(
     flags: Flags, exit_event: Event, queue: Queue[int | Exception]
 ) -> None:
-    # Sets the flags until Flags.RELEASE is used or until the thread
-    # which called this dies.
     _call_and_put_result_in_queue(flags.value, queue)
     exit_event.wait(_release_event_timeout)
     _call_and_put_result_in_queue(Flags.RELEASE.value, queue)

--- a/src/wakepy/methods/windows.py
+++ b/src/wakepy/methods/windows.py
@@ -97,8 +97,8 @@ def _inhibit_until_released(
 
 _release_event_timeout: int | float | None = None
 """Timeout for the release events (to stop a inhibit thread). None means
-wait indefinitely. This attribute exists for tests (make tests not to
-wait forever).
+wait indefinitely. This variable exists for tests (edit this to make tests not
+to wait forever in case of errors).
 """
 
 

--- a/src/wakepy/methods/windows.py
+++ b/src/wakepy/methods/windows.py
@@ -135,7 +135,7 @@ def _call_set_thread_execution_state(flags: int) -> int:
         # This sets the return type to be unsigned 32-bit integer. Otherwise it
         # will be a signed 32-bit integer which is overflown. So for example
         # instead of returning 2147483649 it would return -2147483647.
-        ctypes.windll.kernel32.SetThreadExecutionState.restype = ctypes.c_uint32
+        ctypes.windll.kernel32.SetThreadExecutionState.restype = ctypes.c_uint32 # type: ignore[attr-defined,unused-ignore]
         logger.debug(
             "Calling SetThreadExecutionState with flags: %s (%s)", flags, Flags(flags)
         )

--- a/tasks.py
+++ b/tasks.py
@@ -34,7 +34,7 @@ tox -e build
 
 from __future__ import annotations
 
-import os 
+import os
 import platform
 import typing
 

--- a/tests/unit/test_methods/test_windows.py
+++ b/tests/unit/test_methods/test_windows.py
@@ -1,5 +1,7 @@
 from unittest.mock import patch
 
+
+import re
 import pytest
 
 from wakepy.methods.windows import (
@@ -103,3 +105,38 @@ class TestWindowsSetThreadExecutionState:
         with patch("wakepy.methods.windows.ctypes.windll.kernel32.SetThreadExecutionState", lambda x:0):
             with pytest.raises(RuntimeError, match="SetThreadExecutionState returned NULL"):
                 method.exit_mode()
+
+
+    @pytest.mark.parametrize(
+        "method_cls",
+        [WindowsKeepPresenting, WindowsKeepRunning],
+    )
+    def test_exit_mode_before_enter(self, method_cls):
+        # does not make much practical sense but required for test coverage
+        method = method_cls()
+        # need to add something to the queue; otherwise would wait until an exception
+        method._queue_from_thread.put(1)
+        method.exit_mode()
+        assert method._inhibiting_thread is None 
+
+
+
+    @pytest.mark.parametrize(
+        "method_cls, expected_flag",
+        [
+            (
+                WindowsKeepPresenting,
+                ES_CONTINUOUS | ES_SYSTEM_REQUIRED | ES_DISPLAY_REQUIRED,
+            ),
+            (WindowsKeepRunning, ES_CONTINUOUS | ES_SYSTEM_REQUIRED),
+        ],
+    )
+    def test_wrong_return_type_from_set_thread_execution_state(self, method_cls, expected_flag):
+        method = method_cls()
+
+        def set_thread_execution_state(flags):
+            return 'foo'
+
+        with patch("wakepy.methods.windows.ctypes.windll.kernel32.SetThreadExecutionState", set_thread_execution_state):
+            with pytest.raises(RuntimeError, match=re.escape("Unknown result type: <class 'str'> (foo)")):
+                method.enter_mode()

--- a/tests/unit/test_methods/test_windows.py
+++ b/tests/unit/test_methods/test_windows.py
@@ -1,7 +1,11 @@
 import re
+import sys
 from unittest.mock import patch
 
 import pytest
+
+if sys.platform != "win32":
+    pytest.skip(allow_module_level=True)
 
 import wakepy.methods.windows as windows
 from wakepy.methods.windows import (

--- a/tests/unit/test_methods/test_windows.py
+++ b/tests/unit/test_methods/test_windows.py
@@ -7,7 +7,7 @@ import pytest
 if sys.platform != "win32":
     pytest.skip(allow_module_level=True)
 
-import wakepy.methods.windows as windows # type: ignore[unreachable, unused-ignore]
+import wakepy.methods.windows as windows  # type: ignore[unreachable, unused-ignore]
 from wakepy.methods.windows import (
     ES_CONTINUOUS,
     ES_DISPLAY_REQUIRED,

--- a/tests/unit/test_methods/test_windows.py
+++ b/tests/unit/test_methods/test_windows.py
@@ -1,9 +1,9 @@
+import re
 from unittest.mock import patch
 
-
-import re
 import pytest
 
+import wakepy.methods.windows as windows
 from wakepy.methods.windows import (
     ES_CONTINUOUS,
     ES_DISPLAY_REQUIRED,
@@ -12,10 +12,10 @@ from wakepy.methods.windows import (
     WindowsKeepRunning,
 )
 
-import wakepy.methods.windows as windows
-
 windows._release_event_timeout = 0.001
 """Make tests *not* to wait forever"""
+
+
 class TestWindowsSetThreadExecutionState:
 
     @pytest.mark.parametrize(
@@ -35,11 +35,13 @@ class TestWindowsSetThreadExecutionState:
             assert flags == expected_flag
             return flags
 
-        with patch("wakepy.methods.windows.ctypes.windll.kernel32.SetThreadExecutionState", set_thread_execution_state):
+        with patch(
+            "wakepy.methods.windows.ctypes.windll.kernel32.SetThreadExecutionState",
+            set_thread_execution_state,
+        ):
             retval = method.enter_mode()
 
         assert retval is None
-
 
     @pytest.mark.parametrize(
         "method_cls",
@@ -48,14 +50,20 @@ class TestWindowsSetThreadExecutionState:
     def test_exit_mode_success(self, method_cls):
         method = method_cls()
         # prepare: enter the mode
-        with patch("wakepy.methods.windows.ctypes.windll.kernel32.SetThreadExecutionState", lambda x:x):
+        with patch(
+            "wakepy.methods.windows.ctypes.windll.kernel32.SetThreadExecutionState",
+            lambda x: x,
+        ):
             method.enter_mode()
 
         def set_thread_execution_state(flags):
             assert flags == ES_CONTINUOUS
             return flags
 
-        with patch("wakepy.methods.windows.ctypes.windll.kernel32.SetThreadExecutionState", set_thread_execution_state):
+        with patch(
+            "wakepy.methods.windows.ctypes.windll.kernel32.SetThreadExecutionState",
+            set_thread_execution_state,
+        ):
             retval = method.exit_mode()
 
         assert retval is None
@@ -70,7 +78,10 @@ class TestWindowsSetThreadExecutionState:
         def raising_exc(_):
             raise AttributeError("foo")
 
-        with patch("wakepy.methods.windows.ctypes.windll.kernel32.SetThreadExecutionState", raising_exc):
+        with patch(
+            "wakepy.methods.windows.ctypes.windll.kernel32.SetThreadExecutionState",
+            raising_exc,
+        ):
             with pytest.raises(RuntimeError, match="Could not use kernel32.dll!"):
                 method.enter_mode()
 
@@ -81,13 +92,19 @@ class TestWindowsSetThreadExecutionState:
     def test_exit_mode_with_exception(self, method_cls):
         method = method_cls()
 
-        with patch("wakepy.methods.windows.ctypes.windll.kernel32.SetThreadExecutionState", lambda x:x):
+        with patch(
+            "wakepy.methods.windows.ctypes.windll.kernel32.SetThreadExecutionState",
+            lambda x: x,
+        ):
             method.enter_mode()
 
         def raising_exc(_):
             raise AttributeError("foo")
 
-        with patch("wakepy.methods.windows.ctypes.windll.kernel32.SetThreadExecutionState", raising_exc):
+        with patch(
+            "wakepy.methods.windows.ctypes.windll.kernel32.SetThreadExecutionState",
+            raising_exc,
+        ):
             with pytest.raises(RuntimeError, match="Could not use kernel32.dll!"):
                 method.exit_mode()
 
@@ -98,14 +115,21 @@ class TestWindowsSetThreadExecutionState:
     def test_exit_mode_with_bad_return_value_from_thread(self, method_cls):
         method = method_cls()
 
-        with patch("wakepy.methods.windows.ctypes.windll.kernel32.SetThreadExecutionState", lambda x:x):
+        with patch(
+            "wakepy.methods.windows.ctypes.windll.kernel32.SetThreadExecutionState",
+            lambda x: x,
+        ):
             method.enter_mode()
 
         # returning 0 means returning NULL (error in SetThreadExecutionState call)
-        with patch("wakepy.methods.windows.ctypes.windll.kernel32.SetThreadExecutionState", lambda x:0):
-            with pytest.raises(RuntimeError, match="SetThreadExecutionState returned NULL"):
+        with patch(
+            "wakepy.methods.windows.ctypes.windll.kernel32.SetThreadExecutionState",
+            lambda x: 0,
+        ):
+            with pytest.raises(
+                RuntimeError, match="SetThreadExecutionState returned NULL"
+            ):
                 method.exit_mode()
-
 
     @pytest.mark.parametrize(
         "method_cls",
@@ -117,9 +141,7 @@ class TestWindowsSetThreadExecutionState:
         # need to add something to the queue; otherwise would wait until an exception
         method._queue_from_thread.put(1)
         method.exit_mode()
-        assert method._inhibiting_thread is None 
-
-
+        assert method._inhibiting_thread is None
 
     @pytest.mark.parametrize(
         "method_cls, expected_flag",
@@ -131,12 +153,20 @@ class TestWindowsSetThreadExecutionState:
             (WindowsKeepRunning, ES_CONTINUOUS | ES_SYSTEM_REQUIRED),
         ],
     )
-    def test_wrong_return_type_from_set_thread_execution_state(self, method_cls, expected_flag):
+    def test_wrong_return_type_from_set_thread_execution_state(
+        self, method_cls, expected_flag
+    ):
         method = method_cls()
 
         def set_thread_execution_state(flags):
-            return 'foo'
+            return "foo"
 
-        with patch("wakepy.methods.windows.ctypes.windll.kernel32.SetThreadExecutionState", set_thread_execution_state):
-            with pytest.raises(RuntimeError, match=re.escape("Unknown result type: <class 'str'> (foo)")):
+        with patch(
+            "wakepy.methods.windows.ctypes.windll.kernel32.SetThreadExecutionState",
+            set_thread_execution_state,
+        ):
+            with pytest.raises(
+                RuntimeError,
+                match=re.escape("Unknown result type: <class 'str'> (foo)"),
+            ):
                 method.enter_mode()

--- a/tests/unit/test_methods/test_windows.py
+++ b/tests/unit/test_methods/test_windows.py
@@ -10,7 +10,10 @@ from wakepy.methods.windows import (
     WindowsKeepRunning,
 )
 
+import wakepy.methods.windows as windows
 
+windows._release_event_timeout = 1
+"""Make tests *not* to wait forever"""
 class TestWindowsSetThreadExecutionState:
 
     @pytest.mark.parametrize(

--- a/tests/unit/test_methods/test_windows.py
+++ b/tests/unit/test_methods/test_windows.py
@@ -7,7 +7,7 @@ import pytest
 if sys.platform != "win32":
     pytest.skip(allow_module_level=True)
 
-import wakepy.methods.windows as windows
+import wakepy.methods.windows as windows # type: ignore[unreachable, unused-ignore]
 from wakepy.methods.windows import (
     ES_CONTINUOUS,
     ES_DISPLAY_REQUIRED,

--- a/tests/unit/test_methods/test_windows.py
+++ b/tests/unit/test_methods/test_windows.py
@@ -121,7 +121,8 @@ class TestWindowsSetThreadExecutionState:
         ):
             method.enter_mode()
 
-        # returning 0 means returning NULL (error in SetThreadExecutionState call)
+        # returning 0 means returning NULL (error in SetThreadExecutionState
+        # call)
         with patch(
             "wakepy.methods.windows.ctypes.windll.kernel32.SetThreadExecutionState",
             lambda x: 0,
@@ -138,7 +139,8 @@ class TestWindowsSetThreadExecutionState:
     def test_exit_mode_before_enter(self, method_cls):
         # does not make much practical sense but required for test coverage
         method = method_cls()
-        # need to add something to the queue; otherwise would wait until an exception
+        # need to add something to the queue; otherwise would wait until an
+        # exception
         method._queue_from_thread.put(1)
         method.exit_mode()
         assert method._inhibiting_thread is None


### PR DESCRIPTION
Fixes: #167

The [SetThreadExecutionState](https://wakepy.readthedocs.io/stable/methods-reference.html#setthreadexecutionstate) Method may now have multiple modes (same or different) activated within the same python thread without them interfering with each other on activation or deactivation, as wakepy creates a separate worker thread for the single purpose of setting and keeping the thread execution flag each time you activate a mode with the SetThreadExecutionState wakepy.Method.


# Before this PR

Running

```python
from wakepy import keep
import time 

def foo():
   with keep.running():
       ...

with keep.presenting():
    foo()
    time.sleep(1000)
```
produced no lock holders (Expected: DISPLAY and SYSTEM):

```
PS C:\Users\niko> powercfg /requests
DISPLAY:
None.

SYSTEM:
None.

AWAYMODE:
None.

EXECUTION:
None.

PERFBOOST:
None.

ACTIVELOCKSCREEN:
None.
```

## After this PR

Running

```python
from wakepy import keep
import time 

def foo():
   with keep.running():
       ...

with keep.presenting():
    foo()
    time.sleep(1000)
```

produces (as expected)

```
PS C:\Users\niko> powercfg /requests
DISPLAY:
[PROCESS] \Device\HarddiskVolume3\Python310\python.exe

SYSTEM:
[PROCESS] \Device\HarddiskVolume3\Python310\python.exe

AWAYMODE:
None.

EXECUTION:
None.

PERFBOOST:
None.

ACTIVELOCKSCREEN:
None.
```
(DISPLAY and SYSTEM kept awake as expected), and running 

```python
def foo():
   with keep.presenting():
       ...

with keep.running():
    foo()
    time.sleep(1000)
```

produces:

```
PS C:\Users\niko> powercfg /requests
DISPLAY:
None.

SYSTEM:
[PROCESS] \Device\HarddiskVolume3\Python310\python.exe

AWAYMODE:
None.

EXECUTION:
None.

PERFBOOST:
None.

ACTIVELOCKSCREEN:
None.
```

(only SYSTEM kept awake as expected)
