### PR TITLE
feat: Add three-state Mode.active to distinguish "not yet activated" and "deactivated" from "activation failed"

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -1,7 +1,12 @@
 # Changelog
 
-## wakepy x.x.x
+## wakepy 2.0.0
 🗓️ unreleased
+
+### ✨ Features
+
+#### ✨ Python API
+- 🚨 {attr}`Mode.active <wakepy.Mode.active>` changed from `bool` to `bool | None`. The value is now `None` when the Mode has not been activated yet or has been deactivated, `True` when activated successfully, and `False` when activation was attempted but failed. Inside the `with` block, the value is always `True` or `False`. Previously, both "not yet activated" and "activation failed" were represented as `False`. This is a breaking change only if code checks `mode.active` outside the context manager *and* compares with `is False` or `== False`. Unlikely, but possible. Hence, this major version bump.
 
 ### 📖 Documentation
 - Document Cinnamon support ([#587](https://github.com/wakepy/wakepy/pull/587))

--- a/docs/source/migration.md
+++ b/docs/source/migration.md
@@ -1,4 +1,32 @@
 # Migration Guide
+## Migration Guide: 2.0.0
+
+### Mode.active type change
+
+{attr}`Mode.active <wakepy.Mode.active>` changed from `bool` to `bool | None`. The initial value and the value after deactivation is now `None` instead of `False`:
+
+| State | Before | After |
+|---|---|---|
+| Not yet activated | `False` | `None` |
+| Activated successfully | `True` | `True` |
+| Activation failed | `False` | `False` |
+| Deactivated | `False` | `None` |
+
+Inside the `with` block, `mode.active` is always `True` or `False`, never `None`. This is only a breaking change if your code checks `mode.active` outside the context manager *and* compares with `is False` or `== False`.
+
+```{code-block} python
+from wakepy import keep
+
+mode = keep.running()
+
+mode.active    # None (not yet activated)
+
+with mode:
+    mode.active  # True (success) or False (failure)
+
+mode.active    # None (deactivated)
+```
+
 ## Migration Guide: 1.0.0
 
 ### New decorator syntax

--- a/docs/source/user-guide.md
+++ b/docs/source/user-guide.md
@@ -82,7 +82,7 @@ def otherfunc():
 
 The Mode has following important attributes:
 
-- {attr}`m.active <wakepy.Mode.active>`: `True`, if activating mode was successful, and mode is not yet deactivated. Will be set to `False` when deactivating the mode. Can be [faked in CI](./tests-and-ci.md#wakepy_fake_success).
+- {attr}`m.active <wakepy.Mode.active>`: `True` if activating mode was successful. `False` if activation was attempted but failed. When using the context manager or decorator syntax, this is always `True` or `False` during the active scope (inside the `with` block or the decorated function). Before activation or after deactivation, the value is `None`. Can be [faked in CI](./tests-and-ci.md#wakepy_fake_success).
 - {attr}`m.method <wakepy.Mode.method>`: Information about the used method. Unlike the `active_method`, will be available *also* after the deactivating the mode. (Type: {class}`~wakepy.MethodInfo`)
 - {attr}`m.active_method <wakepy.Mode.active_method>`: Information about the *active* method. Will be `None` after deactivating the mode. (Type: {class}`~wakepy.MethodInfo`)
 - {attr}`m.result <wakepy.Mode.result>`: An {class}`~wakepy.ActivationResult` instance which gives more detailed information about the activation process.

--- a/src/wakepy/core/mode.py
+++ b/src/wakepy/core/mode.py
@@ -375,9 +375,24 @@ class Mode:
     for the :func:`keep.presenting <wakepy.keep.presenting>` mode.
     """
 
-    active: bool
-    """``True`` if the mode is active. Otherwise, ``False``. See also:
-    :attr:`active_method`."""
+    active: bool | None
+    """Tells whether the mode is active.
+
+    - ``None``: The Mode has not been activated yet, or has been deactivated.
+    - ``True``: The Mode was activated successfully.
+    - ``False``: The Mode was activated, but activation failed (no Method
+      succeeded).
+
+    When using the context manager or decorator syntax, this is always
+    ``True`` or ``False`` during the active scope (inside the ``with``
+    block or the decorated function).
+
+    See also: :attr:`active_method`.
+
+    .. versionchanged:: 2.0.0
+        Changed from ``bool`` to ``bool | None``. The initial value and the
+        value after deactivation is now ``None`` instead of ``False``.
+    """
 
     result: ActivationResult
     """The activation result which tells more about the activation process
@@ -441,7 +456,7 @@ class Mode:
         )
 
         self._init_params = params
-        self.active: bool = False
+        self.active: bool | None = None
         self.result = ActivationResult([])
         self.name = params.name
 
@@ -847,7 +862,7 @@ class Mode:
         self._active_method = None
         self.active_method = None
         self.heartbeat = None
-        self.active = False
+        self.active = None
         self._has_entered_context = False
         return deactivated
 

--- a/tests/unit/test_core/test_mode.py
+++ b/tests/unit/test_core/test_mode.py
@@ -188,13 +188,29 @@ class TestModeContextManager:
         # reached the end of the with block
         assert flag_end_of_with_block
 
-        # After exiting the mode, Mode.active is set to False
-        assert m.active is False
+        # After exiting the mode, Mode.active is set to None
+        assert m.active is None
         # The active_method is set to None
         assert m.active_method is None
         # The activation result is still there (not removed during
         # deactivation)
         assert activation_result == m.result
+
+    def test_active_is_none_before_activation(self, mode0: Mode):
+        """Mode.active is None before entering the context manager"""
+        assert mode0.active is None
+
+    def test_active_is_false_on_failed_activation(self):
+        """Mode.active is False when activation is attempted but fails"""
+        params = _ModeParams(method_classes=[], on_fail="pass")
+        mode = Mode(params)
+
+        assert mode.active is None
+
+        with mode as m:
+            assert m.active is False
+
+        assert m.active is None
 
     @pytest.mark.usefixtures("WAKEPY_FAKE_SUCCESS_eq_1")
     def test_no_methods_succeeds_when_using_fake_success(

--- a/tests/unit/test_modes.py
+++ b/tests/unit/test_modes.py
@@ -109,14 +109,14 @@ def test_keep_running_with_fake_success(monkeypatch, fake_dbus_adapter):
     """Simple smoke test for keep.running()"""
     monkeypatch.setenv("WAKEPY_FAKE_SUCCESS", "1")
     mode = keep.running(dbus_adapter=fake_dbus_adapter)
-    assert mode.active is False
+    assert mode.active is None
 
     with mode as m:
         assert mode is m
         assert m.active is True
         assert m.result.success is True
 
-    assert m.active is False
+    assert m.active is None
     assert isinstance(m.result, ActivationResult)
 
 


### PR DESCRIPTION
Before: There was no way to distinguish between these two states of `Mode.active`:

- Just initialized or deactivated → `Mode.active = False`
- Activated but not successfully → `Mode.active = False`

After: Change `Mode.active` from `bool` to `bool | None`, introducing a third state:

    | State                            | Before  | After   |
    |----------------------------------|---------|---------|
    | Just initialized or deactivated  | `False` | `None`  |
    | Activated successfully           | `True`  | `True`  |
    | Activated with a failure         | `False` | `False` |

When using the context manager or decorator syntax, `Mode.active` is
always `True` or `False` during the active scope. The `None` state only
appears before activation or after deactivation, which is useful in
event-driven applications where a Mode object is stored and activated
later.


Unfortunately, there is a (rare) use case when this change is backwards incompatible (if comparing the Mode.active with the = or is operator outside the context), so this necessitates a major version bump from 1.0.0 to 2.0.0.

Closes: #590