### PR TITLE
Fix flaky tests on pypy+windows

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -17,6 +17,7 @@
 
 ### 👷 Maintenance
 - Fix development environment setup instructions and requirements on Windows ([#445](https://github.com/fohrloop/wakepy/pull/445))
+- Fix flaky tests on pypy+windows ([#447](https://github.com/fohrloop/wakepy/pull/447))
 
 ## wakepy 0.10.2
 🗓️ 2025-04-21

--- a/src/wakepy/methods/windows.py
+++ b/src/wakepy/methods/windows.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import ctypes
 import enum
+import warnings
 import logging
 import threading
 import typing
@@ -81,6 +82,13 @@ class WindowsSetThreadExecutionState(Method, ABC):
         )
         self._inhibiting_thread.start()
         self._check_thread_response()
+        if not self._queue_from_thread.empty(): # pragma: no cover
+            warnings.warn(
+                'The queue from the inhibitor thread contained more than one respose! '
+                'This most likely means that the thread exited before being released '
+                'due to a small timeout value. This should never happen outside tests, '
+                'and if this occurs in tests, it means that the _release_event_timeout '
+                'is set too low!')
 
     def exit_mode(self) -> None:
         self._release.set()

--- a/src/wakepy/methods/windows.py
+++ b/src/wakepy/methods/windows.py
@@ -9,10 +9,10 @@ from __future__ import annotations
 
 import ctypes
 import enum
-import warnings
 import logging
 import threading
 import typing
+import warnings
 from abc import ABC, abstractmethod
 from queue import Queue
 from threading import Event, Thread
@@ -82,13 +82,14 @@ class WindowsSetThreadExecutionState(Method, ABC):
         )
         self._inhibiting_thread.start()
         self._check_thread_response()
-        if not self._queue_from_thread.empty(): # pragma: no cover
+        if not self._queue_from_thread.empty():  # pragma: no cover
             warnings.warn(
-                'The queue from the inhibitor thread contained more than one respose! '
-                'This most likely means that the thread exited before being released '
-                'due to a small timeout value. This should never happen outside tests, '
-                'and if this occurs in tests, it means that the _release_event_timeout '
-                'is set too low!')
+                "The queue from the inhibitor thread contained more than one respose! "
+                "This most likely means that the thread exited before being released "
+                "due to a small timeout value. This should never happen outside tests, "
+                "and if this occurs in tests, it means that the _release_event_timeout "
+                "is set too low!"
+            )
 
     def exit_mode(self) -> None:
         self._release.set()

--- a/tests/unit/test_methods/test_windows.py
+++ b/tests/unit/test_methods/test_windows.py
@@ -15,6 +15,7 @@ from wakepy.methods.windows import Flags, WindowsKeepPresenting, WindowsKeepRunn
 windows.WindowsSetThreadExecutionState._release_event_timeout = 0.5
 """Make tests *not* to wait forever. A too small value may cause flaky tests.
 Previously, a value of 0.001 caused tests on PyPy on Windows to fail randomly.
+See: https://github.com/fohrloop/wakepy/pull/447
 """
 
 patch_SetThreadExecutionState_working = patch(

--- a/tests/unit/test_methods/test_windows.py
+++ b/tests/unit/test_methods/test_windows.py
@@ -12,8 +12,10 @@ if sys.platform != "win32":
 import wakepy.methods.windows as windows  # type: ignore[unreachable, unused-ignore]
 from wakepy.methods.windows import Flags, WindowsKeepPresenting, WindowsKeepRunning
 
-windows.WindowsSetThreadExecutionState._release_event_timeout = 0.001
-"""Make tests *not* to wait forever"""
+windows.WindowsSetThreadExecutionState._release_event_timeout = 0.5
+"""Make tests *not* to wait forever. A too small value may cause flaky tests.
+Previously, a value of 0.001 caused tests on PyPy on Windows to fail randomly.
+"""
 
 patch_SetThreadExecutionState_working = patch(
     "wakepy.methods.windows.ctypes.windll.kernel32.SetThreadExecutionState",


### PR DESCRIPTION
Fixes: #443

The explanation for this problem was pretty simple:
- When using wakepy normally, it waits undefinitely in the worker thread for uninhibit command (release event)
- During tests, a 1ms timeout value was used for the release event. This was enough in every other case, but not with PyPy+Windows combination. For some reason, code runs slower with PyPy+Windows and the timeout needed to be increased.

As a fix: Changed the timeout from 1ms to 500ms. Also added a helpful(?) warning which will be issued if the queue gets two items instead of one (which happens if the timeout is too small).