### PR TITLE
mode_name is str instead of ModeName | str

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -23,6 +23,7 @@
 ### 🚨 Backwards incompatible changes
 - Make the `Mode._from_name()` and `Mode._method_classes` private; Not part of the public API anymore ([#458](https://github.com/fohrloop/wakepy/pull/458))
 - The `Mode.active_method`, `Mode.used_method`, are now instances of the new ModeInfo (previously strings) ([#460](https://github.com/fohrloop/wakepy/pull/460))
+- The `ActivationResult.mode_name` is now always a string (instead of being a ModeName) ([#462](https://github.com/fohrloop/wakepy/pull/462))
 
 ### 👷 Maintenance
 - Fix development environment setup instructions and requirements on Windows ([#445](https://github.com/fohrloop/wakepy/pull/445))

--- a/src/wakepy/core/activationresult.py
+++ b/src/wakepy/core/activationresult.py
@@ -80,7 +80,11 @@ class ActivationResult:
 
     mode_name: Optional[str] = None
     """Name of the :class:`Mode`. If the associated ``Mode`` does not have a
-    name, the ``mode_name`` will be ``None``."""
+    name, the ``mode_name`` will be ``None``.
+
+    .. versionchanged:: 1.0.0.
+        The ``mode_name`` is now always a string (or None) instead of
+        ``ModeName``."""
 
     active_method: MethodInfo | None = field(init=False)
     """The :class:`MethodInfo` about the used (successful) :class:`Method`. If

--- a/src/wakepy/core/activationresult.py
+++ b/src/wakepy/core/activationresult.py
@@ -22,7 +22,6 @@ from .constants import WAKEPY_FAKE_SUCCESS, StageName, StageNameValue
 if typing.TYPE_CHECKING:
     from typing import Optional
 
-    from .constants import ModeName
     from .method import MethodInfo
 
 
@@ -328,7 +327,7 @@ class MethodActivationResult:
         return f"({success_str}{error_at}, {self.method_name}{failure_reason})"
 
     @property
-    def mode_name(self) -> ModeName | str:
+    def mode_name(self) -> str:
         """The name of the mode of the :class:`Method` this result is for."""
         return self.method.mode_name
 

--- a/src/wakepy/core/method.py
+++ b/src/wakepy/core/method.py
@@ -643,7 +643,7 @@ class MethodInfo:
     :ref:`wakepy-methods`. Examples: "SetThreadExecutionState", "caffeinate".
     """
 
-    mode_name: ModeName | str
+    mode_name: str
     """The name of the mode the method implements. Examples: "keep.running" for
     the :func:`keep.presenting <wakepy.keep.presenting>` mode and
     "keep.presenting" for the :func:`keep.running <wakepy.keep.running>` mode.
@@ -657,7 +657,7 @@ class MethodInfo:
         """Creates a MethodInfo from a Method instance."""
         return cls(
             name=method.name,
-            mode_name=method.mode_name,
+            mode_name=str(method.mode_name),
             supported_platforms=method.supported_platforms,
         )
 


### PR DESCRIPTION
Closes: #455 together with #459 and #460

The `ModeName | str` is just confusing to end-users. 

For all end-user-facing parts, all "Mode names" will be simply strings.

