### PR TITLE
tests related to issue 478 

### DIFF
--- a/scripts/debug.py
+++ b/scripts/debug.py
@@ -1,0 +1,17 @@
+from wakepy import keep
+
+with keep.running():
+    print("This code is running in the keep.running mode.")
+
+print("This code is outside of the keep.running mode.")
+
+
+@keep.running
+def long_running_function():
+    print("This function is running in the keep.running mode (long_running_function)")
+
+
+long_running_function()
+
+
+print("This code is outside of the long_running_function.")

--- a/tox.ini
+++ b/tox.ini
@@ -17,8 +17,7 @@ description = run the tests with pytest
 deps = -r{toxinidir}/requirements/requirements-test.txt
 commands =
     ; -W error: turn warnings into errors
-    {envpython} -m pytest -W error {tty:--color=yes} \
-        --cov-branch --cov {envsitepackagesdir}/wakepy --cov-fail-under=100 {posargs}
+    {envpython} -W error scripts/debug.py
 
 ; The following makes the packaging use the external builder defined in
 ; [testenv:.pkg_external] instead of using tox to create sdist/wheel.


### PR DESCRIPTION
This is just a test PR.

Testing if the issue #478 occurs on latest release 

Related PR: https://github.com/fohrloop/wakepy/pull/479 (that one is based on the latest development version)