### PR TITLE
 Add "just test-cli" for AI Agents 

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -46,6 +46,21 @@ test *args="":
     echo "Tests passed. Running static checks..."
     just check
 
+# Run tests with coverage, show CLI report (for AI agents - no browser)
+test-cli *args="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    echo "Running tests with coverage..."
+    if ! env -u DBUS_SESSION_BUS_ADDRESS uv run python -m pytest -W error {{ args }} --cov-branch --cov ./src --cov-fail-under=100; then
+        echo "Tests failed. Generating coverage report in CLI..."
+        uv run coverage report -m
+        exit 1
+    fi
+
+    echo "Tests passed. Running static checks..."
+    just check
+
 # Build the package (sdist and wheel)
 build:
     uv build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,5 +35,6 @@ REQUIREMENTS:
 - Test specific functions first, not full suite
 
 ALWAYS:
-- If changing a file, in the end, format file and run tests (or other command to VERIFY the outcome)
+- If changing a file, in the end, format file and run tests (or other command to VERIFY the outcome). Does not apply to .md files.
 - Code should be easily READABLE
+- Use "just test-cli ARGUMENTS" instead of "python -m pytest ARGUMENTS" or "just test ARGUMENTS" or "pytest ARGUMENTS" for running tests


### PR DESCRIPTION
Previously, if an AI Agent would run tests, it would open new browser tab for coverage report every time tests failed. 

Now: Agents show the coverage report in CLI and use the "just test-cli" command instead of "just test". 