### PR TITLE
Fix: Cannot install -r requirements/requirements-test.txt

### DIFF
--- a/requirements/requirements-docs.txt
+++ b/requirements/requirements-docs.txt
@@ -3,6 +3,7 @@ accessible-pygments==0.0.5
 alabaster==0.7.16
 Babel==2.15.0
 beautifulsoup4==4.12.3
+# Need the build in order to get the _version.py
 build==1.1.1
 certifi==2024.2.2
 charset-normalizer==3.3.2
@@ -15,7 +16,8 @@ MarkupSafe==2.1.5
 mdit-py-plugins==0.4.1
 mdurl==0.1.2
 myst-parser==2.0.0
-packaging==24.0
+numpydoc==1.7.0
+packaging==24.1
 pydata-sphinx-theme==0.15.3
 Pygments==2.18.0
 pyproject_hooks==1.1.0
@@ -37,7 +39,3 @@ tabulate==0.9.0
 tomli==2.0.1
 typing_extensions==4.12.0
 urllib3==2.2.1
-numpydoc==1.7.0
-
-# Need to build in order to get the _version.py
-build==1.1.1


### PR DESCRIPTION
Closes: #402

Could not create the development environment with the instructions because of version clash caused by changes introduced in #389