### PR TITLE
Fix the wakepy logo/text printed to CLI 

### DIFF
--- a/src/wakepy/__main__.py
+++ b/src/wakepy/__main__.py
@@ -191,7 +191,7 @@ def get_startup_text(mode: ModeName) -> str:
     from wakepy import __version__
 
     wakepy_text = WAKEPY_TEXT_TEMPLATE.format(
-        VERSION_STRING=f"{'  v.'+__version__[:24]: <24}"
+        VERSION_STRING=f"{'  v.'+__version__[:24]: <28}"
     )
     options_txt = WAKEPY_TICKBOXES_TEMPLATE.strip("\n").format(
         no_auto_suspend="x",


### PR DESCRIPTION
Closes: #399

This got broken in #396 (part of 0.10.0 release)

