### PR TITLE
Add ruff format --check to pipelines

### DIFF
--- a/.github/workflows/build-and-run-tests.yml
+++ b/.github/workflows/build-and-run-tests.yml
@@ -174,8 +174,10 @@ jobs:
         run: uv sync --locked --group check
       - name: Isort check
         run: uv run isort src/wakepy tests/ --check --diff
-      - name: Ruff check
+      - name: Ruff linter check
         run: uv run ruff check --no-fix src/wakepy tests/
+      - name: Ruff format check
+        run: uv run ruff format --check src/wakepy tests/
       - name: Mypy check
         run: uv run mypy src/wakepy tests/
 


### PR DESCRIPTION
Motivation: When switched from Black to ruff in #523, forgot to add the ruff format checks in the GitHub pipelines. 

Add the ruff format --check command to the GitHub workflow doing the code checks.

Amends #523
