### PR TITLE
Remove the AttributeError traceback when building docs on Windows/MacOS

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -107,6 +107,13 @@ numpydoc_class_members_toctree = False
 # listings (duplicate info).
 numpydoc_show_class_members = False
 
+# This is a fix for https://github.com/fohrloop/wakepy/issues/448
+autodoc_mock_imports = []
+try:
+    from wakepy import JeepneyDBusAdapter  # noqa: F401
+except ImportError:
+    autodoc_mock_imports.append("wakepy.dbus_adapters.jeepney")
+
 
 def setup(app: Sphinx) -> None:
     app.add_js_file("wakepy-docs.js", loading_method="defer")

--- a/tasks.py
+++ b/tasks.py
@@ -84,6 +84,11 @@ def check(c) -> None:
 @task
 def docs(c) -> None:
     """Starts sphinx build with live-reload on browser."""
+    if not is_unix_like_foss(CURRENT_PLATFORM):
+        print(
+            "WARNING: Note that full docs are built only on Linux / BSD (most of the "
+            "docs are fine)"
+        )
 
     run = get_run_with_print(c)
     # The `-a` flag ensures that *all* files (not only edited files) will get


### PR DESCRIPTION
Fixes: #448