### PR TITLE
Change how platform support is defined

### DIFF
--- a/docs/source/api-reference.md
+++ b/docs/source/api-reference.md
@@ -51,10 +51,18 @@ Wakepy Core
 .. autoclass:: wakepy.ModeExit
     :exclude-members: args, with_traceback
 
-.. autoclass:: wakepy.core.constants.PlatformName
+.. autoclass:: wakepy.core.constants.PlatformType
   :members:
   :undoc-members:
   :member-order: bysource
+
+.. autoclass:: wakepy.core.constants.IdentifiedPlatformType
+  :members:
+  :undoc-members:
+  :member-order: bysource
+
+.. autodata:: wakepy.core.platform.CURRENT_PLATFORM
+  :no-value:
 
 DBus Adapter
 -------------

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -5,6 +5,10 @@
 
 ### ✨ Features
 - 📢 CLI arguments: Change `-k, --keep-running` to be `-r, --keep-running` and `-p, --presentation` to be `-p, --keep-presenting`; Be more consistent with the naming of the [Modes](#wakepy-modes). The old alternatives are deprecated and will be removed in a future release. ([#356](https://github.com/fohrloop/wakepy/pull/356))
+- If platform is unknown to wakepy, do not fail any Method in the platform check phase anymore, but try to use it. This means for example that any system running GNOME that is not Linux (or BSD) could still use wakepy with the [org.gnome.SessionManager](https://wakepy.readthedocs.io/stable/methods-reference.html#org-gnome-sessionmanager) ([#379](https://github.com/fohrloop/wakepy/pull/379))
+
+### 🚨 Backwards incompatible
+- Renamed [`PlatformName`](https://wakepy.readthedocs.io/v0.9.0.post1/api-reference.html#wakepy.core.constants.PlatformName) to [`PlatformType`](https://wakepy.readthedocs.io/v0.10.0/api-reference.html#wakepy.core.constants.PlatformType) and added new types: `ANY`, which means "any platform", `BSD`, meaning "any BSD system" in the future, but currently just FreeBSD / GhostBSD, and  `UNIX_LIKE_FOSS`, which means "Unix-like desktop environment, but FOSS". Includes: Linux and BSD. Excludes: Android (mobile), MacOS (non-FOSS), ChromeOS (non-FOSS). Only affects you if you have created custom [Method](https://wakepy.readthedocs.io/v0.9.0.post1/api-reference.html#wakepy.Method) subclasses.  ([#379](https://github.com/fohrloop/wakepy/pull/379))
 
 ### 👷 Maintenance
 - Fixed GitHub Release pipeline: Creates releases only from tags. Added automatic titles. Cannot accidentally publish with "main" tag. ([#328](https://github.com/fohrloop/wakepy/pull/328), [#346](https://github.com/fohrloop/wakepy/pull/346))

--- a/src/wakepy/__main__.py
+++ b/src/wakepy/__main__.py
@@ -69,6 +69,7 @@ def handle_activation_error(result: ActivationResult) -> None:
 def _get_activation_error_text(result: ActivationResult) -> str:
     from wakepy import __version__
 
+    # LATER: This should be improved in https://github.com/fohrloop/wakepy/issues/378
     error_text = f"""
     Wakepy could not activate the "{result.mode_name}" mode. This might occur because of a bug or because your current platform is not yet supported or your system is missing required software.
 

--- a/src/wakepy/core/__init__.py
+++ b/src/wakepy/core/__init__.py
@@ -7,8 +7,9 @@ See the public Python API at: https://wakepy.readthedocs.io/
 from .activationresult import ActivationResult as ActivationResult
 from .activationresult import MethodActivationResult as MethodActivationResult
 from .constants import BusType as BusType
+from .constants import IdentifiedPlatformType as IdentifiedPlatformType
 from .constants import ModeName as ModeName
-from .constants import PlatformName as PlatformName
+from .constants import PlatformType as PlatformType
 from .dbus import DBusAdapter as DBusAdapter
 from .dbus import DBusAddress as DBusAddress
 from .dbus import DBusMethod as DBusMethod

--- a/src/wakepy/core/constants.py
+++ b/src/wakepy/core/constants.py
@@ -49,6 +49,8 @@ class PlatformType(StrEnum):
     :meth:`~wakepy.Method.supported_platforms`.
     """
 
+    # All of the IdentifiedPlatformType are always part of the PlatformType
+    # (also enforced with a test)
     WINDOWS = IdentifiedPlatformType.WINDOWS.value
     """Any Windows version from Windows 10 onwards."""
 
@@ -64,6 +66,8 @@ class PlatformType(StrEnum):
     UNKNOWN = IdentifiedPlatformType.UNKNOWN.value
     """Any non-identified platform"""
 
+    # These are special, combined platform types that make it easier to
+    # define the MethodSubclass.supported_platforms.
     BSD = auto()
     """Any BSD system (Currently just FreeBSD / GhostBSD, but is likely to
     change in the future)."""

--- a/src/wakepy/core/constants.py
+++ b/src/wakepy/core/constants.py
@@ -22,22 +22,58 @@ falsy.
 """
 
 
-class PlatformName(StrEnum):
-    """All the different platforms wakepy knows about. Any platform that is not
-    detected will be named ``OTHER``."""
+class IdentifiedPlatformType(StrEnum):
+    """The type identifier for the (:attr:`~wakepy.core.platform.CURRENT_PLATFORM`).
+    Any process will be categorized into exactly one
+    :class:`IdentifiedPlatformType` type; these are mutually exclusive options.
+    Any platform that is not detected will be labeled as ``UNKNOWN``.
+
+    See also: :class:`PlatformType`, which you should use with Method
+    subclasses."""  # noqa: W505
 
     WINDOWS = auto()
-
     LINUX = auto()
-
     MACOS = auto()
+    FREEBSD = auto()
+    UNKNOWN = auto()
+
+
+class PlatformType(StrEnum):
+    """Enumeration for supported platform types. Each identified platform can
+    be categorized to at least one, but potentially many of these. In other
+    words, each :class:`IdentifiedPlatformType` (type of
+    :attr:`~wakepy.core.platform.CURRENT_PLATFORM`) maps into one or many
+    ``PlatformType``.
+
+    To be used in subclasses of :class:`~wakepy.Method` in the
+    :meth:`~wakepy.Method.supported_platforms`.
+    """
+
+    WINDOWS = IdentifiedPlatformType.WINDOWS.value
+    """Any Windows version from Windows 10 onwards."""
+
+    LINUX = IdentifiedPlatformType.LINUX.value
+    """Includes any Linux distro. Excludes things like  Android &  ChromeOS"""
+
+    MACOS = IdentifiedPlatformType.MACOS.value
     """Mac OS (Darwin)"""
 
-    OTHER = auto()
-    """Anything else"""
+    FREEBSD = IdentifiedPlatformType.FREEBSD.value
+    """FreeBSD. Also includes GhostBSD"""
 
+    UNKNOWN = IdentifiedPlatformType.UNKNOWN.value
+    """Any non-identified platform"""
 
-PlatformNameValue = Literal["WINDOWS", "LINUX", "MACOS", "OTHER"]
+    BSD = auto()
+    """Any BSD system (Currently just FreeBSD / GhostBSD, but is likely to
+    change in the future)."""
+
+    UNIX_LIKE_FOSS = auto()
+    """Unix-like desktop environment, but FOSS. Includes: LINUX and BSD.
+    Excludes: Android (mobile), MacOS (non-FOSS), ChromeOS (non-FOSS)."""
+
+    ANY = auto()
+    """Means any platform."""
 
 
 class ModeName(StrEnum):

--- a/src/wakepy/core/platform.py
+++ b/src/wakepy/core/platform.py
@@ -1,23 +1,103 @@
+from __future__ import annotations
+
 import platform
+import typing
 import warnings
 
-from .constants import PlatformName
+from .constants import IdentifiedPlatformType, PlatformType
+
+if typing.TYPE_CHECKING:
+    from typing import Callable, Tuple
+
+    PlatformFunc = Callable[[IdentifiedPlatformType], bool]
 
 
-def get_current_platform() -> PlatformName:
+def get_current_platform() -> IdentifiedPlatformType:
     # Ref: https://docs.python.org/3/library/platform.html#platform.system
     system = platform.system()
     if system == "Windows":
-        return PlatformName.WINDOWS
+        return IdentifiedPlatformType.WINDOWS
     elif system == "Darwin":
-        return PlatformName.MACOS
+        return IdentifiedPlatformType.MACOS
     elif system == "Linux":
-        return PlatformName.LINUX
+        return IdentifiedPlatformType.LINUX
+    elif system == "FreeBSD":
+        return IdentifiedPlatformType.FREEBSD
 
+    # LATER: This should be improved in https://github.com/fohrloop/wakepy/issues/378
     warnings.warn(
         f"Could not detect current platform! platform.system() returned {system}"
     )
-    return PlatformName.OTHER
+    return IdentifiedPlatformType.UNKNOWN
 
 
-CURRENT_PLATFORM = get_current_platform()
+CURRENT_PLATFORM: IdentifiedPlatformType = get_current_platform()
+"""The current platform as detected. If the platform cannot be detected,
+defaults to ``UNKNOWN``."""
+
+
+def get_platform_supported(
+    platform: IdentifiedPlatformType, supported_platforms: Tuple[PlatformType, ...]
+) -> bool | None:
+    """Checks if a platform is in the supported platforms.
+
+    Parameters
+    ----------
+    platform: IdentifiedPlatformType
+        The platform to check.
+    supported_platforms:
+        The platforms to check against.
+
+    Returns
+    -------
+    is_supported: bool | None
+        If platform is supported, returns True. If the support is unknown,
+        returns None, and if the platform is not supported, returns False.
+    """
+    for supported_platform in supported_platforms:
+        func = PLATFORM_INFO_FUNCS[supported_platform]
+        if func(platform) is True:
+            return True
+    if is_unknown(platform):
+        return None
+    return False
+
+
+def is_windows(current_platform: IdentifiedPlatformType) -> bool:
+    return current_platform == IdentifiedPlatformType.WINDOWS
+
+
+def is_linux(current_platform: IdentifiedPlatformType) -> bool:
+    return current_platform == IdentifiedPlatformType.LINUX
+
+
+def is_freebsd(current_platform: IdentifiedPlatformType) -> bool:
+    return current_platform == IdentifiedPlatformType.FREEBSD
+
+
+def is_macos(current_platform: IdentifiedPlatformType) -> bool:
+    return current_platform == IdentifiedPlatformType.MACOS
+
+
+def is_bsd(current_platform: IdentifiedPlatformType) -> bool:
+    return is_freebsd(current_platform)
+
+
+def is_unknown(current_platform: IdentifiedPlatformType) -> bool:
+    return current_platform == IdentifiedPlatformType.UNKNOWN
+
+
+def is_unix_like_foss(current_platform: IdentifiedPlatformType) -> bool:
+    return is_bsd(current_platform) or is_linux(current_platform)
+
+
+PLATFORM_INFO_FUNCS: dict[PlatformType, PlatformFunc] = {
+    PlatformType.WINDOWS: is_windows,
+    PlatformType.LINUX: is_linux,
+    PlatformType.MACOS: is_macos,
+    PlatformType.FREEBSD: is_freebsd,
+    PlatformType.UNKNOWN: is_unknown,
+    PlatformType.BSD: is_bsd,
+    PlatformType.ANY: lambda _: True,
+    PlatformType.UNIX_LIKE_FOSS: is_unix_like_foss,
+}

--- a/src/wakepy/methods/_testing.py
+++ b/src/wakepy/methods/_testing.py
@@ -2,7 +2,7 @@
 activation success. It is controlled with the WAKEPY_FAKE_SUCCESS environment
 variable and meant to be used in CI pipelines / tests."""
 
-from wakepy.core import CURRENT_PLATFORM, Method
+from wakepy.core import Method, PlatformType
 from wakepy.core.constants import WAKEPY_FAKE_SUCCESS
 
 
@@ -16,7 +16,7 @@ class WakepyFakeSuccess(Method):
 
     name = WAKEPY_FAKE_SUCCESS
     mode_name = "_fake"
-    supported_platforms = (CURRENT_PLATFORM,)
+    supported_platforms = (PlatformType.ANY,)
 
     def enter_mode(self) -> None:
         """Does nothing ("succeeds" automatically; Will never raise an

--- a/src/wakepy/methods/freedesktop.py
+++ b/src/wakepy/methods/freedesktop.py
@@ -14,7 +14,7 @@ from wakepy.core import (
     DBusMethodCall,
     Method,
     ModeName,
-    PlatformName,
+    PlatformType,
 )
 
 if typing.TYPE_CHECKING:
@@ -41,7 +41,7 @@ class FreedesktopInhibitorWithCookieMethod(Method):
     """Base class for freedesktop.org D-Bus based methods."""
 
     service_dbus_address: DBusAddress
-    supported_platforms = (PlatformName.LINUX,)
+    supported_platforms = (PlatformType.LINUX,)
 
     def __init__(self, **kwargs: object) -> None:
         super().__init__(**kwargs)

--- a/src/wakepy/methods/gnome.py
+++ b/src/wakepy/methods/gnome.py
@@ -11,7 +11,7 @@ from wakepy.core import (
     DBusMethodCall,
     Method,
     ModeName,
-    PlatformName,
+    PlatformType,
 )
 
 if typing.TYPE_CHECKING:
@@ -56,7 +56,7 @@ class _GnomeSessionManager(Method, ABC):
         params=("inhibit_cookie",),
     ).of(session_manager)
 
-    supported_platforms = (PlatformName.LINUX,)
+    supported_platforms = (PlatformType.LINUX,)
 
     @property
     @abstractmethod

--- a/src/wakepy/methods/macos.py
+++ b/src/wakepy/methods/macos.py
@@ -5,7 +5,7 @@ import typing
 from abc import ABC, abstractmethod
 from subprocess import PIPE, Popen
 
-from wakepy.core import Method, ModeName, PlatformName
+from wakepy.core import Method, ModeName, PlatformType
 
 if typing.TYPE_CHECKING:
     from typing import Optional
@@ -18,7 +18,7 @@ class _MacCaffeinate(Method, ABC):
     Also: https://web.archive.org/web/20140604153141/https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man8/caffeinate.8.html
     """
 
-    supported_platforms = (PlatformName.MACOS,)
+    supported_platforms = (PlatformType.MACOS,)
 
     def __init__(self, **kwargs: object) -> None:
         super().__init__(**kwargs)

--- a/src/wakepy/methods/windows.py
+++ b/src/wakepy/methods/windows.py
@@ -9,7 +9,7 @@ from abc import ABC, abstractmethod
 from queue import Queue
 from threading import Event, Thread
 
-from wakepy.core import Method, ModeName, PlatformName
+from wakepy.core import Method, ModeName, PlatformType
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +34,7 @@ class WindowsSetThreadExecutionState(Method, ABC):
 
     # The SetThreadExecutionState docs say that it supports Windows XP and
     # above (client) or Windows Server 2003 and above (server)
-    supported_platforms = (PlatformName.WINDOWS,)
+    supported_platforms = (PlatformType.WINDOWS,)
     _wait_timeout = 5  # seconds
     """timeout for calls like queue.get() and thread.join() which could
     otherwise block execution indefinitely."""

--- a/tests/unit/test_core/conftest.py
+++ b/tests/unit/test_core/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 
 from tests.unit.test_core.testmethods import TestMethod
-from wakepy.core import DBusAddress, DBusMethod, Method, PlatformName
+from wakepy.core import DBusAddress, DBusMethod, Method, PlatformType
 from wakepy.core.heartbeat import Heartbeat
 
 
@@ -28,34 +28,34 @@ def provide_methods_different_platforms(monkeypatch, testutils):
 
     class WindowsA(TestMethod):
         name = "WinA"
-        supported_platforms = (PlatformName.WINDOWS,)
+        supported_platforms = (PlatformType.WINDOWS,)
 
     class WindowsB(TestMethod):
         name = "WinB"
-        supported_platforms = (PlatformName.WINDOWS,)
+        supported_platforms = (PlatformType.WINDOWS,)
 
     class WindowsC(TestMethod):
         name = "WinC"
-        supported_platforms = (PlatformName.WINDOWS,)
+        supported_platforms = (PlatformType.WINDOWS,)
 
     class LinuxA(TestMethod):
         name = "LinuxA"
-        supported_platforms = (PlatformName.LINUX,)
+        supported_platforms = (PlatformType.LINUX,)
 
     class LinuxB(TestMethod):
         name = "LinuxB"
-        supported_platforms = (PlatformName.LINUX,)
+        supported_platforms = (PlatformType.LINUX,)
 
     class LinuxC(TestMethod):
         name = "LinuxC"
-        supported_platforms = (PlatformName.LINUX,)
+        supported_platforms = (PlatformType.LINUX,)
 
     class MultiPlatformA(TestMethod):
         name = "multiA"
         supported_platforms = (
-            PlatformName.LINUX,
-            PlatformName.WINDOWS,
-            PlatformName.MACOS,
+            PlatformType.LINUX,
+            PlatformType.WINDOWS,
+            PlatformType.MACOS,
         )
 
 

--- a/tests/unit/test_core/test_constants.py
+++ b/tests/unit/test_core/test_constants.py
@@ -1,9 +1,10 @@
-from wakepy.core import BusType, ModeName, PlatformName
-from wakepy.core.constants import BusTypeValue, ModeNameValue, PlatformNameValue
-
-
-def test_platformname(assert_strenum_values):
-    assert_strenum_values(PlatformName, PlatformNameValue)
+from wakepy.core import BusType, ModeName
+from wakepy.core.constants import (
+    BusTypeValue,
+    IdentifiedPlatformType,
+    ModeNameValue,
+    PlatformType,
+)
 
 
 def test_mode_name(assert_strenum_values):
@@ -12,3 +13,13 @@ def test_mode_name(assert_strenum_values):
 
 def test_bustype(assert_strenum_values):
     assert_strenum_values(BusType, BusTypeValue)
+
+
+def test_platform_types_in_sync():
+    """Test that each IdentifiedPlatformType is also in PlatformType: anything
+    that can be detected can also be selected by the Method sublasses in
+    supported_platforms."""
+
+    identified = {member.value for member in IdentifiedPlatformType}
+    selectable = {member.value for member in PlatformType}
+    assert not (identified - selectable)

--- a/tests/unit/test_core/test_mode.py
+++ b/tests/unit/test_core/test_mode.py
@@ -10,6 +10,7 @@ import pytest
 
 from tests.unit.test_core.testmethods import get_test_method_class
 from wakepy import ActivationError, ActivationResult, Method, Mode
+from wakepy.core import PlatformType
 from wakepy.core.activationresult import MethodActivationResult
 from wakepy.core.constants import WAKEPY_FAKE_SUCCESS, StageName
 from wakepy.core.dbus import DBusAdapter
@@ -21,7 +22,6 @@ from wakepy.core.mode import (
     select_methods,
     should_fake_success,
 )
-from wakepy.core.platform import CURRENT_PLATFORM
 from wakepy.core.registry import get_method, get_methods
 
 if typing.TYPE_CHECKING:
@@ -48,7 +48,7 @@ def methods_abc(monkeypatch, testutils) -> List[Type[Method]]:
     testutils.empty_method_registry(monkeypatch)
 
     class TestMethod(Method):
-        supported_platforms = (CURRENT_PLATFORM,)
+        supported_platforms = (PlatformType.ANY,)
 
     class MethodA(TestMethod):
         name = "MethodA"

--- a/tests/unit/test_core/test_platform.py
+++ b/tests/unit/test_core/test_platform.py
@@ -2,25 +2,85 @@ from unittest.mock import patch
 
 import pytest
 
-from wakepy.core import PlatformName
-from wakepy.core.platform import get_current_platform
+from wakepy.core import PlatformType
+from wakepy.core.constants import IdentifiedPlatformType
+from wakepy.core.platform import get_current_platform, get_platform_supported
+
+P = IdentifiedPlatformType
 
 
 class TestGetCurrentPlatform:
 
     @patch("platform.system", lambda: "Windows")
     def test_windows(self):
-        assert get_current_platform() == PlatformName.WINDOWS
+        assert get_current_platform() == PlatformType.WINDOWS
 
     @patch("platform.system", lambda: "Darwin")
     def test_macos(self):
-        assert get_current_platform() == PlatformName.MACOS
+        assert get_current_platform() == PlatformType.MACOS
 
     @patch("platform.system", lambda: "Linux")
     def test_linux(self):
-        assert get_current_platform() == PlatformName.LINUX
+        assert get_current_platform() == PlatformType.LINUX
+
+    @patch("platform.system", lambda: "FreeBSD")
+    def test_bsd(self):
+        assert get_current_platform() == PlatformType.FREEBSD
 
     @patch("platform.system", lambda: "This does not exist")
     def test_other(self):
         with pytest.warns(UserWarning, match="Could not detect current platform!"):
-            assert get_current_platform() == PlatformName.OTHER
+            assert get_current_platform() == PlatformType.UNKNOWN
+
+
+class TestPlatformSupported:
+    """tests for get_platform_supported"""
+
+    def test_windows(self):
+
+        # On Windows, anything that supports Windows is supported.
+        assert get_platform_supported(P.WINDOWS, (PlatformType.WINDOWS,)) is True
+        assert (
+            get_platform_supported(
+                P.WINDOWS,
+                (PlatformType.MACOS, PlatformType.WINDOWS, PlatformType.LINUX),
+            )
+            is True
+        )
+
+        # If there is no windows in the supported platforms, get False
+        assert get_platform_supported(P.WINDOWS, (PlatformType.LINUX,)) is False
+        assert (
+            get_platform_supported(P.WINDOWS, (PlatformType.LINUX, PlatformType.BSD))
+            is False
+        )
+        # Unless there is ANY, which means anything is supported
+        assert (
+            get_platform_supported(
+                P.WINDOWS, (PlatformType.LINUX, PlatformType.BSD, PlatformType.ANY)
+            )
+            is True
+        )
+
+    def test_unknown(self):
+        # Unknown platform is always "unknown"; returns None
+        assert get_platform_supported(P.UNKNOWN, (PlatformType.WINDOWS,)) is None
+        assert get_platform_supported(P.UNKNOWN, (PlatformType.LINUX,)) is None
+        # .. unless "ANY" is supported.
+        assert get_platform_supported(P.UNKNOWN, (PlatformType.ANY,)) is True
+
+    def test_freebsd(self):
+
+        assert get_platform_supported(P.FREEBSD, (PlatformType.WINDOWS,)) is False
+        assert get_platform_supported(P.FREEBSD, (PlatformType.FREEBSD,)) is True
+        # FreeBSD is BSD
+        assert get_platform_supported(P.FREEBSD, (PlatformType.BSD,)) is True
+        # FreeBSD is unix like
+        assert get_platform_supported(P.FREEBSD, (PlatformType.UNIX_LIKE_FOSS,)) is True
+
+    def test_linux(self):
+
+        assert get_platform_supported(P.LINUX, (PlatformType.WINDOWS,)) is False
+        assert get_platform_supported(P.LINUX, (PlatformType.LINUX,)) is True
+        # Linux is unix like
+        assert get_platform_supported(P.LINUX, (PlatformType.UNIX_LIKE_FOSS,)) is True

--- a/tests/unit/test_core/test_prioritization.py
+++ b/tests/unit/test_core/test_prioritization.py
@@ -5,7 +5,7 @@ import typing
 
 import pytest
 
-from wakepy.core import PlatformName
+from wakepy.core import PlatformType
 from wakepy.core.constants import WAKEPY_FAKE_SUCCESS
 from wakepy.core.prioritization import (
     _check_methods_priority,
@@ -25,7 +25,7 @@ if typing.TYPE_CHECKING:
 def set_current_platform_to_linux(monkeypatch):
 
     monkeypatch.setattr(
-        "wakepy.core.prioritization.CURRENT_PLATFORM", PlatformName.LINUX
+        "wakepy.core.prioritization.CURRENT_PLATFORM", PlatformType.LINUX
     )
 
 
@@ -33,7 +33,8 @@ def set_current_platform_to_linux(monkeypatch):
 def set_current_platform_to_windows(monkeypatch):
 
     monkeypatch.setattr(
-        "wakepy.core.prioritization.CURRENT_PLATFORM", PlatformName.WINDOWS
+        "wakepy.core.prioritization.CURRENT_PLATFORM",
+        PlatformType.WINDOWS,
     )
 
 

--- a/tests/unit/test_core/testmethods.py
+++ b/tests/unit/test_core/testmethods.py
@@ -38,7 +38,7 @@ import itertools
 from collections import Counter
 from typing import Iterable, Type
 
-from wakepy.core import CURRENT_PLATFORM
+from wakepy.core import PlatformType
 from wakepy.core.method import Method
 
 
@@ -82,7 +82,7 @@ def get_test_method_class(
     enter_mode=METHOD_MISSING,
     heartbeat=METHOD_MISSING,
     exit_mode=METHOD_MISSING,
-    supported_platforms=(CURRENT_PLATFORM,),
+    supported_platforms=(PlatformType.ANY,),
 ) -> Type[Method]:
     """Get a test Method class with the .caniuse(), .enter_mode(), .heartbeat()
     and .exit_mode() methods defined as wanted. All methods can either be:

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -14,7 +14,7 @@ from wakepy.__main__ import (
     parse_arguments,
     wait_until_keyboardinterrupt,
 )
-from wakepy.core import CURRENT_PLATFORM
+from wakepy.core import PlatformType
 from wakepy.core.constants import ModeName
 
 
@@ -36,7 +36,7 @@ def method1(mode_name_working):
 
         name = "method1"
         mode_name = mode_name_working
-        supported_platforms = (CURRENT_PLATFORM,)
+        supported_platforms = (PlatformType.ANY,)
 
         def enter_mode(self) -> None:
             return
@@ -52,7 +52,7 @@ def method2_broken(mode_name_broken):
 
         name = "method2_broken"
         mode_name = mode_name_broken
-        supported_platforms = (CURRENT_PLATFORM,)
+        supported_platforms = (PlatformType.ANY,)
 
         def enter_mode(self) -> None:
             raise RuntimeError("foo")


### PR DESCRIPTION
Closes: https://github.com/fohrloop/wakepy/issues/377

### Summary
* Replace PlatformName with PlatformType and IdentifiedPlatformType
* If platform is unknown, do not fail in the platform check
  phase anymore, but continue trying using the method.
  

### Before
PlatformName constant, which is used to both: (1) As type for current
platform (2) As types to list in subclasses of Method in the 
supported_platforms attribute.

The problem was that the supported platforms definition was not very
flexible. For example when adding support for FreeBSD (GhostBSD), in
https://github.com/fohrloop/wakepy/issues/359, one would have needed
to add the PlatformName.FREEBSD to each of the methods, like this:

```python
class SomeMethod(Method):
    supported_platforms = (PlatformName.LINUX, PlatformName.FREEBSD) 
```

### Now

Now there's the possibility to use

```python
class SomeMethod(Method):
    supported_platforms = (PlatformType.UNIX_LIKE_FOSS, ) 
```

where the UNIX_LIKE_FOSS contains all FOSS Unix-like systems (linux+bsd,
but not MacOS or Android). Adding now systems to the list does not
require any changes in the Method subclasses supporting UNIX_LIKE_FOSS.

There are now two types of constants: (1) IdentifiedPlatformType, which
is used as the type of the current platform and (2) PlatformType, which
is used in the subclasses of Method in the supported_platforms
attribute.

#### New PlatformTypes

`PlatformType.BSD`: Any BSD system. Currently only consists of FreeBSD but
the list may grow in the future.

`PlatformType.UNIX_LIKE_FOSS`: Unix-like desktop environment, but FOSS.
Includes: Linux and BSD. Excludes: Android (mobile), MacOS (non-FOSS),
ChromeOS (non-FOSS)

`PlatformType.ANY`: Any platform.


#### New behavior

Platform support check does not fail (but returns "I don't know"/None)
if the platform could not be detected. This means that methods like
org.gnome.SessionManager will be tried also on non-linux systems (which
might be using Gnome).


#### BACKWARDS INCOMPATIBLE CHANGES

The name of the enum class to use in Method.supported_platforms was
changed from PlatformName to PlatformType. This only breaks code which
uses custom wakepy.Methods, and the fix is to rename the variable.

#### Other small changes
get_platform_supported() now takes the current platform and supported
platforms as arguments (previously, used Method and current platform).






