### PR TITLE
Add PyPy Support + tests

### DIFF
--- a/.github/workflows/build-and-run-tests.yml
+++ b/.github/workflows/build-and-run-tests.yml
@@ -51,7 +51,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         # All supported python versions on linux
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "pypy3.7", "pypy3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "pypy3.8", "pypy3.10"]
         include:
           # Oldest supported python on MacOS
           - python-version: "3.7"

--- a/.github/workflows/build-and-run-tests.yml
+++ b/.github/workflows/build-and-run-tests.yml
@@ -51,7 +51,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         # All supported python versions on linux
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "pypy3.7", "pypy3.10"]
         include:
           # Oldest supported python on MacOS
           - python-version: "3.7"
@@ -64,6 +64,9 @@ jobs:
             os: windows-latest
           # Newest supported python on Windows
           - python-version: "3.13"
+            os: windows-latest
+          # PyPy on Windows
+          - python-version: "pypy3.10"
             os: windows-latest
       fail-fast: false
 

--- a/DEV.md
+++ b/DEV.md
@@ -71,8 +71,12 @@ run code formatting checks.
 
 ## Running tests with multiple environments
 
-- Requirement:  One or more of the python versions mentioned in the envlist in tox.ini have to be installed and available for tox. Missing python versions are going to be simply skipped. If running on UNIX/macOS,
-  you may use [pyenv](https://github.com/pyenv/pyenv) to install multiple versions of python.
+- Requirement:  One or more of the python versions mentioned in the envlist in tox.ini have to be installed and available for tox. Missing python versions are going to be simply skipped. If running on UNIX/macOS, you may use [pyenv](https://github.com/pyenv/pyenv) to install multiple versions of python. In this case, you probably want to use the [pyenv global](https://github.com/pyenv/pyenv/blob/master/COMMANDS.md#pyenv-global-advanced) to mark multiple versions, as in the example below. Also note that pypy3.7 would be used in place of CPython3.7 with py37 tox marker, if CPython3.7 is not installed.
+
+```
+pyenv global 3.12.6 3.10.15 3.7.17 pypy3.10 pypy3.7
+```
+
 - To run the tests with multiple python versions, use tox:
 
 ```

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Unix above refers to Linux in wakepy 0.9.x, but upcoming releases of wakepy will
 
 ## Installing
 
-Wakepy supports CPython 3.7 to 3.13 (PyPy support: [wakepy/#274](https://github.com/fohrloop/wakepy/issues/274)), and may be installed from [PyPI](https://pypi.org/project/wakepy/) with
+Wakepy supports CPython 3.7 to 3.13 and PyPy 3.8 to 3.10, and may be installed from [PyPI](https://pypi.org/project/wakepy/) with
 
 ```
 pip install wakepy
@@ -241,7 +241,7 @@ Wakepy vision is to support *any*<sup>†</sup> environment which runs Python. T
   </tbody>
 </table>
 
-In addition, [supporting PyPy](https://github.com/fohrloop/wakepy/issues/274) is on the roadmap. If you have ideas or comments, please post yours on [wakepy/#317](https://github.com/fohrloop/wakepy/discussions/317).
+If you have ideas or comments, please post yours on [wakepy/#317](https://github.com/fohrloop/wakepy/discussions/317).
 
 ## Licenses
 

--- a/docs/source/installing.md
+++ b/docs/source/installing.md
@@ -1,6 +1,11 @@
 # Installing
 
-The supported python versions are CPython 3.7, 3.8, 3.9, 3.10, 3.12 and 3.13 (PyPy support: [wakepy/#274](https://github.com/fohrloop/wakepy/issues/274)).
+The supported python versions are
+
+- CPython 3.7, 3.8, 3.9, 3.10, 3.12 and 3.13
+- [PyPy](https://pypy.org/) 3.8, 3.9 and 3.10 (PyPy 3.7 might work as well [^pypy37])
+
+[^pypy37]: The PyPy 3.7 also passes unit tests but cannot be used with mypy, so it's not officially supported. See: [this comment in wakepy/#393](https://github.com/fohrloop/wakepy/pull/393#issuecomment-2362974437)
 
 ## PyPI
 Wakepy may be installed from [PyPI](https://pypi.org/project/wakepy/) with pip (or [uv](https://github.com/astral-sh/uv)). For example:

--- a/requirements/requirements-mypy.txt
+++ b/requirements/requirements-mypy.txt
@@ -4,10 +4,8 @@ mypy==1.11.2; python_version>='3.8'
 mypy==1.4.1; python_version=='3.7'
 
 
-# The following installs are for mypy.
+# For mypy:
 pytest -c requirements-test.txt
-time-machine -c requirements-test.txt
-
 types-colorama
 types-colorama==0.4.15.12; python_version>='3.7'
 

--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -13,9 +13,5 @@ pytest-cov==5.0.0; python_version>='3.8'
 pytest-cov==4.1.0; python_version=='3.7'
 coverage-conditional-plugin==0.9.0
 
-# Python 3.7 support dropped in time-machine 2.11.0
-time-machine==2.14.0; python_version>='3.8'
-time-machine==2.10.0; python_version=='3.7'
-
 # Jeepney is used in the integration tests for creating a D-Bus server
 jeepney==0.8.0;sys_platform=='linux'

--- a/tests/unit/test_core/test_method/test_activation.py
+++ b/tests/unit/test_core/test_method/test_activation.py
@@ -8,7 +8,6 @@ import re
 from unittest.mock import patch
 
 import pytest
-import time_machine
 
 from tests.unit.test_core.testmethods import (
     FAILURE_REASON,
@@ -227,15 +226,15 @@ class TestTryEnterAndHeartbeat:
             assert "The only accepted return value is None" in err_message
             assert heartbeat_call_time is None
 
-    @time_machine.travel(
-        dt.datetime(2023, 12, 21, 16, 17, tzinfo=dt.timezone.utc), tick=False
-    )
-    def test_enter_mode_missing_heartbeat_success(self):
+    @patch("wakepy.core.method.dt.datetime")
+    def test_enter_mode_missing_heartbeat_success(self, mock_datetime):
         """Tests 4) MS from TABLE 1; enter_mode missing, heartbeat success"""
 
         expected_time = dt.datetime.strptime(
             "2023-12-21 16:17:00", "%Y-%m-%d %H:%M:%S"
         ).replace(tzinfo=dt.timezone.utc)
+        mock_datetime.now.return_value = expected_time
+
         for method in combinations_of_test_methods(
             enter_mode=[METHOD_MISSING],
             heartbeat=[None],
@@ -307,14 +306,13 @@ class TestTryEnterAndHeartbeat:
             ):
                 try_enter_and_heartbeat(method)
 
-    @time_machine.travel(
-        dt.datetime(2023, 12, 21, 16, 17, tzinfo=dt.timezone.utc), tick=False
-    )
-    def test_enter_mode_success_heartbeat_success(self):
+    @patch("wakepy.core.method.dt.datetime")
+    def test_enter_mode_success_heartbeat_success(self, mock_datetime):
         """Tests 7) SS from TABLE 1; enter_mode success & heartbeat success"""
         expected_time = dt.datetime.strptime(
             "2023-12-21 16:17:00", "%Y-%m-%d %H:%M:%S"
         ).replace(tzinfo=dt.timezone.utc)
+        mock_datetime.now.return_value = expected_time
 
         for method in combinations_of_test_methods(
             enter_mode=[None],

--- a/tests/unit/test_core/test_method/test_activation.py
+++ b/tests/unit/test_core/test_method/test_activation.py
@@ -226,14 +226,9 @@ class TestTryEnterAndHeartbeat:
             assert "The only accepted return value is None" in err_message
             assert heartbeat_call_time is None
 
-    @patch("wakepy.core.method.dt.datetime")
-    def test_enter_mode_missing_heartbeat_success(self, mock_datetime):
+    @pytest.mark.usefixtures("mock_datetime")
+    def test_enter_mode_missing_heartbeat_success(self):
         """Tests 4) MS from TABLE 1; enter_mode missing, heartbeat success"""
-
-        expected_time = dt.datetime.strptime(
-            "2023-12-21 16:17:00", "%Y-%m-%d %H:%M:%S"
-        ).replace(tzinfo=dt.timezone.utc)
-        mock_datetime.now.return_value = expected_time
 
         for method in combinations_of_test_methods(
             enter_mode=[METHOD_MISSING],
@@ -242,7 +237,7 @@ class TestTryEnterAndHeartbeat:
         ):
             res = try_enter_and_heartbeat(method)
             # Expecting: Return Success + '' +  heartbeat time
-            assert res == (True, "", expected_time)
+            assert res == (True, "", self.fake_datetime_now)
 
     def test_enter_mode_success_heartbeat_missing(self):
         """Tests 5) SM from TABLE 1; enter_mode success, heartbeat missing"""
@@ -306,14 +301,9 @@ class TestTryEnterAndHeartbeat:
             ):
                 try_enter_and_heartbeat(method)
 
-    @patch("wakepy.core.method.dt.datetime")
-    def test_enter_mode_success_heartbeat_success(self, mock_datetime):
+    @pytest.mark.usefixtures("mock_datetime")
+    def test_enter_mode_success_heartbeat_success(self):
         """Tests 7) SS from TABLE 1; enter_mode success & heartbeat success"""
-        expected_time = dt.datetime.strptime(
-            "2023-12-21 16:17:00", "%Y-%m-%d %H:%M:%S"
-        ).replace(tzinfo=dt.timezone.utc)
-        mock_datetime.now.return_value = expected_time
-
         for method in combinations_of_test_methods(
             enter_mode=[None],
             heartbeat=[None],
@@ -321,7 +311,7 @@ class TestTryEnterAndHeartbeat:
         ):
             res = try_enter_and_heartbeat(method)
             # Expecting Return Success + '' + heartbeat time
-            assert res == (True, "", expected_time)
+            assert res == (True, "", self.fake_datetime_now)
 
     def test_enter_mode_returns_bad_balue(self):
         # Case: returning bad value (None return value accepted)
@@ -340,6 +330,14 @@ class TestTryEnterAndHeartbeat:
         assert success is False
         assert "The only accepted return value is None" in err_message
         assert heartbeat_call_time is None
+
+    fake_datetime_now = dt.datetime.strptime("2000-01-01 12:34:56", "%Y-%m-%d %H:%M:%S")
+
+    @pytest.fixture
+    def mock_datetime(self):
+        with patch("wakepy.core.method.dt.datetime") as datetime:
+            datetime.now.return_value = self.fake_datetime_now
+            yield
 
 
 class TestCanIUseFails:

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,8 @@ envlist =
     py311
     py312
     py313
+    pypy3.7
+    pypy3.10
     check
 minversion = 4.8.0
 


### PR DESCRIPTION
Closes: #274

- Add tests for PyPy in the GitHub Actions
- Replaced time-machine with mocked datetime.now() to make it possible to run tests with PyPy
- Update documentation

Note: It's likely that all versions of wakepy have been running well with PyPy. This is just the official rubber stamp as there's now also CI tests for PyPy.
