### PR TITLE
remove unused Mode._logger

### DIFF
--- a/src/wakepy/core/mode.py
+++ b/src/wakepy/core/mode.py
@@ -230,7 +230,6 @@ class Mode:
 
         self.on_fail = on_fail
         self.methods_priority = methods_priority
-        self._logger = logging.getLogger(__name__)
 
     @classmethod
     def _from_name(


### PR DESCRIPTION
Mode has ._logger attribute which is never used. Removing it.