### PR TITLE
Fix development environment requirements on Windows

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -14,6 +14,12 @@ Requirements:
 - At least one of the supported Python versions installed (see README.md and/or tox.ini).
 - pip >= 21.3 (for pyproject.toml support)
 
+Update pip and install wheel:
+
+```
+python -m pip install -U pip wheel
+```
+
 Install in editable state with the `dev` requirements:
 ```
 python -m pip install -r requirements/requirements-dev.txt -e .

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -5,7 +5,10 @@
 -r requirements-docs.txt
 -r requirements-check.txt
 
-sphinx-autobuild==2024.9.19
+# On Windows, cannot use later version of sphinx-autobuild until
+# https://github.com/sphinx-doc/sphinx-autobuild/issues/197 is resolved.
+# See also: https://github.com/fohrloop/wakepy/issues/444
+sphinx-autobuild==2024.4.16
 IPython
 invoke==2.2.0
 # Colorama is used with the tasks.py (invoke commands)


### PR DESCRIPTION
Fixes: #444

There were two easy solutions for the problem

1. Instruct using pip<=23.2.1
2. Downgrade to sphinx-autobuild==2024.4.16

Out of these two options, downgrading the sphinx-autobuild seemed like the right solution.  It is not possible to use later version of pip on Windows with more recent versions of sphinx-autobuild until https://github.com/sphinx-doc/sphinx-autobuild/issues/197 is resolved.

