### PR TITLE
Fix prioritized order of Methods

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -6,6 +6,9 @@
 ### ✨ Minor Enhancements
 - Better error message when selected Method is not part of the selected Mode ([#427](https://github.com/fohrloop/wakepy/pull/427))
 
+### 🐞 Bug fixes
+- Fix prioritized order of Methods ([#429](https://github.com/fohrloop/wakepy/pull/429)). 
+
 ## wakepy 0.10.2
 🗓️ 2025-04-21
 

--- a/src/wakepy/core/prioritization.py
+++ b/src/wakepy/core/prioritization.py
@@ -14,7 +14,7 @@ import typing
 from typing import List, Sequence, Set, Union
 
 from .constants import WAKEPY_FAKE_SUCCESS
-from .platform import CURRENT_PLATFORM
+from .platform import CURRENT_PLATFORM, get_platform_supported
 
 if typing.TYPE_CHECKING:
     from typing import List, Optional, Tuple, Union
@@ -254,7 +254,7 @@ def _order_set_of_methods_by_priority(methods: Set[MethodCls]) -> List[MethodCls
             0 if m.name == WAKEPY_FAKE_SUCCESS else 1,
             # Then, prioritize methods supporting CURRENT_PLATFORM over any
             # others
-            0 if CURRENT_PLATFORM in m.supported_platforms else 1,
+            0 if get_platform_supported(CURRENT_PLATFORM, m.supported_platforms) else 1,
             m.name.lower() if m.name else "",
         ),
     )

--- a/tests/unit/test_core/conftest.py
+++ b/tests/unit/test_core/conftest.py
@@ -44,11 +44,11 @@ def provide_methods_different_platforms(monkeypatch, testutils):
 
     class LinuxB(TestMethod):
         name = "LinuxB"
-        supported_platforms = (PlatformType.LINUX,)
+        supported_platforms = (PlatformType.UNIX_LIKE_FOSS,)
 
     class LinuxC(TestMethod):
         name = "LinuxC"
-        supported_platforms = (PlatformType.LINUX,)
+        supported_platforms = (PlatformType.UNIX_LIKE_FOSS,)
 
     class MultiPlatformA(TestMethod):
         name = "multiA"


### PR DESCRIPTION
Fixes: #428 

Background: Sometimes wakepy tried different Methods in wrong order. For example, it could try the "caffeinate" method (works only on MacOS) on Linux before any Linux-specific method. This problem has been introduced in https://github.com/fohrloop/wakepy/pull/379/ and was present in wakepy versions 0.10.0 to 0.10.2.

### On Linux (Gnome):

Before:
```
Could not activate Mode "keep.presenting"!

Method usage results, in order (highest priority first):
[(FAIL @PLATFORM_SUPPORT, caffeinate, ""), (FAIL @ACTIVATION, org.gnome.SessionManager, "ValueError('Buhuu this does not work yet')"), (FAIL @PLATFORM_SUPPORT, SetThreadExecutionState, "")]
```

After:

```
Could not activate Mode "keep.presenting"!

Method usage results, in order (highest priority first):
[(FAIL @ACTIVATION, org.gnome.SessionManager, "ValueError('Buhuu this does not work yet')"), (FAIL @PLATFORM_SUPPORT, caffeinate, ""), (FAIL @PLATFORM_SUPPORT, SetThreadExecutionState, "")]
```