### PR TITLE
Try: Run GitHub Releases only on tags which start with "v"

### DIFF
--- a/.github/workflows/publish-a-release.yml
+++ b/.github/workflows/publish-a-release.yml
@@ -10,6 +10,7 @@ name: Publish a wakepy release 📦
 jobs:
 
   build-and-test:
+    if: startsWith(github.ref, 'refs/tags/v')
     uses: ./.github/workflows/build-and-run-tests.yml
 
   sign-artifacts:

--- a/.github/workflows/publish-a-release.yml
+++ b/.github/workflows/publish-a-release.yml
@@ -69,10 +69,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: >-
+          VERSION="${{github.repository}}" &&
           gh release create
           '${{ github.ref_name }}'
           --repo '${{ github.repository }}'
+          --title "wakepy ${VERSION:1}"
           --notes ""
+          --draft
       - name: Publish distribution & signatures 📦 to GitHub Releases
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
This tries to fix #346

* Check if running with tag which starts with "v"
* Add title: wakepy x.y.z to GitHub Releases from the tag
* Release as draft.