### PR TITLE
Make on_fail="warn" default (was: "error")

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -11,6 +11,7 @@
 
 ### ✨ Enhancements
 - Improve warnings and errors if platform is not supported ([#383](https://github.com/fohrloop/wakepy/pull/383))
+- Change default `on_fail` action to be "warn" instead of "error" (in keep.running and keep.presenting modes). ([#388](https://github.com/fohrloop/wakepy/pull/388))
 
 ### 👷 Maintenance
 - Fixed GitHub Release pipeline: Creates releases only from tags. Added automatic titles. Cannot accidentally publish with "main" tag. ([#328](https://github.com/fohrloop/wakepy/pull/328), [#346](https://github.com/fohrloop/wakepy/pull/346))

--- a/docs/source/user-guide.md
+++ b/docs/source/user-guide.md
@@ -69,21 +69,26 @@ used_method: org.gnome.SessionManager
 ## Controlling the on-fail action
 ```{versionadded} 0.8.0
 ```
+```{versionchanged} 0.10.0
+`on_fail` defaults to "warn" instead of "error". See: [wakepy/#376](https://github.com/fohrloop/wakepy/issues/376).
+```
 
-Wakepy follows the [Zen on Python](https://peps.python.org/pep-0020/):
+The wakepy Modes (e.g. [`keep.running`](#keep-running-mode) and  [`keep.presenting`](#keep-presenting-mode)) also take an `on_fail` input argument which may be used to alter the behavior. Example:
 
-> Errors should never pass silently.  
-> Unless explicitly silenced.
+```{code-block} python
+from wakepy import keep
 
-and therefore by default if a mode cannot be activated, an {class}`~wakepy.ActivationError` is raised. The wakepy Modes also take an `on_fail` input argument which may be used to alter the behavior.
+with keep.running(on_fail="warn"):
+    # do something
+```
 
 
 ### on-fail actions
 
 | `on_fail`                | What happens? |
 | ------------------------ | ------------ |
-| "error"  (default)    | Raises an {class}`~wakepy.ActivationError`        |
-| "warn"  | Issues an {class}`~wakepy.ActivationWarning` |
+| "warn" (default) | Issues an {class}`~wakepy.ActivationWarning` |
+| "error" | Raises an {class}`~wakepy.ActivationError`        |
 | "pass"  | Does nothing |
 | Callable | The callable is called with one argument: the result of the activation which is <br> a instance of {class}`~wakepy.ActivationResult`. The call occurs before the with block is entered. |
 

--- a/src/wakepy/core/mode.py
+++ b/src/wakepy/core/mode.py
@@ -173,7 +173,7 @@ class Mode:
         method_classes: list[Type[Method]],
         methods_priority: Optional[MethodsPriorityOrder] = None,
         name: Optional[ModeName | str] = None,
-        on_fail: OnFail = "error",
+        on_fail: OnFail = "warn",
         dbus_adapter: Type[DBusAdapter] | DBusAdapterTypeSeq | None = None,
     ):
         r"""Initialize a `Mode` using `Method`\ s.
@@ -209,7 +209,7 @@ class Mode:
         methods: Optional[StrCollection] = None,
         omit: Optional[StrCollection] = None,
         methods_priority: Optional[MethodsPriorityOrder] = None,
-        on_fail: OnFail = "error",
+        on_fail: OnFail = "warn",
         dbus_adapter: Type[DBusAdapter] | DBusAdapterTypeSeq | None = None,
     ) -> Mode:
         """

--- a/src/wakepy/modes/keep.py
+++ b/src/wakepy/modes/keep.py
@@ -18,7 +18,7 @@ def running(
     methods: Optional[StrCollection] = None,
     omit: Optional[StrCollection] = None,
     methods_priority: Optional[MethodsPriorityOrder] = None,
-    on_fail: OnFail = "error",
+    on_fail: OnFail = "warn",
     dbus_adapter: Type[DBusAdapter] | DBusAdapterTypeSeq | None = None,
 ) -> Mode:
     """Create a wakepy mode (a context manager) for keeping programs running.
@@ -91,7 +91,7 @@ def presenting(
     methods: Optional[StrCollection] = None,
     omit: Optional[StrCollection] = None,
     methods_priority: Optional[MethodsPriorityOrder] = None,
-    on_fail: OnFail = "error",
+    on_fail: OnFail = "warn",
     dbus_adapter: Type[DBusAdapter] | DBusAdapterTypeSeq | None = None,
 ) -> Mode:
     """Create a wakepy mode (a context manager) for keeping a system running


### PR DESCRIPTION
Closes: #376

This change can also be reverted if this seems to be troublesome. But with default `on_fail` of "warn", most people will be probably happier and do not think that wakepy is "flaky" e.g. on linux, where it's not always possible (at least yet) to prevent automatic idle action / suspend.