### PR TITLE
More readable failure reasons if a DBus based method fails

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -7,7 +7,7 @@
 - Update the wakepy CLI printout: Adds the used Method and activated Mode to the printout ([#434](https://github.com/fohrloop/wakepy/pull/434))
 
 ### ✨ Minor Enhancements
-- Better error message when selected Method is not part of the selected Mode ([#427](https://github.com/fohrloop/wakepy/pull/427))
+- Better error messages: When selected Method is not part of the selected Mode ([#427](https://github.com/fohrloop/wakepy/pull/427)) and when a D-Bus -based method fails ([#438](https://github.com/fohrloop/wakepy/pull/438))
 - Enhance Mode Activation Observability. Add logging (DEBUG and INFO level) for different parts in the Mode activation process. Show which methods are to be tried, and log any success and failure of activating a Mode. Improved the `ActivationResult.get_failure_text()` output. Added `NoMethodsWarning` which is issued if trying to activate a Mode with an empty list of methods. ([#411](https://github.com/fohrloop/wakepy/pull/411))
 - Make ActivationWarning use proper stacklevel, so that issued warnings point to user code, and not into wakepy source code. ([#432](https://github.com/fohrloop/wakepy/pull/432))
 

--- a/src/wakepy/core/method.py
+++ b/src/wakepy/core/method.py
@@ -49,6 +49,10 @@ unnamed = "__unnamed__"
 """Constant for defining unnamed Method(s)"""
 
 
+class DBusCallError(RuntimeError):
+    """Raised when a Method's D-Bus call fails."""
+
+
 class Method(ABC):
     """Methods are objects that are used to switch modes. The phases for
     changing and being in a Mode is:
@@ -273,7 +277,14 @@ class Method(ABC):
                 f'{self.__class__.__name__ } cannot process dbus method call "{call}" '
                 "as it does not have a DBusAdapter."
             )
-        return self.dbus_adapter.process(call)
+        try:
+            return self.dbus_adapter.process(call)
+        except Exception as exc:
+            raise DBusCallError(
+                f"DBus call of method '{call.method.name}' on interface "
+                f"'{call.method.interface}' with args {call.args} failed with message: "
+                f"{exc}"
+            ) from exc
 
     def __str__(self) -> str:
         return f"<wakepy Method: {self.__class__.__name__}>"


### PR DESCRIPTION
Fixes: #437

Failure reason in the ActivationResult is now more readable if the failure comes from a DBus call.

Before:

```
(#1, org.freedesktop.PowerManagement, ACTIVATION, DBusErrorResponse(Message(Header(<Endianness.little: 1>, 
<MessageType.error: 3>, <MessageFlag.no_reply_expected: 1>, 1, 32, 4294967295, fields={<HeaderFields.reply_serial:
 5>: 2, <HeaderFields.sender: 7>: 'org.freedesktop.DBus', <HeaderFields.error_name: 4>:
 'org.freedesktop.DBus.Error.ServiceUnknown', <HeaderFields.signature: 8>: 's', <HeaderFields.destination: 6>: ':1.476'}),
 ('The name is not activatable',)))),
```

After:

```
(#1, org.freedesktop.PowerManagement, ACTIVATION, DBusCallError("DBus call of method 'Inhibit' on interface
 'org.freedesktop.PowerManagement.Inhibit' with args ('wakepy', 'wakelock active') failed with message:
 [org.freedesktop.DBus.Error.ServiceUnknown] ('The name is not activatable',)")),
```