### PR TITLE
fix pipeline publishing releases to GitHub

### DIFF
--- a/.github/workflows/publish-a-release.yml
+++ b/.github/workflows/publish-a-release.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           name: wakepy-python-packages
           path: ./dist/
-      - uses: sigstore/gh-action-sigstore-python@61f6a500bbfdd9a2a339cf033e5421951fbc1cd2 #v2.1.1
+      - uses: sigstore/gh-action-sigstore-python@f514d46b907ebcd5bedc05145c03b69c1edd8b46 #v3.0.0
         with:
           inputs: >-
             ./dist/*.tar.gz

--- a/.github/workflows/publish-a-release.yml
+++ b/.github/workflows/publish-a-release.yml
@@ -29,7 +29,7 @@ jobs:
           inputs: >-
             ./dist/*.tar.gz
             ./dist/*.whl
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v.4.5.0
         with:
           name: signed-wakepy-python-packages
           path: ./dist/*.*


### PR DESCRIPTION
Fixes: https://github.com/fohrloop/wakepy/issues/421

use upload-artifact v4.5.0 instead of v4
update gh-action-sigstore-python from 2.1.1 to 3.0.0