### PR TITLE
add GEMINI.md

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
Add support for Gemini CLI which required by default a GEMINI.md. While Gemini CLI can be configured to use AGENTS.md, it is better to just create a link from GEMINI.md to AGENTS.md, since that does not require any configuration from the user.

Closes: N/A