### PR TITLE
new CLI flags

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -4,7 +4,7 @@
 🗓️ unreleased
 
 ### ✨ Features
-- 📢 CLI arguments: Change `-k, --keep-running` to be `-r, --keep-running` and `-p, --presentation` to be `-p, --keep-presenting`; Be more consistent with the naming of the [Modes](#wakepy-modes). The old alternatives are deprecated and will be removed in a future release.
+- 📢 CLI arguments: Change `-k, --keep-running` to be `-r, --keep-running` and `-p, --presentation` to be `-p, --keep-presenting`; Be more consistent with the naming of the [Modes](#wakepy-modes). The old alternatives are deprecated and will be removed in a future release. ([#356](https://github.com/fohrloop/wakepy/pull/356))
 
 ### 👷 Maintenance
 - Fixed GitHub Release pipeline: Creates releases only from tags. Added automatic titles. Cannot accidentally publish with "main" tag. ([#328](https://github.com/fohrloop/wakepy/pull/328), [#346](https://github.com/fohrloop/wakepy/pull/346))

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -1,7 +1,10 @@
 # Changelog
 
-## wakepy X.Y.Z
+## wakepy 0.10.0
 🗓️ unreleased
+
+### ✨ Features
+- 📢 CLI arguments: Change `-k, --keep-running` to be `-r, --keep-running` and `-p, --presentation` to be `-p, --keep-presenting`; Be more consistent with the naming of the [Modes](#wakepy-modes). The old alternatives are deprecated and will be removed in a future release.
 
 ### 👷 Maintenance
 - Fixed GitHub Release pipeline: Creates releases only from tags. Added automatic titles. Cannot accidentally publish with "main" tag. ([#328](https://github.com/fohrloop/wakepy/pull/328), [#346](https://github.com/fohrloop/wakepy/pull/346))

--- a/src/wakepy/__main__.py
+++ b/src/wakepy/__main__.py
@@ -42,7 +42,7 @@ WAKEPY_TICKBOXES_TEMPLATE = """
  [{presentation_mode}] Display is kept on and automatic screenlock disabled.
 """
 
-_deprecations = []
+_deprecations: list[str] = []
 
 
 def main() -> None:


### PR DESCRIPTION
Closes: #355

The wakepy Modes are keep.running and keep.presenting.

The CLI options are:

-k, --keep-running
-p, --presentation

For consistency, changed the new CLI flags to be:

-r, --keep-running
-p, --keep-presenting

The old ones will raise a DeprecationWarning when used.