### PR TITLE
docs: update shields & banner region (README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,15 @@
 <div align="center">
-
-![GitHub tag (latest by date)](https://img.shields.io/github/v/tag/wakepy/wakepy)&nbsp;
-![PyPI](https://img.shields.io/pypi/v/wakepy)&nbsp;
-![PyPI - Downloads](https://img.shields.io/pypi/dw/wakepy)&nbsp;
-[![pyversions](https://img.shields.io/badge/Python-3.7_to_3.15+-blue?logo=python&logoColor=white)](https://pypi.python.org/pypi/wakepy)&nbsp;
-[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)&nbsp;
-![mypy](https://img.shields.io/badge/mypy-checked-blue)&nbsp;
-![coverage](https://img.shields.io/badge/coverage-100%25-32bb13)
-![License](https://img.shields.io/github/license/wakepy/wakepy)
-
+<img src="https://img.shields.io/github/v/tag/wakepy/wakepy" alt="GitHub tag (latest by date)">&nbsp;
+<img src="https://img.shields.io/pypi/v/wakepy" alt="PyPI">&nbsp;
+<img src="https://img.shields.io/pypi/dw/wakepy" alt="PyPI - Downloads">&nbsp;
+<a href="https://pypi.python.org/pypi/wakepy"><img src="https://img.shields.io/badge/Python-3.7_to_3.15+-blue?logo=python&amp;logoColor=white" alt="pyversions"></a>&nbsp;
+<a href="https://github.com/astral-sh/ruff"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json" alt="Ruff"></a>&nbsp;
+<img src="https://img.shields.io/badge/mypy-checked-blue" alt="mypy">&nbsp;
+<img src="https://img.shields.io/badge/coverage-100%25-32bb13" alt="coverage">
+<img src="https://img.shields.io/github/license/wakepy/wakepy" alt="License">
+<br/>
+<img src="./docs/source/img/wakepy-banner.svg" alt="Wakepy Banner">
 </div>
-
-![](./docs/source/img/wakepy-banner.svg)
 
 Cross-platform wakelock / keep-awake / stay-awake written in Python.
 


### PR DESCRIPTION
- Make README shields centered
- Make python versions shields shorter. Instead of `python 3.7 | 3.8 | 3.9 | 3.10 | 3.11 | 3.12 | 3.13 | 3.14 | 3.15` just say `Python 3.7 to 3.15+`.
- Show weekly downloads instead of monthly downloads. Weekly downloads is more common metric, used for example in https://pyatlas.io/,  https://clickpy.clickhouse.com/dashboard/wakepy and https://pypi.kopdog.com/package/?name=wakepy
- Make the shields + banner segment to be fully HTML. Seems that the markdown was not well read by all automated tools. For example: https://piptrends.com/package/wakepy was a mess

Closes: N/A