### PR TITLE
Raise ContextAlreadyEnteredError if trying to use context manager twice without exiting first

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -18,6 +18,7 @@
 
 ### 🐞 Bug fixes
 - Fix prioritized order of Methods ([#429](https://github.com/fohrloop/wakepy/pull/429)).
+- Raise ContextAlreadyEnteredError (subclass of RuntimeError) if trying to use context manager twice without exiting first ([#476](https://github.com/fohrloop/wakepy/pull/476))
 
 ### 📖 Documentation
 - Documentation page for [Post Keepawake behavior](https://wakepy.readthedocs.io/stable/post-keepawake-behavior.html). Documented the behavior on Windows, KDE and GNOME ([#472](https://github.com/fohrloop/wakepy/pull/472))

--- a/src/wakepy/__init__.py
+++ b/src/wakepy/__init__.py
@@ -21,6 +21,7 @@ except ImportError:  # pragma: no cover
 from .core import ActivationError as ActivationError
 from .core import ActivationResult as ActivationResult
 from .core import ActivationWarning as ActivationWarning
+from .core import ContextAlreadyEnteredError as ContextAlreadyEnteredError
 from .core import DBusAdapter as DBusAdapter
 from .core import Method as Method
 from .core import MethodActivationResult as MethodActivationResult

--- a/src/wakepy/core/__init__.py
+++ b/src/wakepy/core/__init__.py
@@ -18,6 +18,7 @@ from .method import Method as Method
 from .method import MethodInfo as MethodInfo
 from .mode import ActivationError as ActivationError
 from .mode import ActivationWarning as ActivationWarning
+from .mode import ContextAlreadyEnteredError as ContextAlreadyEnteredError
 from .mode import Mode as Mode
 from .mode import ModeExit as ModeExit
 from .platform import CURRENT_PLATFORM as CURRENT_PLATFORM

--- a/tests/unit/test_core/test_mode.py
+++ b/tests/unit/test_core/test_mode.py
@@ -9,7 +9,14 @@ from unittest.mock import Mock
 import pytest
 
 from tests.unit.test_core.testmethods import get_test_method_class
-from wakepy import ActivationError, ActivationResult, Method, MethodInfo, Mode
+from wakepy import (
+    ActivationError,
+    ActivationResult,
+    ContextAlreadyEnteredError,
+    Method,
+    MethodInfo,
+    Mode,
+)
 from wakepy.core import PlatformType
 from wakepy.core.activationresult import MethodActivationResult
 from wakepy.core.constants import WAKEPY_FAKE_SUCCESS, StageName
@@ -218,6 +225,20 @@ class TestModeActivateDeactivate:
             with mode0:
                 # Setting active method
                 mode0._active_method = None
+
+    def test_activate_twice_without_deactivation(
+        self,
+        mode0: Mode,
+    ):
+        # It should not be possible to activate a mode twice without
+        # deactivating it first.
+        with mode0 as m:
+            with pytest.raises(
+                ContextAlreadyEnteredError,
+                match="A Mode can only be activated once!.*",
+            ):
+                with m:
+                    ...
 
 
 @pytest.mark.usefixtures("WAKEPY_FAKE_SUCCESS_eq_1")


### PR DESCRIPTION
Fixes: #475 
