### PR TITLE
Improve logging: org.gnome.Sessionmanager and freedesktop methods

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -13,6 +13,7 @@
 - Better error messages: When selected Method is not part of the selected Mode ([#427](https://github.com/fohrloop/wakepy/pull/427)) and when a D-Bus -based method fails ([#438](https://github.com/fohrloop/wakepy/pull/438))
 - Enhance Mode Activation Observability. Add logging (DEBUG and INFO level) for different parts in the Mode activation process. Show which methods are to be tried, and log any success and failure of activating a Mode. Improved the `ActivationResult.get_failure_text()` output. Added `NoMethodsWarning` which is issued if trying to activate a Mode with an empty list of methods. ([#411](https://github.com/fohrloop/wakepy/pull/411)) 
 - Add logging to every Method activation and deactivation step ([#469](https://github.com/fohrloop/wakepy/pull/469))
+- Improve logging: org.gnome.Sessionmanager and freedesktop methods ([#474](https://github.com/fohrloop/wakepy/pull/474))
 - Make ActivationWarning use proper stacklevel, so that issued warnings point to user code, and not into wakepy source code. ([#432](https://github.com/fohrloop/wakepy/pull/432))
 
 ### 🐞 Bug fixes

--- a/src/wakepy/methods/gnome.py
+++ b/src/wakepy/methods/gnome.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import enum
+import logging
 import typing
 from abc import ABC, abstractmethod
 
@@ -16,6 +17,8 @@ from wakepy.core import (
 
 if typing.TYPE_CHECKING:
     from typing import Optional
+
+logger = logging.getLogger(__name__)
 
 
 class GnomeFlag(enum.IntFlag):
@@ -82,6 +85,13 @@ class _GnomeSessionManager(Method, ABC):
             raise RuntimeError(
                 "Could not get inhibit cookie from org.gnome.SessionManager"
             )
+
+        logger.debug(
+            "Got inhibit cookie from org.gnome.SessionManager: %s. Flags: %s (%s)",
+            retval[0],
+            self.flags.name,
+            self.flags.value,
+        )
         self.inhibit_cookie = retval[0]
 
     def exit_mode(self) -> None:
@@ -89,6 +99,12 @@ class _GnomeSessionManager(Method, ABC):
             # Nothing to exit from.
             return
 
+        logger.debug(
+            "Exiting org.gnome.SessionManager mode using inhibit cookie: %s. Flags: %s (%s)",
+            self.inhibit_cookie,
+            self.flags.name,
+            self.flags.value,
+        )
         call = DBusMethodCall(
             method=self.method_uninhibit,
             args=dict(inhibit_cookie=self.inhibit_cookie),

--- a/src/wakepy/methods/gnome.py
+++ b/src/wakepy/methods/gnome.py
@@ -100,7 +100,7 @@ class _GnomeSessionManager(Method, ABC):
             return
 
         logger.debug(
-            "Exiting org.gnome.SessionManager mode using inhibit cookie: %s. Flags: %s (%s)",
+            "Exiting org.gnome.SessionManager mode using inhibit cookie: %s. Flags: %s (%s)",  # noqa: E501
             self.inhibit_cookie,
             self.flags.name,
             self.flags.value,


### PR DESCRIPTION
Add to the logs the used inhibitor cookie values on Gnome and freedesktop D-Bus based methods, and the detected DE. Make the detected DE to be always uppercase.