### PR TITLE
Improve warnings and errors if platform is not supported

### DIFF
--- a/src/wakepy/__main__.py
+++ b/src/wakepy/__main__.py
@@ -22,6 +22,7 @@ from textwrap import dedent, fill
 from wakepy import ModeExit
 from wakepy.core.constants import ModeName
 from wakepy.core.mode import Mode
+from wakepy.core.platform import get_platform_debug_info
 
 if typing.TYPE_CHECKING:
     from typing import List, Tuple
@@ -67,9 +68,10 @@ def handle_activation_error(result: ActivationResult) -> None:
 
 
 def _get_activation_error_text(result: ActivationResult) -> str:
+    import textwrap
+
     from wakepy import __version__
 
-    # LATER: This should be improved in https://github.com/fohrloop/wakepy/issues/378
     error_text = f"""
     Wakepy could not activate the "{result.mode_name}" mode. This might occur because of a bug or because your current platform is not yet supported or your system is missing required software.
 
@@ -79,8 +81,7 @@ def _get_activation_error_text(result: ActivationResult) -> str:
     - wakepy version: {__version__}
     - Mode: {result.mode_name}
     - Python version: {sys.version}
-    - Operating system & version: [PLEASE FILL THIS]
-    - Desktop Environment & version (if not default): [FILL OR REMOVE THIS LINE]
+    {textwrap.indent(get_platform_debug_info().strip(), ' '*4).strip()}
     - Additional details: [FILL OR REMOVE THIS LINE]
 
     Thank you!

--- a/src/wakepy/core/platform.py
+++ b/src/wakepy/core/platform.py
@@ -28,9 +28,8 @@ def get_current_platform() -> IdentifiedPlatformType:
     elif system == "FreeBSD":
         return IdentifiedPlatformType.FREEBSD
 
-    # LATER: This should be improved in https://github.com/fohrloop/wakepy/issues/378
     warnings.warn(
-        f"Could not detect current platform! platform.system() returned {system}"
+        f"Could not detect current platform! Debug info:\n{get_platform_debug_info()}"
     )
     return IdentifiedPlatformType.UNKNOWN
 

--- a/src/wakepy/core/platform.py
+++ b/src/wakepy/core/platform.py
@@ -60,37 +60,48 @@ def get_platform_debug_info_dict() -> Dict[str, str]:
 
 
 def get_etc_os_release() -> dict[str, str]:
-    ignored_keys = [
-        "ANSI_COLOR",
-        "LOGO",
-        "CPE_NAME",
-        "DEFAULT_HOSTNAME",
-        "HOME_URL",
-        "DOCUMENTATION_URL",
-        "SUPPORT_URL",
-        "SUPPORT_END",
-        "BUG_REPORT_URL",
-        "REDHAT_BUGZILLA_PRODUCT",
-        "REDHAT_BUGZILLA_PRODUCT_VERSION",
-        "REDHAT_SUPPORT_PRODUCT",
-        "REDHAT_SUPPORT_PRODUCT_VERSION",
-    ]
-    os_release_file = Path("/etc/os-release")
-    if not os_release_file.exists():
-        os_release_file = Path("/etc/lsb-release")
-    if not os_release_file.exists():
+    """Get metadata about OS release from /etc/os-release file or, if that is
+    missing, from /etc/lsb-release. If neither of the files exist, returns an
+    empty dictionary. Otherwise, returns key-value pairs from the release
+    file."""
+
+    if Path(ETC_OS_RELEASE_PATH).exists():
+        release_file = ETC_OS_RELEASE_PATH
+    elif Path(ETC_LSB_RELEASE_PATH).exists():
+        release_file = ETC_LSB_RELEASE_PATH
+    else:
         return dict()
 
     out = dict()
-    with open(os_release_file) as f:
+    with open(release_file) as f:
         for line in f:
             key, value = line.split("=", maxsplit=1)
-            if key in ignored_keys:
+            if key in ignored_release_keys:
                 continue
-            key_out = f"({os_release_file}) {key}"
+            key_out = f"({release_file}) {key}"
             out[key_out] = value.strip()
     return out
 
+
+ETC_OS_RELEASE_PATH = "/etc/os-release"
+ETC_LSB_RELEASE_PATH = "/etc/lsb-release"
+
+# keys ignored in /etc/os-release and /etc/lsb-release files
+ignored_release_keys = [
+    "ANSI_COLOR",
+    "LOGO",
+    "CPE_NAME",
+    "DEFAULT_HOSTNAME",
+    "HOME_URL",
+    "DOCUMENTATION_URL",
+    "SUPPORT_URL",
+    "SUPPORT_END",
+    "BUG_REPORT_URL",
+    "REDHAT_BUGZILLA_PRODUCT",
+    "REDHAT_BUGZILLA_PRODUCT_VERSION",
+    "REDHAT_SUPPORT_PRODUCT",
+    "REDHAT_SUPPORT_PRODUCT_VERSION",
+]
 
 CURRENT_PLATFORM: IdentifiedPlatformType = get_current_platform()
 """The current platform as detected. If the platform cannot be detected,

