### PR TITLE
fix: Terminate caffeinate process even if python process is killed abruptly (#571)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,6 +221,8 @@ exclude_lines = [
 "platform_system != 'Linux'" = "**/wakepy/dbus_adapters/*.py"
 # Windows methods only need to be tested on Windows
 "platform_system != 'Windows'" = "**/wakepy/methods/windows.py"
+# MacOS methods only need to be tested on MacOS
+"platform_system != 'Darwin'" = "**/wakepy/methods/macos.py"
 
 [tool.coverage.coverage_conditional_plugin.rules]
 no-cover-if-no-dbus = "platform_system != 'Linux'"

--- a/src/wakepy/methods/macos.py
+++ b/src/wakepy/methods/macos.py
@@ -60,12 +60,12 @@ class _MacCaffeinate(Method, ABC):
 
 class CaffeinateKeepRunning(_MacCaffeinate):
     mode_name = ModeName.KEEP_RUNNING
-    command = ["caffeinate"]
+    command = ["caffeinate", "cat"]
     name = "caffeinate"
 
 
 class CaffeinateKeepPresenting(_MacCaffeinate):
     mode_name = ModeName.KEEP_PRESENTING
     # -d:  Create an assertion to prevent the display from sleeping.
-    command = ["caffeinate", "-d"]
+    command = ["caffeinate", "-d", "cat"]
     name = "caffeinate"

--- a/tests/integration/test_macos.py
+++ b/tests/integration/test_macos.py
@@ -9,8 +9,14 @@ if platform.system() != "Darwin":
 
 
 class TestMacOS:
-    def test_caffeinate_works(self):
+    def test_caffeinate_runs(self):
         # Test that the caffeinate command can be run without errors
         with keep.running() as m:
+            assert m.active is True
+            assert str(m.method) == "caffeinate"
+
+    def test_caffeinate_presents(self):
+        # Test that the caffeinate command can be run without errors
+        with keep.presenting() as m:
             assert m.active is True
             assert str(m.method) == "caffeinate"


### PR DESCRIPTION
By default `caffeinate` process runs indefinitely until killed. If Python is terminated, contexts do not exit, so nothing kills `caffeinate`, the process leaks. 

`caffeinate` has a number of options to deal with this scenario:
- it can wait for a pid (`-w`)
- it can run a child to completion

`-w` option is suspected to  be absent in MacOS 10.9 and older
    
Running a `cat` command to completion would work due to the `PIPE` input, but would use an additional `cat` process and require `cat` to be present in `PATH`.
    
As portability is deemed more important, `cat` solution was chosen.

Fixes #571
