### PR TITLE
Use proper stacklevel in warnings

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -6,6 +6,7 @@
 ### ✨ Minor Enhancements
 - Better error message when selected Method is not part of the selected Mode ([#427](https://github.com/fohrloop/wakepy/pull/427))
 - Enhance Mode Activation Observability. Add logging (DEBUG and INFO level) for different parts in the Mode activation process. Show which methods are to be tried, and log any success and failure of activating a Mode. Improved the `ActivationResult.get_failure_text()` output. Added `NoMethodsWarning` which is issued if trying to activate a Mode with an empty list of methods. ([#411](https://github.com/fohrloop/wakepy/pull/411))
+- Make ActivationWarning use proper stacklevel, so that issued warnings point to user code, and not into wakepy source code. ([#432](https://github.com/fohrloop/wakepy/pull/432))
 
 ### 🐞 Bug fixes
 - Fix prioritized order of Methods ([#429](https://github.com/fohrloop/wakepy/pull/429)). 

--- a/src/wakepy/core/mode.py
+++ b/src/wakepy/core/mode.py
@@ -653,7 +653,7 @@ def handle_activation_fail(on_fail: OnFail, result: ActivationResult) -> None:
     if on_fail == "pass":
         return
     elif on_fail == "warn":
-        warnings.warn(result.get_failure_text(), ActivationWarning)
+        warnings.warn(result.get_failure_text(), ActivationWarning, stacklevel=4)
         return
     elif on_fail == "error":
         raise ActivationError(result.get_failure_text())

--- a/src/wakepy/core/platform.py
+++ b/src/wakepy/core/platform.py
@@ -29,7 +29,8 @@ def get_current_platform() -> IdentifiedPlatformType:
         return IdentifiedPlatformType.FREEBSD
 
     warnings.warn(
-        f"Could not detect current platform! Debug info:\n{get_platform_debug_info()}"
+        f"Could not detect current platform! Debug info:\n{get_platform_debug_info()}",
+        stacklevel=8,
     )
     return IdentifiedPlatformType.UNKNOWN
 


### PR DESCRIPTION
Fixes: #431

Previously, stacklevel on ActivationWarning was default (=1), which
would mean that the warning would point to a line inside wakepy source
code and not in the user code. 
