### PR TITLE
docs: fix visible whitespace between README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,14 @@
 <div align="center">
-
-<a href="https://github.com/wakepy/wakepy">
-  <img src="https://img.shields.io/github/v/tag/wakepy/wakepy" alt="GitHub tag (latest by date)">
-</a>
-<a href="https://pypi.org/project/wakepy/">
-  <img src="https://img.shields.io/pypi/v/wakepy" alt="PyPI version">
-</a>
-<a href="https://anaconda.org/conda-forge/wakepy">
-  <img src="https://img.shields.io/conda/vn/conda-forge/wakepy" alt="conda-forge version">
-</a>
-<a href="https://pypistats.org/packages/wakepy">
-  <img src="https://img.shields.io/pypi/dw/wakepy" alt="PyPI - Downloads">
-</a>
-<a href="https://devguide.python.org/versions/">
-  <img src="https://img.shields.io/badge/Python-3.7_to_3.15+-blue?logo=python&amp;logoColor=white" alt="pyversions">
-</a>
-<a href="https://github.com/astral-sh/uv">
-  <img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json" alt="uv">
-</a>
-<a href="https://github.com/astral-sh/ruff">
-  <img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json" alt="Ruff">
-</a>
-<a href="https://github.com/python/mypy">
-  <img src="https://img.shields.io/static/v1?label=&amp;message=mypy&amp;color=1f5082&amp;labelColor=grey&amp;logo=python&amp;logoColor=white" alt="mypy">
-</a>
-<a href="https://github.com/wakepy/wakepy/blob/7b758485c2e44855cd181f25d98c25ed37961f73/.github/actions/run-tests/action.yml#L72">
-  <img src="https://img.shields.io/badge/100%25-coverage-%230A9EDC?logo=pytest&amp;logoColor=white" alt="100% test coverage">
-</a>
-<a href="https://github.com/wakepy/wakepy/blob/main/LICENSE.txt">
-  <img src="https://img.shields.io/github/license/wakepy/wakepy" alt="License">
-</a>
-
-<br/>
+<a href="https://github.com/wakepy/wakepy"><img src="https://img.shields.io/github/v/tag/wakepy/wakepy" alt="GitHub tag (latest by date)"></a>
+<a href="https://pypi.org/project/wakepy/"><img src="https://img.shields.io/pypi/v/wakepy" alt="PyPI version"></a>
+<a href="https://anaconda.org/conda-forge/wakepy"><img src="https://img.shields.io/conda/vn/conda-forge/wakepy" alt="conda-forge version"></a>
+<a href="https://pypistats.org/packages/wakepy"><img src="https://img.shields.io/pypi/dw/wakepy" alt="PyPI - Downloads"></a>
+<a href="https://devguide.python.org/versions/"><img src="https://img.shields.io/badge/Python-3.7_to_3.15+-blue?logo=python&amp;logoColor=white" alt="pyversions"></a>
+<a href="https://github.com/astral-sh/uv"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json" alt="uv"></a>
+<a href="https://github.com/astral-sh/ruff"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json" alt="Ruff"></a>
+<a href="https://github.com/python/mypy"><img src="https://img.shields.io/static/v1?label=&amp;message=mypy&amp;color=1f5082&amp;labelColor=grey&amp;logo=python&amp;logoColor=white" alt="mypy"></a>
+<a href="https://github.com/wakepy/wakepy/blob/7b758485c2e44855cd181f25d98c25ed37961f73/.github/actions/run-tests/action.yml#L72"><img src="https://img.shields.io/badge/100%25-coverage-%230A9EDC?logo=pytest&amp;logoColor=white" alt="100% test coverage"></a>
+<a href="https://github.com/wakepy/wakepy/blob/main/LICENSE.txt"><img src="https://img.shields.io/github/license/wakepy/wakepy" alt="License"></a><br/>
 
 <a href="https://github.com/wakepy/wakepy">
  <img src="./docs/source/img/wakepy-banner.svg" alt="Wakepy Banner">


### PR DESCRIPTION
There was extra whitespace added between the shields/badges in the README. The whitespace was made visible because these were links. Hiding that all by taking a small hit in markdown readability. 

Closes: N/A