### PR TITLE
add: missing space character to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Here's some reasons why you might want to consider using wakepy:
 <dl>
   <dt>🙅🏼‍♂️ Non-disruptive methods ✅</dt>
   <dd>No mouse wiggling or pressing random keys like F15. Wakepy is completely non-disruptive. It uses the APIs and programs the system provides for keeping a system awake.</dd>
-  <dt>🛡️Safe to crash 💥</dt>
+  <dt>🛡️ Safe to crash 💥</dt>
   <dd>No changing of any system settings; killing the process abruptly will not leave the keepawake on, and will not require any manual clean-up.</dd>
   <dt>🚨 For security reasons 🔒</dt>
   <dd>With <a href="https://wakepy.readthedocs.io/stable/modes.html#keep-running-mode"><b><code>keep.running</code></b></a> mode you can disable <i>just</i> the automatic suspend and keep the automatic screen lock untouched.</dd>


### PR DESCRIPTION
A space character was missing from README.

Before:

```
  <dt>🛡️Safe to crash 💥</dt>
```

after:

```
  <dt>🛡️ Safe to crash 💥</dt>
```