### PR TITLE
Rename the CLI flags: Addendum to PR 356

### DIFF
--- a/docs/source/cli-api.md
+++ b/docs/source/cli-api.md
@@ -19,9 +19,9 @@ wakepy [-h] [-k] [-p]
 
 options:
   -h, --help               show this help message and exit
-  -k, --keep-running       Keep programs running; inhibit automatic sleep/suspend. This
+  -r, --keep-running       Keep programs running; inhibit automatic sleep/suspend. This
                            is used as a default if no modes are selected.
-  -p, --presentation       Presentation mode; inhibit automatic sleep, screensaver and
+  -p, --keep-presenting    Presentation mode; inhibit automatic sleep, screensaver and
                            screenlock
 ```
 

--- a/docs/source/cli-api.md
+++ b/docs/source/cli-api.md
@@ -15,7 +15,7 @@ python -m wakepy
 This starts wakepy in the *default mode* (`-k`), which corresponds to a call to `keep.running` with default arguments. The available options are:
 
 ```{code-block} output
-wakepy [-h] [-k] [-p]
+wakepy [-h | -r | -p]
 
 options:
   -h, --help               show this help message and exit
@@ -31,3 +31,7 @@ options:
 
 If you just installed `wakepy`, you might need to restart shell / terminal application to make added to the PATH.
 ````
+
+```{versionchanged} 0.10.0
+Renamed `-k` to `-r` and `--presentation` to `--keep-presenting` ([wakepy/#355](https://github.com/fohrloop/wakepy/issues/355)).
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,9 +85,6 @@ disallow_untyped_defs = false
 module = ['toxfile']
 disallow_any_unimported = false
 
-[tool.pytest.ini_options]
-filterwarnings = "ignore:.*is deprecated in wakepy 0.7.0 and will be removed in a future version of wakepy.*:DeprecationWarning"
-
 [tool.coverage.run]
 plugins = ["coverage_conditional_plugin"]
 omit = [

--- a/src/wakepy/__main__.py
+++ b/src/wakepy/__main__.py
@@ -16,7 +16,6 @@ import itertools
 import sys
 import time
 import typing
-import warnings
 from textwrap import dedent, fill
 
 from wakepy import ModeExit

--- a/src/wakepy/__main__.py
+++ b/src/wakepy/__main__.py
@@ -51,7 +51,7 @@ def main() -> None:
 
     # print the deprecations _after_ the startup text to make them more visible
     for deprecation_msg in deprecations:
-        warnings.warn(deprecation_msg, category=DeprecationWarning)  # pragma: no cover
+        print(deprecation_msg)  # pragma: no cover
 
     with mode:
         if not mode.active:


### PR DESCRIPTION
Amends: #356
Relates to issue: #355

- Update CLI API docs
- Use print() instead of DeprecationWarning, as DeprecationWarnings are
  not printed to standard output by default.