### PR TITLE
Fix keep.running mode on KDE Plasma 6.x.x

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -3,6 +3,9 @@
 ## wakepy x.x.x
 🗓️ unreleased
 
+### 🐞 Bug fixes
+- Fix keep.running mode on KDE Plasma 6.x.x, when `plasmashell --version` output contained extra lines, such as "QThreadStorage: entry 3 destroyed before end of thread 0x61b4ee73d540"
+
 ### 👷 Maintenance
 - Disallow TODO comments ([#410](https://github.com/fohrloop/wakepy/pull/410))
 

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -4,7 +4,7 @@
 🗓️ unreleased
 
 ### 🐞 Bug fixes
-- Fix keep.running mode on KDE Plasma 6.x.x, when `plasmashell --version` output contained extra lines, such as "QThreadStorage: entry 3 destroyed before end of thread 0x61b4ee73d540"
+- Fix keep.running mode on KDE Plasma 6.x.x, when `plasmashell --version` output contained extra lines, such as "QThreadStorage: entry 3 destroyed before end of thread 0x61b4ee73d540" ([#417](https://github.com/fohrloop/wakepy/pull/417))
 
 ### 👷 Maintenance
 - Disallow TODO comments ([#410](https://github.com/fohrloop/wakepy/pull/410))

--- a/src/wakepy/methods/freedesktop.py
+++ b/src/wakepy/methods/freedesktop.py
@@ -233,12 +233,16 @@ def _get_kde_plasma_version() -> Optional[Tuple[int, ...]]:
         If no KDE Plasma is found, returns None.
 
     """
-    # returns for example 'plasmashell 5.27.9'
-    out = subprocess.getoutput("plasmashell --version")
-    mtch = re.match("plasmashell ([0-9][0-9.]*)$", out)
-    if mtch is None:
+    # returns for example 'plasmashell 5.27.9' but may also return some
+    # additional text. See: https://github.com/fohrloop/wakepy/issues/415
+    output = subprocess.getoutput("plasmashell --version")
+    for line in output.splitlines():
+        match = re.match(".*plasmashell ([0-9.]*).*", line)
+        if match:
+            break
+    else:
         return None
 
-    versionstring = mtch.group(1)
+    versionstring = match.group(1)
     versiontuple = tuple(int(x) for x in versionstring.split("."))
     return versiontuple

--- a/tests/unit/test_methods/test_freedesktop.py
+++ b/tests/unit/test_methods/test_freedesktop.py
@@ -249,6 +249,37 @@ class TestGetKDEPlasmaVersion:
         ):
             assert _get_kde_plasma_version() == (4, 5, 6)
 
+    def test_success_with_additional_text_same_line(self):
+        with patch(
+            "wakepy.methods.freedesktop.subprocess.getoutput",
+            return_value="FOO plasmashell 4.5.6post-123 BAR",
+        ):
+            assert _get_kde_plasma_version() == (4, 5, 6)
+
+    def test_success_qthread_storage_pre(self):
+        # Test for bug: https://github.com/fohrloop/wakepy/issues/415
+        with patch(
+            "wakepy.methods.freedesktop.subprocess.getoutput",
+            return_value="QThreadStorage: entry 3 destroyed before end of thread 0x61b4ee73d540\nQThreadStorage: entry 2 destroyed before end of thread 0x61b4ee73d540\nplasmashell 6.3.4",  # noqa: E501
+        ):
+            assert _get_kde_plasma_version() == (6, 3, 4)
+
+    def test_success_qthread_storage_post(self):
+        # Test for bug: https://github.com/fohrloop/wakepy/issues/415
+        with patch(
+            "wakepy.methods.freedesktop.subprocess.getoutput",
+            return_value="plasmashell 6.3.4\nQThreadStorage: entry 3 destroyed before end of thread 0x61b4ee73d540\nQThreadStorage: entry 2 destroyed before end of thread 0x61b4ee73d540",  # noqa: E501
+        ):
+            assert _get_kde_plasma_version() == (6, 3, 4)
+
+    def test_success_qthread_storage_mid(self):
+        # Test for bug: https://github.com/fohrloop/wakepy/issues/415
+        with patch(
+            "wakepy.methods.freedesktop.subprocess.getoutput",
+            return_value="QThreadStorage: entry 3 destroyed before end of thread 0x61b4ee73d540\nplasmashell 6.3.4\nQThreadStorage: entry 2 destroyed before end of thread 0x61b4ee73d540",  # noqa: E501
+        ):
+            assert _get_kde_plasma_version() == (6, 3, 4)
+
     def test_bad_output(self):
         with patch(
             "wakepy.methods.freedesktop.subprocess.getoutput",


### PR DESCRIPTION
Fixes: #415 

On KDE Plasma 6.x.x, the output of `plasmashell --version` could contain extra lines. For example:

```
> plasmashell --version
plasmashell 6.3.4
QThreadStorage: entry 3 destroyed before end of thread 0x581f80656540
QThreadStorage: entry 2 destroyed before end of thread 0x581f80656540
```

That previously did not match the regex for getting the KDE Plasma version, and activating the keep.running mode would fail. Now the regex is more forgiving and accepts some extra text.