### PR TITLE
Enhance Mode Activation Observability: Better Logs and Diagnostics

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -5,6 +5,7 @@
 
 ### ✨ Minor Enhancements
 - Better error message when selected Method is not part of the selected Mode ([#427](https://github.com/fohrloop/wakepy/pull/427))
+- Enhance Mode Activation Observability. Add logging (DEBUG and INFO level) for different parts in the Mode activation process. Show which methods are to be tried, and log any success and failure of activating a Mode. Improved the `ActivationResult.get_failure_text()` output. Added `NoMethodsWarning` which is issued if trying to activate a Mode with an empty list of methods. ([#411](https://github.com/fohrloop/wakepy/pull/411))
 
 ### 🐞 Bug fixes
 - Fix prioritized order of Methods ([#429](https://github.com/fohrloop/wakepy/pull/429)). 

--- a/tests/unit/test_core/test_activationresult.py
+++ b/tests/unit/test_core/test_activationresult.py
@@ -317,10 +317,11 @@ class TestActivationResult:
             [mr_platform_support_fail, mr_requirements_fail], mode_name="SomeMode"
         )
         assert ar.get_failure_text() == (
-            'Could not activate Mode "SomeMode"!\n\nMethod usage results, in order '
-            "(highest priority first):\n[(FAIL @PLATFORM_SUPPORT, fail-platform, "
-            '"Platform XYZ not supported!"), (FAIL @REQUIREMENTS, fail-requirements, '
-            '"Missing requirement: Some SW v.1.2.3")]'
+            'Could not activate wakepy Mode "SomeMode"!\n\nTried Methods (in the order '
+            "of attempt):\n(#1, fail-platform, PLATFORM_SUPPORT, Platform XYZ not "
+            "supported!),\n(#2, fail-requirements, REQUIREMENTS, Missing requirement: "
+            "Some SW v.1.2.3).\nThe format of each item in the list is (index, "
+            "method_name, failure_stage, failure_reason)."
         )
 
     def test_active_method(

--- a/tests/unit/test_modes.py
+++ b/tests/unit/test_modes.py
@@ -133,22 +133,26 @@ class TestOnFail:
     """Test failure handling for keep.presenting and keep.running. (the on_fail
     parameter)"""
 
+    @pytest.mark.filterwarnings("ignore:.*:wakepy.core.mode.NoMethodsWarning")
     def test_on_fail_pass(self, mode_under_test, expected_name):
         with mode_under_test(methods=[], on_fail="pass") as m:
             self._assertions_for_activation_failure(m, expected_name)
 
+    @pytest.mark.filterwarnings("ignore:.*:wakepy.core.mode.NoMethodsWarning")
     def test_on_fail_warn(self, mode_under_test, expected_name):
-        err_txt = f'Could not activate Mode "{expected_name}"!'
+        err_txt = f'Could not activate wakepy Mode "{expected_name}"!'
         with pytest.warns(ActivationWarning, match=re.escape(err_txt)):
             with mode_under_test(methods=[], on_fail="warn") as m:
                 self._assertions_for_activation_failure(m, expected_name)
 
+    @pytest.mark.filterwarnings("ignore:.*:wakepy.core.mode.NoMethodsWarning")
     def test_on_fail_error(self, mode_under_test, expected_name):
-        err_txt = f'Could not activate Mode "{expected_name}"!'
+        err_txt = f'Could not activate wakepy Mode "{expected_name}"!'
         with pytest.raises(ActivationError, match=re.escape(err_txt)):
             with mode_under_test(methods=[], on_fail="error") as m:
                 self._assertions_for_activation_failure(m, expected_name)
 
+    @pytest.mark.filterwarnings("ignore:.*:wakepy.core.mode.NoMethodsWarning")
     def test_on_fail_callable(self, mode_under_test, expected_name):
         called = False
 


### PR DESCRIPTION
Closes: #411 

* Add activation process related logs
* Improve the error text: ActivationResult.get_failure_text()
* Issue NoMethodsWarning if trying to activate a Mode with empty list of Methods

## Examples

Test script:

```python
import logging
import time

logging.basicConfig(
    level=logging.DEBUG, format="%(asctime)s - %(levelname)s - %(message)s"
)

from wakepy import keep

t0 = time.time()
with keep.presenting(
    methods=[
        "SetThreadExecutionState",
        "caffeinate",
        "org.gnome.SessionManager",
    ],
    on_fail="pass",
) as m:
    time.sleep(2)
```

**When activation successful**:

Shows clearly the different stages, the different methods to be used and the outcome. Both DEBUG and INFO level logs.

```
2025-07-10 12:12:10,084 - DEBUG - Creating wakepy mode "keep.presenting" with methods=['SetThreadExecutionState', 'caffeinate', 'org.gnome.SessionManager'], omit=None, methods_priority=None, on_fail=pass, dbus_adapter=None
2025-07-10 12:12:10,084 - DEBUG - Found 4 method(s) for mode "keep.presenting": [<class 'wakepy.methods.freedesktop.FreedesktopScreenSaverInhibit'>, <class 'wakepy.methods.gnome.GnomeSessionManagerNoIdle'>, <class 'wakepy.methods.macos.CaffeinateKeepPresenting'>, <class 'wakepy.methods.windows.WindowsKeepPresenting'>]
2025-07-10 12:12:10,085 - DEBUG - Selected 3 method(s) for mode "keep.presenting": [<class 'wakepy.methods.gnome.GnomeSessionManagerNoIdle'>, <class 'wakepy.methods.macos.CaffeinateKeepPresenting'>, <class 'wakepy.methods.windows.WindowsKeepPresenting'>]
2025-07-10 12:12:10,085 - DEBUG - 'WAKEPY_FAKE_SUCCESS' not set.
2025-07-10 12:12:10,086 - INFO - Activating wakepy mode "keep.presenting". Will try the following methods in this order: ['org.gnome.SessionManager', 'caffeinate', 'SetThreadExecutionState']
2025-07-10 12:12:10,150 - INFO - Activated wakepy mode "keep.presenting" with method: org.gnome.SessionManager
```

**Example of failure**

Shows which methods were tried, in what order, and why they failed
```
... (similar logs)
2025-07-10 12:13:53,389 - INFO - Activating wakepy mode "keep.presenting". Will try the following methods in this order: ['org.gnome.SessionManager', 'caffeinate', 'SetThreadExecutionState']
2025-07-10 12:13:53,440 - INFO - Could not activate wakepy Mode "keep.presenting"! Tried Methods (in the order of attempt): (#1, org.gnome.SessionManager, ACTIVATION, RuntimeError('Intentional failure here')), (#2, caffeinate, PLATFORM_SUPPORT, -), (#3, SetThreadExecutionState, PLATFORM_SUPPORT, -). The format of each item in the list is (index, method_name, failure_stage, failure_reason).
```

**Example of the ActivationResult.get_failure_text()**

```python
>>> # Assuming the activation will fail for some reason
>>> with keep.presenting() as m:
>>>     # do stuff
>>>
>>> print(m.activation_result.get_failure_text())
```

which could print:

```
Could not activate wakepy Mode "keep.presenting"!

Tried Methods (in the order of attempt):
(#1, org.gnome.SessionManager, ACTIVATION, RuntimeError('Intentional failure here')),
(#2, caffeinate, PLATFORM_SUPPORT, -),
(#3, SetThreadExecutionState, PLATFORM_SUPPORT, -).
The format of each item in the list is (index, method_name, failure_stage, failure_reason).
```

**Example of NoMethodsWarning**

When running:

```python
with keep.presenting(methods=[], on_fail="pass") as m:
    ...
```

example output:
```
2025-07-10 16:38:02,551 - DEBUG - Found 4 method(s) for mode "keep.presenting": [<class 'wakepy.methods.freedesktop.FreedesktopScreenSaverInhibit'>, <class 'wakepy.methods.gnome.GnomeSessionManagerNoIdle'>, <class 'wakepy.methods.macos.CaffeinateKeepPresenting'>, <class 'wakepy.methods.windows.WindowsKeepPresenting'>]
2025-07-10 16:38:02,552 - DEBUG - Selected 0 method(s) for mode "keep.presenting": []
/home/fohrloop/code/wakepy/bar.py:11: NoMethodsWarning: No methods selected for mode "keep.presenting"! This will lead to automatic failure of mode activation. To suppress this warning, select at least one of the available methods, which are: [<class 'wakepy.methods.freedesktop.FreedesktopScreenSaverInhibit'>, <class 'wakepy.methods.gnome.GnomeSessionManagerNoIdle'>, <class 'wakepy.methods.macos.CaffeinateKeepPresenting'>, <class 'wakepy.methods.windows.WindowsKeepPresenting'>]
  with keep.presenting(
2025-07-10 16:38:02,553 - DEBUG - 'WAKEPY_FAKE_SUCCESS' not set.
2025-07-10 16:38:02,554 - INFO - Activating wakepy mode "keep.presenting". Will try the following methods in this order: []
2025-07-10 16:38:02,596 - INFO - Could not activate wakepy Mode "keep.presenting"! Did not try any methods!
```