### PR TITLE
Fix pipelines: Instead of Python 3.7 test on Python 3.8 on Macos

### DIFF
--- a/.github/workflows/build-and-run-tests.yml
+++ b/.github/workflows/build-and-run-tests.yml
@@ -57,8 +57,8 @@ jobs:
           # The ubuntu-latest does not include python 3.7 anymore.
           - python-version: "3.7"
             os: ubuntu-22.04
-          # Oldest supported python on MacOS
-          - python-version: "3.7"
+          # Oldest supported python on MacOS runners
+          - python-version: "3.8"
             os: macos-14
           # Newest supported python on MacOS
           - python-version: "3.14"


### PR DESCRIPTION
Closes: https://github.com/wakepy/wakepy/issues/491

Since macos-13 runners were removed, and Python 3.7 is not available on macos-14 runners, testing on Python 3.8. This is just a quick fix to fix the pipelines. Should check later if it's possible at all to test on Python 3.7 on macOS.