--- a/src/wakepy/core/platform.py
+++ b/src/wakepy/core/platform.py
@@ -76,7 +76,7 @@ def get_etc_os_release() -> dict[str, str]:
     with open(release_file) as f:
         for line in f:
             key, value = line.split("=", maxsplit=1)
-            if key in ignored_release_keys:
+            if key in IGNORED_RELEASE_FILE_KEYS:
                 continue
             key_out = f"({release_file}) {key}"
             out[key_out] = value.strip()
@@ -87,7 +87,7 @@ ETC_OS_RELEASE_PATH = "/etc/os-release"
 ETC_LSB_RELEASE_PATH = "/etc/lsb-release"
 
 # keys ignored in /etc/os-release and /etc/lsb-release files
-ignored_release_keys = [
+IGNORED_RELEASE_FILE_KEYS = [
     "ANSI_COLOR",
     "LOGO",
     "CPE_NAME",

--- a/src/wakepy/core/platform.py
+++ b/src/wakepy/core/platform.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
+import os
 import platform
+import sys
+import sysconfig
 import typing
 import warnings
+from pathlib import Path
 
 from .constants import IdentifiedPlatformType, PlatformType
 
 if typing.TYPE_CHECKING:
-    from typing import Callable, Tuple
+    from typing import Callable, Dict, Tuple
 
     PlatformFunc = Callable[[IdentifiedPlatformType], bool]
 
@@ -29,6 +33,63 @@ def get_current_platform() -> IdentifiedPlatformType:
         f"Could not detect current platform! platform.system() returned {system}"
     )
     return IdentifiedPlatformType.UNKNOWN
+
+
+def get_platform_debug_info() -> str:
+    info_dict = get_platform_debug_info_dict()
+    return "\n".join(f"- {key}: {val}" for key, val in info_dict.items())
+
+
+def get_platform_debug_info_dict() -> Dict[str, str]:
+    info = dict()
+    try:
+        info["os.name"] = os.name
+        info["sys.platform"] = sys.platform
+        info["platform.system()"] = platform.system()
+        info["platform.release()"] = platform.release()
+        info["platform.machine()"] = platform.machine()
+        info["sysconfig.get_platform()"] = sysconfig.get_platform()
+        info["DESKTOP_SESSION"] = os.environ.get("DESKTOP_SESSION", "[not set]")
+        os_release_info = get_etc_os_release()
+        info.update(os_release_info)
+    except Exception:
+        # This should never happen, but better to be safe.
+        warnings.warn("Error in creating platform debug info")
+
+    return info
+
+
+def get_etc_os_release() -> dict[str, str]:
+    ignored_keys = [
+        "ANSI_COLOR",
+        "LOGO",
+        "CPE_NAME",
+        "DEFAULT_HOSTNAME",
+        "HOME_URL",
+        "DOCUMENTATION_URL",
+        "SUPPORT_URL",
+        "SUPPORT_END",
+        "BUG_REPORT_URL",
+        "REDHAT_BUGZILLA_PRODUCT",
+        "REDHAT_BUGZILLA_PRODUCT_VERSION",
+        "REDHAT_SUPPORT_PRODUCT",
+        "REDHAT_SUPPORT_PRODUCT_VERSION",
+    ]
+    os_release_file = Path("/etc/os-release")
+    if not os_release_file.exists():
+        os_release_file = Path("/etc/lsb-release")
+    if not os_release_file.exists():
+        return dict()
+
+    out = dict()
+    with open(os_release_file) as f:
+        for line in f:
+            key, value = line.split("=", maxsplit=1)
+            if key in ignored_keys:
+                continue
+            key_out = f"({os_release_file}) {key}"
+            out[key_out] = value.strip()
+    return out
 
 
 CURRENT_PLATFORM: IdentifiedPlatformType = get_current_platform()

--- a/tests/unit/test_core/test_platform.py
+++ b/tests/unit/test_core/test_platform.py
@@ -125,12 +125,12 @@ def test_get_platform_debug_info():
     - platform.release\(\): .*
     - platform.machine\(\): .*
     - sysconfig.get_platform\(\): .*
-    .*
     """.strip(
             "\n"
         )
     )
-    assert re.match(expected_out, debug_info)
+    # re.DOTALL makes . to match also the newlines.
+    assert re.match(expected_out, debug_info, re.DOTALL)
 
 
 mock_etc_os_release = """

--- a/tests/unit/test_core/test_platform.py
+++ b/tests/unit/test_core/test_platform.py
@@ -136,6 +136,7 @@ def test_get_platform_debug_info():
 mock_etc_os_release = """
 NAME="Ubuntu"
 FOO=123
+BUG_REPORT_URL="http://this-is-skipped"
 """.strip()
 
 mock_etc_lsb_release = """

--- a/tests/unit/test_core/test_platform.py
+++ b/tests/unit/test_core/test_platform.py
@@ -1,10 +1,17 @@
+import re
+import textwrap
 from unittest.mock import patch
 
 import pytest
 
 from wakepy.core import PlatformType
 from wakepy.core.constants import IdentifiedPlatformType
-from wakepy.core.platform import get_current_platform, get_platform_supported
+from wakepy.core.platform import (
+    get_current_platform,
+    get_platform_debug_info,
+    get_platform_debug_info_dict,
+    get_platform_supported,
+)
 
 P = IdentifiedPlatformType
 
@@ -84,3 +91,30 @@ class TestPlatformSupported:
         assert get_platform_supported(P.LINUX, (PlatformType.LINUX,)) is True
         # Linux is unix like
         assert get_platform_supported(P.LINUX, (PlatformType.UNIX_LIKE_FOSS,)) is True
+
+
+def test_get_platform_debug_info_dict():
+    info_dct = get_platform_debug_info_dict()
+    assert isinstance(info_dct, dict)
+
+    for key, val in info_dct.items():
+        assert isinstance(key, str)
+        assert isinstance(val, str)
+
+
+def test_get_platform_debug_info():
+    debug_info = get_platform_debug_info()
+    expected_out = textwrap.dedent(
+        r"""
+    - os.name: .*
+    - sys.platform: .*
+    - platform.system\(\): .*
+    - platform.release\(\): .*
+    - platform.machine\(\): .*
+    - sysconfig.get_platform\(\): .*
+    .*
+    """.strip(
+            "\n"
+        )
+    )
+    assert re.match(expected_out, debug_info)

--- a/tests/unit/test_core/test_platform.py
+++ b/tests/unit/test_core/test_platform.py
@@ -1,6 +1,6 @@
 import re
 import textwrap
-from unittest.mock import patch
+from unittest.mock import Mock, mock_open, patch
 
 import pytest
 
@@ -8,6 +8,7 @@ from wakepy.core import PlatformType
 from wakepy.core.constants import IdentifiedPlatformType
 from wakepy.core.platform import (
     get_current_platform,
+    get_etc_os_release,
     get_platform_debug_info,
     get_platform_debug_info_dict,
     get_platform_supported,
@@ -93,13 +94,25 @@ class TestPlatformSupported:
         assert get_platform_supported(P.LINUX, (PlatformType.UNIX_LIKE_FOSS,)) is True
 
 
-def test_get_platform_debug_info_dict():
-    info_dct = get_platform_debug_info_dict()
-    assert isinstance(info_dct, dict)
+class TestGetPlatformDebugInfoDict:
+    def test_basic(self):
+        info_dct = get_platform_debug_info_dict()
+        assert isinstance(info_dct, dict)
 
-    for key, val in info_dct.items():
-        assert isinstance(key, str)
-        assert isinstance(val, str)
+        for key, val in info_dct.items():
+            assert isinstance(key, str)
+            assert isinstance(val, str)
+
+    @staticmethod
+    def raise_exc():
+        raise Exception("forced exception")
+
+    @patch("wakepy.core.platform.platform", raise_exc)
+    def test_exception(self):
+        with pytest.warns(match="Error in creating platform debug info"):
+            info_dct = get_platform_debug_info_dict()
+        assert isinstance(info_dct, dict)
+        assert len(info_dct) == 2
 
 
 def test_get_platform_debug_info():
@@ -118,3 +131,73 @@ def test_get_platform_debug_info():
         )
     )
     assert re.match(expected_out, debug_info)
+
+
+mock_etc_os_release = """
+NAME="Ubuntu"
+FOO=123
+""".strip()
+
+mock_etc_lsb_release = """
+LSB_RELEASE_KEY="something"
+BAR=456
+""".strip()
+
+
+def get_path_class_mock(os_release_exists: bool, lsb_release_exists: bool):
+
+    def get_path_mock(filepath: str):
+        pathmock = Mock()
+        if filepath == "/etc/os-release":
+            pathmock.exists.return_value = os_release_exists
+        elif filepath == "/etc/lsb-release":
+            pathmock.exists.return_value = lsb_release_exists
+        else:
+            raise NotImplementedError
+        return pathmock
+
+    path_class_mock = Mock()
+    path_class_mock.side_effect = get_path_mock
+
+    return path_class_mock
+
+
+class TestGetEtcOsReleaseInfo:
+    mock_os_release_exists = get_path_class_mock(
+        os_release_exists=True, lsb_release_exists=False
+    )
+
+    @patch("wakepy.core.platform.Path", mock_os_release_exists)
+    @patch("builtins.open", mock_open(read_data=mock_etc_os_release))
+    def test_os_release(self):
+        # Case: os-release file exists
+        out = get_etc_os_release()
+        assert out == {
+            "(/etc/os-release) NAME": '"Ubuntu"',
+            "(/etc/os-release) FOO": "123",
+        }
+
+    mock_etc_release_exists = get_path_class_mock(
+        os_release_exists=False, lsb_release_exists=True
+    )
+
+    @patch("wakepy.core.platform.Path", mock_etc_release_exists)
+    @patch("builtins.open", mock_open(read_data=mock_etc_lsb_release))
+    def test_lsb_release(self):
+        # Case: os-release file missing, but lsb-release file exists
+        out = get_etc_os_release()
+        assert out == {
+            "(/etc/lsb-release) LSB_RELEASE_KEY": '"something"',
+            "(/etc/lsb-release) BAR": "456",
+        }
+
+    neither_one_exists = get_path_class_mock(
+        os_release_exists=False, lsb_release_exists=False
+    )
+
+    @patch("wakepy.core.platform.Path", neither_one_exists)
+    @patch("builtins.open", mock_open(read_data=mock_etc_lsb_release))
+    def test_no_release_files(self):
+        # Case: os-release and lsb-release files missing
+        out = get_etc_os_release()
+        assert out == dict()


### PR DESCRIPTION
Closes: #378 

Add platform information automatically to error/warning texts. When the `wakepy` CLI command fails, it would now print

```
❯ python -m wakepy
                  _
                 | |
 __      __ __ _ | | __ ___  _ __   _   _
 \ \ /\ / // _` || |/ // _ \| '_ \ | | | |
  \ V  V /| (_| ||   <|  __/| |_) || |_| |
   \_/\_/  \__,_||_|\_\\___|| .__/  \__, |
  v.0.9.2.dev13+g2aab0eb    | |      __/ |
                            |_|     |___/ 
 [x] System will continue running programs
 [ ] Display is kept on and automatic screenlock disabled.

Wakepy could not activate the "keep.running" mode. This might occur because of a
bug or because your current platform is not yet supported or your system is
missing required software.

Check if there is already a related issue in the issue tracker at
https://github.com/fohrloop/wakepy/issues/ and if not, please create a new one.

Include the following:
- wakepy version: 0.9.2.dev13+g2aab0eb
- Mode: keep.running
- Python version: 3.12.5 (main, Aug 23 2024, 00:00:00) [GCC 14.2.1 20240801 (Red
Hat 14.2.1-1)]
- os.name: posix
- sys.platform: linux
- platform.system(): Linux
- platform.release(): 6.10.9-200.fc40.x86_64
- platform.machine(): x86_64
- sysconfig.get_platform(): linux-x86_64
- DESKTOP_SESSION: gnome
- (/etc/os-release) NAME: "Fedora Linux"
- (/etc/os-release) VERSION: "40 (Workstation Edition)"
- (/etc/os-release) ID: fedora
- (/etc/os-release) VERSION_ID: 40
- (/etc/os-release) VERSION_CODENAME: ""
- (/etc/os-release) PLATFORM_ID: "platform:f40"
- (/etc/os-release) PRETTY_NAME: "Fedora Linux 40 (Workstation Edition)"
- (/etc/os-release) VARIANT: "Workstation Edition"
- (/etc/os-release) VARIANT_ID: workstation
- Additional details: [FILL OR REMOVE THIS LINE]

Thank you!
```

The parts from `os.name` until `(/etc/os-release) VARIANT_ID` are added in this PR. In addition, when determining the current platform with `get_current_platform()`, if platform (for example linux) could not be determined, would previously get:

```
/home/fohrloop/code/wakepy/src/wakepy/core/platform.py:28: UserWarning: Could not detect current platform! platform.system() returned Linux
  warnings.warn(
```

and now:

```
/home/fohrloop/code/wakepy/src/wakepy/core/platform.py:31: UserWarning: Could not detect current platform! Debug info:
- os.name: posix
- sys.platform: linux
- platform.system(): Linux
- platform.release(): 6.10.9-200.fc40.x86_64
- platform.machine(): x86_64
- sysconfig.get_platform(): linux-x86_64
- DESKTOP_SESSION: gnome
- (/etc/os-release) NAME: "Fedora Linux"
- (/etc/os-release) VERSION: "40 (Workstation Edition)"
- (/etc/os-release) ID: fedora
- (/etc/os-release) VERSION_ID: 40
- (/etc/os-release) VERSION_CODENAME: ""
- (/etc/os-release) PLATFORM_ID: "platform:f40"
- (/etc/os-release) PRETTY_NAME: "Fedora Linux 40 (Workstation Edition)"
- (/etc/os-release) VARIANT: "Workstation Edition"
- (/etc/os-release) VARIANT_ID: workstation
```