### PR TITLE
Fix failing tests on Fedora 40

### DIFF
--- a/src/wakepy/__init__.py
+++ b/src/wakepy/__init__.py
@@ -34,6 +34,11 @@ support DBus, but it's nice to be able to import this directly from wakepy
 top level package."""
 
 
+# This is a test for Issue 380
+foo = 1
+"""some text \* fooo"""
+
+
 def __getattr__(name: str) -> object:
     """Some lazy implementation of lazy loading.
 

--- a/src/wakepy/__init__.py
+++ b/src/wakepy/__init__.py
@@ -34,11 +34,6 @@ support DBus, but it's nice to be able to import this directly from wakepy
 top level package."""
 
 
-# This is a test for Issue 380
-foo = 1
-"""some text \* fooo"""
-
-
 def __getattr__(name: str) -> object:
     """Some lazy implementation of lazy loading.
 

--- a/src/wakepy/core/method.py
+++ b/src/wakepy/core/method.py
@@ -70,7 +70,7 @@ class Method(ABC):
     registered anywhere)"""
 
     supported_platforms: Tuple[PlatformType, ...] = (PlatformType.ANY,)
-    """Lists the platforms the Method supports. If the current platform is not
+    r"""Lists the platforms the Method supports. If the current platform is not
     part of any of the platform types listed in ``method.supported_platforms``,
     the ``method`` is not* going to be used (when used as part of a
     :class:`Mode`), and the Method activation result will show a fail in the

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -32,6 +32,7 @@ def gc_collect_after_dbus_integration_tests():
     # this as garbage colletion is triggered also automatically. The garbage
     # collection must be triggered here manually as the warnings are
     # ResourceWarning is only filtered away in the dbus integration tests.
+    # See also: comments for pytestmark in tests/integration/test_dbus_adapters.py # noqa: W505, E501
     gc.collect()
 
     logger.debug("called gc.collect")

--- a/tests/integration/test_dbus_adapters.py
+++ b/tests/integration/test_dbus_adapters.py
@@ -18,16 +18,24 @@ from wakepy import JeepneyDBusAdapter
 from wakepy.core import DBusAddress, DBusMethod, DBusMethodCall
 from wakepy.dbus_adapters.jeepney import DBusNotFoundError
 
-# For some unknown reason, when using jeepney, one will get a warning like
-# this:
+# For some unknown reason the D-Bus integration tests emit warnings like
+#
 # ResourceWarning: unclosed <socket.socket fd=14, family=AddressFamily.AF_UNIX, type=SocketKind.SOCK_STREAM, proto=0, raddr=b'\x00/tmp/dbus-cTfPKAeBWk'> # noqa: E501, W505
-# This is just ignored. It only triggers at *random* line, on random test when
-# python does garbage collection.
+# or
+# ResourceWarning: unclosed <socket.socket fd=14, family=1, type=1, proto=0, raddr=/tmp/dbus-WkEJOPjiAu> # noqa: E501, W505
+#
+# on garbage collection (either automatic; on any line or manual; during
+# gc_collect_after_dbus_integration_tests). These warnings are expected and
+# harmless. They occur either because a bug or some feature present in the DBus
+# Service or the interactions with the DBus service in the integration tests.
+# These do not happen during normal usage of wakepy and do not affect wakepy
+# users and are therefore simply ignored.
 #
 # Ref1: https://docs.pytest.org/en/7.1.x/reference/reference.html#pytest-mark-filterwarnings
 # Ref2: https://docs.pytest.org/en/7.1.x/reference/reference.html#globalvar-pytestmark
+# Ref3: https://github.com/fohrloop/wakepy/issues/380
 pytestmark = pytest.mark.filterwarnings(
-    r"ignore:unclosed.*raddr=b'\\x00/tmp/dbus-.*:ResourceWarning"
+    r"ignore:unclosed <socket.*raddr=[^=]*/tmp/dbus-.*:ResourceWarning"
 )
 
 

--- a/tests/integration/test_dbus_adapters.py
+++ b/tests/integration/test_dbus_adapters.py
@@ -34,9 +34,23 @@ from wakepy.dbus_adapters.jeepney import DBusNotFoundError
 # Ref1: https://docs.pytest.org/en/7.1.x/reference/reference.html#pytest-mark-filterwarnings
 # Ref2: https://docs.pytest.org/en/7.1.x/reference/reference.html#globalvar-pytestmark
 # Ref3: https://github.com/fohrloop/wakepy/issues/380
+ignore_resource_warning_regex = r"unclosed <socket.*raddr=[^=]*/tmp/dbus-.*"
 pytestmark = pytest.mark.filterwarnings(
-    r"ignore:unclosed <socket.*raddr=[^=]*/tmp/dbus-.*:ResourceWarning"
+    f"ignore:{ignore_resource_warning_regex}:ResourceWarning"
 )
+
+
+def test_pytestmark_regex_okay():
+    # Tests that the regex used in the pytestmark ignores the warning strings
+    # that have been occurred.
+    examples = [
+        # On Ubuntu:
+        r"""unclosed <socket.socket fd=14, family=AddressFamily.AF_UNIX, type=SocketKind.SOCK_STREAM, proto=0, raddr=b'\x00/tmp/dbus-cTfPKAeBWk'>""",  # noqa: E501
+        # On Fedora 40
+        r"""unclosed <socket.socket fd=14, family=1, type=1, proto=0, raddr=/tmp/dbus-WkEJOPjiAu>""",  # noqa: E501
+    ]
+    for warning_example in examples:
+        assert re.match(ignore_resource_warning_regex, warning_example)
 
 
 @pytest.mark.usefixtures("dbus_calculator_service")


### PR DESCRIPTION
Fixes: #380 

Fixes a SyntaxWarning caused by a docstring.

Fixes a few PytestUnraisableExceptionWarning on Fedora caused by
harmless warnings which were filtered using a regex. The regex only
matched the warnings emitted on Ubuntu, but not on Fedora.