### PR TITLE
call logger.info instead of logging.info

### DIFF
--- a/tests/integration/dbus_service.py
+++ b/tests/integration/dbus_service.py
@@ -134,7 +134,7 @@ class DBusService:
         try:
             connection.send_message(rep)
         except Exception as e:
-            logging.info("Error occured:" + str(e))
+            logger.info("Error occured:" + str(e))
             connection.send_message(self._get_error_message(msg, ".Error.OtherError"))
 
     def _get_error_message(self, msg, method=".Error.NoMethod"):


### PR DESCRIPTION
Closes: #351

the logging info may have some side effects (it may configure logging, as in #343)